### PR TITLE
fix: skip onboarding when user already has data

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -391,12 +391,21 @@ const updateSW = registerSW({
 
 // ── Onboarding ──────────────────────────────────────────────────
 const onboardingComplete = ref(!!localStorage.getItem('onboarding-complete'))
-// Defense against localStorage loss: if user already has exercises, mark onboarding complete
 const workoutStoreForOnboarding = useWorkoutStore()
-if (!onboardingComplete.value && workoutStoreForOnboarding.exercises.length > 0) {
-  localStorage.setItem('onboarding-complete', 'true')
-  onboardingComplete.value = true
-}
+const bodyweightStoreForOnboarding = useBodyweightStore()
+
+// Skip onboarding if user already has any data (exercises or bodyweight entries)
+// Reactive so it catches data that loads asynchronously after auth
+watch(
+  () => workoutStoreForOnboarding.exercises.length + bodyweightStoreForOnboarding.entries.length,
+  (total) => {
+    if (!onboardingComplete.value && total > 0) {
+      localStorage.setItem('onboarding-complete', 'true')
+      onboardingComplete.value = true
+    }
+  },
+  { immediate: true },
+)
 const showOnboarding = computed(() => !onboardingComplete.value)
 const hasSampleData = ref(localStorage.getItem('sample-data') === 'true')
 


### PR DESCRIPTION
## Summary
- Onboarding check is now a reactive watcher instead of a one-time init check
- Catches data that loads asynchronously after auth (Supabase sync)
- Checks both workout exercises and bodyweight entries
- Existing users with data are never shown onboarding

## Test plan
- [ ] New user with no data sees onboarding after sign-in
- [ ] Existing user with exercises skips onboarding
- [ ] Existing user with only bodyweight data skips onboarding
- [ ] After completing onboarding, it doesn't show again

🤖 Generated with [Claude Code](https://claude.com/claude-code)