### PR TITLE
feat: testable auth flow in dev mode

### DIFF
--- a/src/components/AuthScreen.vue
+++ b/src/components/AuthScreen.vue
@@ -53,6 +53,8 @@
         </button>
       </div>
 
+      <button v-if="isDev" class="authDevBtn" @click="devSignIn">Continue as Dev</button>
+
       <p v-if="message" :class="['authMessage', { authError: isError, authSuccess: !isError }]" role="status" aria-live="polite">{{ message }}</p>
     </div>
   </div>
@@ -63,7 +65,8 @@ import { ref } from 'vue'
 import type { Provider } from '@supabase/supabase-js'
 import { useAuth } from '../composables/useAuth'
 
-const { signInWithProvider, signInWithEmail, signUp } = useAuth()
+const { signInWithProvider, signInWithEmail, signUp, devSignIn } = useAuth()
+const isDev = import.meta.env.DEV
 
 const email = ref('')
 const password = ref('')
@@ -281,6 +284,26 @@ async function handleOAuth(provider: Provider) {
 
 .authProviderIcon {
   flex-shrink: 0;
+}
+
+.authDevBtn {
+  width: 100%;
+  padding: 13px 16px;
+  min-height: 44px;
+  margin-top: 12px;
+  font-size: var(--font-subhead);
+  font-weight: 600;
+  font-family: inherit;
+  color: #c9a84c;
+  background: transparent;
+  border: 1px dashed #c9a84c;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.authDevBtn:active {
+  opacity: 0.7;
 }
 
 .authMessage {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -31,11 +31,9 @@ function init(): void {
   if (_initialized) return
   _initialized = true
 
-  // Dev bypass: skip OAuth on localhost so we can test without pushing to prod
-  // Deferred so Pinia is installed by the time stores are accessed
+  // Dev mode: show auth screen, allow instant sign-in via devSignIn()
   if (import.meta.env.DEV) {
-    user.value = { id: 'local-dev', email: 'dev@localhost' }
-    setTimeout(() => initStores('local-dev').then(() => { loading.value = false }), 0)
+    loading.value = false
     return
   }
 
@@ -83,6 +81,11 @@ async function signUp(email: string, password: string): Promise<{ error: AuthErr
   return { error, needsConfirmation: !error && !!data?.user && !data?.session }
 }
 
+async function devSignIn(): Promise<void> {
+  user.value = { id: 'local-dev', email: 'dev@localhost' }
+  await initStores('local-dev')
+}
+
 async function signOut(): Promise<void> {
   try {
     await supabase?.auth.signOut()
@@ -92,5 +95,5 @@ async function signOut(): Promise<void> {
 }
 
 export function useAuth() {
-  return { user, loading, signInWithProvider, signInWithEmail, signUp, signOut }
+  return { user, loading, signInWithProvider, signInWithEmail, signUp, signOut, devSignIn }
 }


### PR DESCRIPTION
## Summary
- Dev mode no longer auto-signs in — shows the auth screen instead
- Added \`devSignIn()\` function and "Continue as Dev" button (dashed gold border, dev-only)
- Sign out returns to auth screen, sign in via dev button works instantly

## Test plan
- [ ] \`npm run dev\` → auth screen appears with "Continue as Dev" button
- [ ] Tap "Continue as Dev" → signed in as local-dev, app loads
- [ ] Sign out → returns to auth screen
- [ ] Production build does NOT show the dev button

🤖 Generated with [Claude Code](https://claude.com/claude-code)