### PR TITLE
feat: sticky log date defaults to last manually set date

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -835,6 +835,9 @@ const reps = computed<number | null>({
   set: (v) => { repsStr.value = v === null ? '' : String(v) },
 })
 const date = ref(todayISO())
+// Remembers the last date the user manually set when logging, so the modal
+// re-opens to that date rather than always resetting to today.
+const lastLogDate = ref(todayISO())
 
 const isEditMode = computed(() => editingSet.value !== null)
 
@@ -874,6 +877,7 @@ function openNewExerciseModal() {
   selectedExerciseId.value = '__new__'
   newExerciseTags.value = []
   newExerciseTagInput.value = ''
+  date.value = lastLogDate.value
   showModal.value = true
 }
 
@@ -906,7 +910,7 @@ function toggleNewExerciseTag(tag: string) {
 function openLogForExercise(exerciseId: string) {
   editingSet.value = null
   selectedExerciseId.value = exerciseId
-  date.value = todayISO()
+  date.value = lastLogDate.value
   showModal.value = true
 }
 
@@ -1061,7 +1065,7 @@ function onTimerComplete() {
 
 function skipToNextSet() {
   stopTimer()
-  date.value = todayISO()
+  date.value = lastLogDate.value
 }
 
 const DEFAULT_PRESETS = [30, 60, 90, 120, 180, 300]
@@ -1490,6 +1494,14 @@ function confirmDeleteTag(tag: string) {
   )
 }
 
+
+// Persist the last manually chosen log date so subsequent modal opens
+// default to it rather than always jumping back to today.
+watch(date, (newDate) => {
+  if (showModal.value && !isEditMode.value) {
+    lastLogDate.value = newDate
+  }
+})
 
 // ── Focus traps for v-if modals ─────────────────────────────────
 watch(showModal, async (open) => {


### PR DESCRIPTION
## Summary
- Log modal now defaults to the last date the user manually picked, rather than always resetting to today
- First open defaults to today as before
- If the user changes the date (e.g. to backfill yesterday), all subsequent log modals open to that date
- Edit modal is unaffected — always opens to the set's own date

## How it works
Added a `lastLogDate` ref initialized to today. A watcher updates it whenever `date` changes while the log modal is open in non-edit mode. All three log modal entry points (`openLogForExercise`, `openNewExerciseModal`, `skipToNextSet`) now default to `lastLogDate` instead of `todayISO()`.

## Test plan
- [ ] Open log modal — defaults to today
- [ ] Change date to yesterday, save a set
- [ ] Open log modal again — defaults to yesterday
- [ ] Edit an existing set — opens to that set's date (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)