### PR TITLE
fix: revert log set to centered modal with keyboard awareness

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -212,9 +212,8 @@
 
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
-    <div v-if="showModal" class="logSheetOverlay" :style="{ bottom: keyboardHeight > 0 ? keyboardHeight + 'px' : '0' }" @click.self="onOverlayClick" @keydown.escape="closeModal">
-      <div class="logSheet" ref="logSheetEl" :style="logSheetSwipe.dragStyle()" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
-        <div class="sheetDragHandle" ref="logSheetHandleEl" aria-hidden="true"><span class="sheetDragPill"></span></div>
+    <div v-if="showModal" class="repMaxOverlay" :style="keyboardHeight > 0 ? { paddingBottom: keyboardHeight + 'px' } : undefined" @click.self="onOverlayClick" @keydown.escape="closeModal">
+      <div class="repMaxModal" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
 
         <!-- Rest timer view -->
         <template v-if="timerActive">
@@ -686,11 +685,6 @@ const detailTab = ref<'sets' | 'prs'>('sets')
 const detailSwipe = useSwipeToDismiss({
   threshold: 100,
   onDismiss: () => { detailExerciseId.value = null },
-})
-
-const logSheetSwipe = useSwipeToDismiss({
-  threshold: 80,
-  onDismiss: () => { closeModal() },
 })
 
 const detailFocus = useFocusTrap()
@@ -1545,40 +1539,15 @@ function confirmDeleteTag(tag: string) {
 
 
 // ── Focus traps for v-if modals ─────────────────────────────────
-const logSheetEl = ref<HTMLElement | null>(null)
-const logSheetHandleEl = ref<HTMLElement | null>(null)
-
 watch(showModal, async (open) => {
   if (open) {
     await nextTick()
-    if (logSheetEl.value && logSheetHandleEl.value) {
-      logSheetSwipe.attach(logSheetEl.value, logSheetHandleEl.value)
-      logModalFocus.activate(logSheetEl.value)
-      logSheetEl.value.addEventListener('focusin', onLogSheetFocusIn)
-    }
+    const el = document.querySelector<HTMLElement>('.repMaxModal')
+    if (el) logModalFocus.activate(el)
   } else {
-    logSheetEl.value?.removeEventListener('focusin', onLogSheetFocusIn)
-    logSheetSwipe.detach()
     logModalFocus.deactivate()
   }
 })
-
-function onLogSheetFocusIn(e: FocusEvent) {
-  const target = e.target
-  const sheet = logSheetEl.value
-  if (!(target instanceof HTMLElement) || !sheet) return
-
-  // Delay to let the keyboard animation settle and visualViewport update
-  setTimeout(() => {
-    const sheetRect = sheet.getBoundingClientRect()
-    const targetRect = target.getBoundingClientRect()
-    // If the focused input is below the visible area of the sheet, scroll it into view
-    const overflow = targetRect.bottom - sheetRect.bottom
-    if (overflow > 0) {
-      sheet.scrollBy({ top: overflow + 16, behavior: 'smooth' })
-    }
-  }, 300)
-}
 
 watch(editTarget, async (target) => {
   if (target) {

--- a/src/components/__tests__/WorkoutTracker.test.js
+++ b/src/components/__tests__/WorkoutTracker.test.js
@@ -447,7 +447,7 @@ describe('WorkoutTracker', () => {
       await wrapper.find('.wtLogBtn').trigger('click')
       await wrapper.vm.$nextTick()
 
-      expect(wrapper.find('.logSheet').exists()).toBe(true)
+      expect(wrapper.find('.repMaxModal').exists()).toBe(true)
     })
   })
 })

--- a/src/index.css
+++ b/src/index.css
@@ -1936,49 +1936,6 @@ button, [role="tab"], [role="switch"], a {
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 
-/* ─── Log Set Bottom Sheet ────────────────────────────────────────────── */
-
-.logSheetOverlay {
-  position: fixed;
-  inset: 0;
-  background: var(--glass-overlay, rgba(0,0,0,0.55));
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  display: flex;
-  align-items: flex-end;
-  justify-content: center;
-  z-index: 100;
-  animation: overlayFadeIn 0.2s ease-out;
-}
-
-.logSheet {
-  width: 100%;
-  max-width: 520px;
-  max-height: 92svh;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  overscroll-behavior: contain;
-  background: var(--glass-fill, var(--bg-elevated));
-  backdrop-filter: blur(32px) saturate(180%);
-  -webkit-backdrop-filter: blur(32px) saturate(180%);
-  border: 1px solid var(--glass-edge, var(--border-strong));
-  border-bottom: none;
-  box-shadow: 0 -8px 32px rgba(0,0,0,0.25), inset 0 1px 0 var(--glass-shine, rgba(255,255,255,0.1));
-  border-radius: 16px 16px 0 0;
-  padding: 0 22px calc(env(safe-area-inset-bottom, 0px) + 16px);
-  text-align: left;
-  animation: sheetSlideUp 0.25s ease-out;
-}
-
-.logSheet h2 {
-  font-size: var(--font-body);
-  font-weight: 700;
-  color: var(--text-primary);
-  text-align: center;
-  margin-bottom: 20px;
-  letter-spacing: -0.2px;
-}
-
 /* ─── Modals ─────────────────────────────────────────────────────────────── */
 
 .repMaxOverlay {


### PR DESCRIPTION
## Summary
- Reverted log set from bottom sheet back to centered modal
- Overlay adds paddingBottom equal to keyboard height so modal floats above numpad
- Removes logSheet CSS, swipe-to-dismiss, and focusin scroll logic
- Eliminates visual clutter from stacked bottom sheets

## Test plan
- [ ] Log a Set opens as centered modal, not bottom sheet
- [ ] When keyboard opens, modal shifts up — weight and reps fields stay visible
- [ ] No stacking clutter when opened from exercise detail view
- [ ] Dismiss via overlay tap, Escape key, and Cancel button all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)