### PR TITLE
fix: move settings button from tab bar to app-level top bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,16 @@
         <button v-if="hasSampleData" class="sampleBanner" @click="clearSampleData">
           Viewing sample data — Tap to clear and start fresh
         </button>
+        <div class="appTopBar">
+          <button
+            class="settingsGearBtn"
+            @click="settingsOpen ? closeSettings() : (settingsOpen = true)"
+            title="Settings"
+            aria-label="Settings"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+          </button>
+        </div>
         <div v-show="activeTab === 'workouts'" class="tabContent"><WorkoutTracker /></div>
         <div v-show="activeTab === 'calendar'" class="tabContent"><CalendarView /></div>
         <div v-show="activeTab === 'weight'" class="tabContent"><BodyweightTracker /></div>
@@ -44,18 +54,6 @@
             <span class="tabLabel">{{ tab.label }}</span>
           </button>
         </div>
-        <button
-          :class="['tabBtn tabBtnSettings', { active: settingsOpen }]"
-          @click="settingsOpen ? closeSettings() : (settingsOpen = true)"
-          title="Settings"
-          aria-label="Settings"
-        >
-          <svg class="tabIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="3"/>
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
-          </svg>
-          <span class="tabLabel">Settings</span>
-        </button>
       </nav>
 
       <!-- Settings bottom sheet -->
@@ -356,6 +354,7 @@ const { toast: undoToast, performUndo } = useUndoToast()
 const settingsOpen = ref(false)
 const settingsEl = ref<HTMLElement | null>(null)
 const legalView = ref<'privacy' | 'terms' | null>(null)
+
 
 // ── Swipe-to-dismiss for settings sheet ────────────────────────
 const settingsSwipe = useSwipeToDismiss({

--- a/src/index.css
+++ b/src/index.css
@@ -507,6 +507,14 @@ button, [role="tab"], [role="switch"], a {
   flex-shrink: 0;
 }
 
+.appTopBar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 4px 0;
+  flex-shrink: 0;
+}
+
 .tabContent {
   flex: 1;
   overflow-y: auto;
@@ -577,9 +585,30 @@ button, [role="tab"], [role="switch"], a {
   color: var(--accent);
 }
 
-.tabBtnSettings {
-  flex: none;
-  padding: 10px 14px 8px;
+.settingsGearBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  border-radius: 8px;
+  transition: color 0.2s, background-color 0.2s;
+  flex-shrink: 0;
+}
+
+.settingsGearBtn:active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.settingsGearBtn svg {
+  width: 20px;
+  height: 20px;
 }
 
 .tabIcon {


### PR DESCRIPTION
## Summary
- Removed settings gear from the bottom tab bar where it sat awkwardly outside the tab group
- Added a new app-level top bar above tab content with the settings gear right-aligned
- Tab bar now contains only the three content tabs with even spacing

## Test plan
- [ ] Settings gear visible in top-right on all three tabs
- [ ] Tapping gear opens settings bottom sheet as before
- [ ] Tab bar has three evenly-spaced tabs, no visual asymmetry
- [ ] Keyboard shortcut (`,`) still opens settings
- [ ] Renders correctly across all 6 themes, light and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)