### PR TITLE
fix: reset onboarding state on sign out

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -564,6 +564,8 @@ function acceptConfirm() {
 function confirmSignOut() {
   showConfirm('Sign out?', () => {
     settingsOpen.value = false
+    localStorage.removeItem('onboarding-complete')
+    onboardingComplete.value = false
     signOut()
   })
 }


### PR DESCRIPTION
## Summary
- Clears \`onboarding-complete\` from localStorage on sign out
- Resets \`onboardingComplete\` ref so the watcher re-evaluates on next sign in
- Fresh sign-in with no data → sees onboarding; with data → skips it

## Test plan
- [ ] Sign out, sign back in as dev (0 data) → onboarding appears
- [ ] Complete onboarding, sign out, sign back in → onboarding appears again (no data)
- [ ] User with existing data signs out and back in → onboarding skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)