### PR TITLE
fix: raise log sheet above iOS keyboard

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -212,7 +212,7 @@
 
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
-    <div v-if="showModal" class="logSheetOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
+    <div v-if="showModal" class="logSheetOverlay" :style="{ bottom: keyboardHeight > 0 ? keyboardHeight + 'px' : '0' }" @click.self="onOverlayClick" @keydown.escape="closeModal">
       <div class="logSheet" ref="logSheetEl" :style="logSheetSwipe.dragStyle()" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
         <div class="sheetDragHandle" ref="logSheetHandleEl" aria-hidden="true"><span class="sheetDragPill"></span></div>
 
@@ -610,12 +610,14 @@ import { useTheme } from '../composables/useTheme'
 import { useUndoToast } from '../composables/useUndoToast'
 import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
+import { useKeyboardOffset } from '../composables/useKeyboardOffset'
 import ExerciseGraph from './ExerciseGraph.vue'
 
 const store = useWorkoutStore()
 const { logEvent } = useAnalytics()
 const { show: showUndo } = useUndoToast()
 const { restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs } = useTheme()
+const { keyboardHeight } = useKeyboardOffset()
 
 // ── Search & tag filtering ──────────────────────────────────────
 const searchQuery = ref('')

--- a/src/composables/useKeyboardOffset.ts
+++ b/src/composables/useKeyboardOffset.ts
@@ -1,0 +1,30 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+
+/**
+ * Tracks the iOS virtual keyboard height using the visualViewport API.
+ * Returns a reactive `keyboardHeight` (px) that updates when the keyboard
+ * opens or closes. Returns 0 on browsers without visualViewport support.
+ */
+export function useKeyboardOffset() {
+  const keyboardHeight = ref(0)
+
+  function update() {
+    const vv = window.visualViewport
+    if (!vv) return
+    // On iOS, innerHeight stays fixed when the keyboard opens.
+    // visualViewport.height shrinks and offsetTop shifts.
+    keyboardHeight.value = Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
+  }
+
+  onMounted(() => {
+    window.visualViewport?.addEventListener('resize', update)
+    window.visualViewport?.addEventListener('scroll', update)
+  })
+
+  onUnmounted(() => {
+    window.visualViewport?.removeEventListener('resize', update)
+    window.visualViewport?.removeEventListener('scroll', update)
+  })
+
+  return { keyboardHeight }
+}


### PR DESCRIPTION
## Summary
- New `useKeyboardOffset` composable tracks keyboard height via `visualViewport` API
- Log sheet overlay bottom is offset by keyboard height so the sheet sits above the numpad
- Gracefully returns 0 on browsers without visualViewport support

## Test plan
- [ ] Open Log a Set, tap weight/reps field — sheet sits above keyboard, all fields visible
- [ ] Dismiss keyboard — sheet returns to normal bottom position
- [ ] Desktop browser — no change in behavior (keyboard height is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)