### PR TITLE
feat: rework Aaron theme to match app icon branding

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -22,7 +22,7 @@ export const THEMES: ThemeOption[] = [
   { id: 'graphite', label: 'Graphite', dot: '#8b5cf6' },
   { id: 'arctic',   label: 'Arctic',   dot: '#0066ff' },
   { id: 'forge',    label: 'Forge',    dot: '#f59e0b' },
-  { id: 'aaron',    label: 'Aaron',    dot: '#2a8a4a' },
+  { id: 'aaron',    label: 'Aaron',    dot: '#c9a84c' },
   { id: 'tina',     label: 'Tina',     dot: '#ec4899' },
 ]
 
@@ -31,7 +31,7 @@ export const THEME_PREVIEWS: Record<ThemeId, { dark: ThemePreviewColors; light: 
   graphite: { dark: { bg: '#111118', card: '#1c1c28', accent: '#8b5cf6', text: '#e4e4f4' }, light: { bg: '#ededf5', card: '#ffffff', accent: '#7c3aed', text: '#18182a' } },
   arctic:   { dark: { bg: '#0e1420', card: '#182030', accent: '#3388ff', text: '#e0e8f8' }, light: { bg: '#dde4f5', card: '#ffffff', accent: '#0066ff', text: '#1a1a2e' } },
   forge:    { dark: { bg: '#100e0b', card: '#1c1814', accent: '#f59e0b', text: '#f0e8d8' }, light: { bg: '#f5ede0', card: '#ffffff', accent: '#d97706', text: '#201a10' } },
-  aaron:    { dark: { bg: '#14261a', card: '#0c1a10', accent: '#c8a44e', text: '#e8f0ea' }, light: { bg: '#c8e0cc', card: '#f4faf5', accent: '#a0842a', text: '#0c1a10' } },
+  aaron:    { dark: { bg: '#0f0f0f', card: '#1a1816', accent: '#c9a84c', text: '#f0ece4' }, light: { bg: '#f2efe8', card: '#faf8f4', accent: '#96800e', text: '#1a1810' } },
   tina:     { dark: { bg: '#1a1020', card: '#261830', accent: '#f472b6', text: '#f0e4f4' }, light: { bg: '#f0dff0', card: '#ffffff', accent: '#ec4899', text: '#1e1028' } },
 }
 
