### PR TITLE
fix: sign out not completing after confirmation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -553,7 +553,10 @@ function acceptConfirm() {
 }
 
 function confirmSignOut() {
-  showConfirm('Sign out?', () => signOut())
+  showConfirm('Sign out?', () => {
+    settingsOpen.value = false
+    signOut()
+  })
 }
 
 function exportData(format: 'csv' | 'json') {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -84,9 +84,11 @@ async function signUp(email: string, password: string): Promise<{ error: AuthErr
 }
 
 async function signOut(): Promise<void> {
-  if (!supabase) return
-  await supabase.auth.signOut()
-  user.value = null
+  try {
+    await supabase?.auth.signOut()
+  } finally {
+    user.value = null
+  }
 }
 
 export function useAuth() {


### PR DESCRIPTION
## Summary
- \`signOut()\` now uses \`try/finally\` to guarantee \`user.value = null\` even if \`supabase.auth.signOut()\` throws
- Also clears user when supabase client is null (was silently returning)
- Closes settings sheet before signing out to prevent stale teleported UI

## Test plan
- [ ] Tap Sign Out in settings, confirm — returns to auth screen
- [ ] Settings sheet is not visible after sign out

🤖 Generated with [Claude Code](https://claude.com/claude-code)