### PR TITLE
fix: auto-scroll log sheet to focused input above keyboard

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1554,12 +1554,31 @@ watch(showModal, async (open) => {
     if (logSheetEl.value && logSheetHandleEl.value) {
       logSheetSwipe.attach(logSheetEl.value, logSheetHandleEl.value)
       logModalFocus.activate(logSheetEl.value)
+      logSheetEl.value.addEventListener('focusin', onLogSheetFocusIn)
     }
   } else {
+    logSheetEl.value?.removeEventListener('focusin', onLogSheetFocusIn)
     logSheetSwipe.detach()
     logModalFocus.deactivate()
   }
 })
+
+function onLogSheetFocusIn(e: FocusEvent) {
+  const target = e.target
+  const sheet = logSheetEl.value
+  if (!(target instanceof HTMLElement) || !sheet) return
+
+  // Delay to let the keyboard animation settle and visualViewport update
+  setTimeout(() => {
+    const sheetRect = sheet.getBoundingClientRect()
+    const targetRect = target.getBoundingClientRect()
+    // If the focused input is below the visible area of the sheet, scroll it into view
+    const overflow = targetRect.bottom - sheetRect.bottom
+    if (overflow > 0) {
+      sheet.scrollBy({ top: overflow + 16, behavior: 'smooth' })
+    }
+  }, 300)
+}
 
 watch(editTarget, async (target) => {
   if (target) {


### PR DESCRIPTION
## Summary
- Adds a `focusin` listener on the log sheet that scrolls to keep the focused input visible
- Uses `getBoundingClientRect` to detect when the input is below the sheet's visible area
- 300ms delay lets the keyboard animation and visualViewport update settle first

## Test plan
- [ ] Tap weight field, enter a value, tap reps field — reps input scrolls into view above keyboard
- [ ] Both weight and reps fields remain visible/accessible
- [ ] No jarring jump — smooth scroll behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)