### PR TITLE
fix: convert Log a Set modal to bottom sheet

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -212,8 +212,9 @@
 
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
-    <div v-if="showModal" class="repMaxOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
-      <div class="repMaxModal" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
+    <div v-if="showModal" class="logSheetOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
+      <div class="logSheet" :ref="onLogSheetMounted" :style="logSheetSwipe.dragStyle()" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
+        <div class="sheetDragHandle" aria-hidden="true"><span class="sheetDragPill"></span></div>
 
         <!-- Rest timer view -->
         <template v-if="timerActive">
@@ -683,6 +684,11 @@ const detailTab = ref<'sets' | 'prs'>('sets')
 const detailSwipe = useSwipeToDismiss({
   threshold: 100,
   onDismiss: () => { detailExerciseId.value = null },
+})
+
+const logSheetSwipe = useSwipeToDismiss({
+  threshold: 80,
+  onDismiss: () => { closeModal() },
 })
 
 const detailFocus = useFocusTrap()
@@ -1535,15 +1541,19 @@ function confirmDeleteTag(tag: string) {
 
 
 // ── Focus traps for v-if modals ─────────────────────────────────
-watch(showModal, async (open) => {
-  if (open) {
-    await nextTick()
-    const el = document.querySelector<HTMLElement>('.repMaxModal')
-    if (el) logModalFocus.activate(el)
-  } else {
+watch(showModal, (open) => {
+  if (!open) {
+    logSheetSwipe.detach()
     logModalFocus.deactivate()
   }
 })
+
+function onLogSheetMounted(el: Element | ComponentPublicInstance | null) {
+  if (el && el instanceof HTMLElement) {
+    logSheetSwipe.attach(el)
+    logModalFocus.activate(el)
+  }
+}
 
 watch(editTarget, async (target) => {
   if (target) {

--- a/src/components/__tests__/WorkoutTracker.test.js
+++ b/src/components/__tests__/WorkoutTracker.test.js
@@ -447,7 +447,7 @@ describe('WorkoutTracker', () => {
       await wrapper.find('.wtLogBtn').trigger('click')
       await wrapper.vm.$nextTick()
 
-      expect(wrapper.find('.repMaxModal').exists()).toBe(true)
+      expect(wrapper.find('.logSheet').exists()).toBe(true)
     })
   })
 })

--- a/src/index.css
+++ b/src/index.css
@@ -1936,6 +1936,49 @@ button, [role="tab"], [role="switch"], a {
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 
+/* ─── Log Set Bottom Sheet ────────────────────────────────────────────── */
+
+.logSheetOverlay {
+  position: fixed;
+  inset: 0;
+  background: var(--glass-overlay, rgba(0,0,0,0.55));
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  z-index: 100;
+  animation: overlayFadeIn 0.2s ease-out;
+}
+
+.logSheet {
+  width: 100%;
+  max-width: 520px;
+  max-height: 92svh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  background: var(--glass-fill, var(--bg-elevated));
+  backdrop-filter: blur(32px) saturate(180%);
+  -webkit-backdrop-filter: blur(32px) saturate(180%);
+  border: 1px solid var(--glass-edge, var(--border-strong));
+  border-bottom: none;
+  box-shadow: 0 -8px 32px rgba(0,0,0,0.25), inset 0 1px 0 var(--glass-shine, rgba(255,255,255,0.1));
+  border-radius: 16px 16px 0 0;
+  padding: 0 22px calc(env(safe-area-inset-bottom, 0px) + 16px);
+  text-align: left;
+  animation: sheetSlideUp 0.25s ease-out;
+}
+
+.logSheet h2 {
+  font-size: var(--font-body);
+  font-weight: 700;
+  color: var(--text-primary);
+  text-align: center;
+  margin-bottom: 20px;
+  letter-spacing: -0.2px;
+}
+
 /* ─── Modals ─────────────────────────────────────────────────────────────── */
 
 .repMaxOverlay {


### PR DESCRIPTION
## Summary
- Converted the Log a Set centered modal to a bottom sheet that slides up from the bottom
- Adds drag handle with swipe-to-dismiss (reuses existing `useSwipeToDismiss` composable)
- Sits above the keyboard on mobile instead of getting squeezed in the center

## Test plan
- [ ] Open Log a Set on mobile — sheet slides up from bottom
- [ ] Keyboard appears and sheet content remains fully visible (weight + reps fields)
- [ ] Swipe down on drag handle dismisses the sheet
- [ ] Tap overlay to dismiss still works
- [ ] Rest timer view still renders correctly inside the sheet
- [ ] Edit set mode still works
- [ ] New exercise modal still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)