@@ -40,7 +40,7 @@ const THEME_META_COLORS: Record<ThemeId, { dark: string; light: string }> = {
   graphite: { dark: '#111118', light: '#ededf5' },
   arctic:   { dark: '#0e1420', light: '#dde4f5' },
   forge:    { dark: '#100e0b', light: '#f5ede0' },
-  aaron:    { dark: '#0c0f14', light: '#eceee8' },
+  aaron:    { dark: '#0f0f0f', light: '#f2efe8' },
   tina:     { dark: '#1a1020', light: '#f0dff0' },
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -244,61 +244,61 @@
 /* ── Aaron ────────────────────────────────────────────────────────── */
 
 [data-theme="aaron"][data-mode="dark"] {
-  --bg-primary:      #0c0f14;
-  --bg-secondary:    #141820;
-  --bg-elevated:     #1c212a;
-  --bg-hover:        #242a34;
-  --border:          #1e2530;
-  --border-strong:   #2c3440;
-  --text-primary:    #e8eaee;
-  --text-secondary:  #8a9070;
-  --text-muted:      #6a7058;
-  --accent:          #c8a44e;
-  --accent-hover:    #d4b258;
-  --accent-subtle:   rgba(200, 164, 78, 0.12);
+  --bg-primary:      #0f0f0f;
+  --bg-secondary:    #1a1816;
+  --bg-elevated:     #222018;
+  --bg-hover:        #2a2820;
+  --border:          #2a2620;
+  --border-strong:   #3a3428;
+  --text-primary:    #f0ece4;
+  --text-secondary:  #a09880;
+  --text-muted:      #706858;
+  --accent:          #c9a84c;
+  --accent-hover:    #d6b85a;
+  --accent-subtle:   rgba(201, 168, 76, 0.12);
   --danger:          #ef4444;
   --danger-subtle:   rgba(239, 68, 68, 0.12);
   --success:         #7aaa60;
   --success-subtle:  rgba(122, 170, 96, 0.12);
   --shadow:          0 16px 48px rgba(0, 0, 0, 0.8);
   --shadow-sm:       0 2px 8px rgba(0, 0, 0, 0.5);
-  --glass-fill:      rgba(200,164,78,0.05);
-  --glass-edge:      rgba(200,164,78,0.10);
-  --glass-shine:     rgba(200,164,78,0.08);
-  --glass-bar:       rgba(10,12,16,0.80);
+  --glass-fill:      rgba(201,168,76,0.05);
+  --glass-edge:      rgba(201,168,76,0.10);
+  --glass-shine:     rgba(201,168,76,0.08);
+  --glass-bar:       rgba(15,15,15,0.82);
   --glass-overlay:   rgba(0,0,0,0.58);
-  --text-on-accent:  #141000;
-  --mesh:            radial-gradient(ellipse 70% 55% at 15% 10%, rgba(200,164,78,0.06) 0%, transparent 65%),
-                     radial-gradient(ellipse 55% 45% at 85% 80%, rgba(120,140,80,0.05) 0%, transparent 65%);
+  --text-on-accent:  #0f0f0f;
+  --mesh:            radial-gradient(ellipse 70% 55% at 15% 10%, rgba(201,168,76,0.06) 0%, transparent 65%),
+                     radial-gradient(ellipse 55% 45% at 85% 80%, rgba(180,150,60,0.04) 0%, transparent 65%);
 }
 
 [data-theme="aaron"][data-mode="light"] {
-  --bg-primary:      #eceee8;
-  --bg-secondary:    #f6f7f4;
+  --bg-primary:      #f2efe8;
+  --bg-secondary:    #faf8f4;
   --bg-elevated:     #ffffff;
-  --bg-hover:        #e4e6e0;
-  --border:          #c8ccc0;
-  --border-strong:   #a8b0a0;
-  --text-primary:    #141820;
-  --text-secondary:  #5a6048;
-  --text-muted:      #727858;
-  --accent:          #806a18;
-  --accent-hover:    #6c5a10;
-  --accent-subtle:   rgba(128, 106, 24, 0.08);
+  --bg-hover:        #eae6dc;
+  --border:          #d8d0c0;
+  --border-strong:   #bab0a0;
+  --text-primary:    #1a1810;
+  --text-secondary:  #6a6048;
+  --text-muted:      #8a8068;
+  --accent:          #96800e;
+  --accent-hover:    #7a6a08;
+  --accent-subtle:   rgba(150, 128, 14, 0.08);
   --danger:          #dc2626;
   --danger-subtle:   rgba(220, 38, 38, 0.08);
   --success:         #5a8a40;
   --success-subtle:  rgba(90, 138, 64, 0.08);
-  --shadow:          0 8px 32px rgba(12, 14, 18, 0.12);
-  --shadow-sm:       0 2px 8px rgba(12, 14, 18, 0.06);
-  --glass-fill:      rgba(200,196,170,0.30);
+  --shadow:          0 8px 32px rgba(20, 18, 10, 0.10);
+  --shadow-sm:       0 2px 8px rgba(20, 18, 10, 0.06);
+  --glass-fill:      rgba(210,200,170,0.30);
   --glass-edge:      rgba(200,180,140,0.40);
   --glass-shine:     rgba(255,255,255,0.90);
-  --glass-bar:       rgba(236,238,232,0.82);
-  --glass-overlay:   rgba(14,18,20,0.20);
+  --glass-bar:       rgba(242,239,232,0.82);
+  --glass-overlay:   rgba(14,12,8,0.20);
   --text-on-accent:  #fff;
-  --mesh:            radial-gradient(ellipse 70% 55% at 15% 10%, rgba(200,164,78,0.10) 0%, transparent 60%),
-                     radial-gradient(ellipse 55% 45% at 85% 80%, rgba(120,140,80,0.07) 0%, transparent 60%);
+  --mesh:            radial-gradient(ellipse 70% 55% at 15% 10%, rgba(201,168,76,0.10) 0%, transparent 60%),
+                     radial-gradient(ellipse 55% 45% at 85% 80%, rgba(180,150,60,0.06) 0%, transparent 60%);
 }
 
 /* ── Tina ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Dark mode: warm near-black backgrounds (#0f0f0f) matching the icon, gold accent (#c9a84c)
- Light mode: warm cream/ivory palette with darker gold accent
- Preview dot changed from green to gold
- Preview colors and meta theme-color updated to match

## Test plan
- [ ] Aaron theme dark mode: warm dark background, gold accents, readable text
- [ ] Aaron theme light mode: warm cream background, gold accents
- [ ] Theme preview in settings shows gold dot and correct preview colors
- [ ] Glass morphism renders correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)