### PR TITLE
fix: modal drag handle hidden behind Dynamic Island in PWA mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1949,6 +1949,7 @@ button, [role="tab"], [role="switch"], a {
   justify-content: center;
   z-index: 100;
   padding: 20px;
+  padding-top: calc(env(safe-area-inset-top, 0px) + 20px);
   animation: overlayFadeIn 0.2s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- Added \`padding-top: calc(env(safe-area-inset-top) + 20px)\` to \`.repMaxOverlay\`
- Pushes all modal content below the Dynamic Island / notch in standalone PWA mode
- Affects exercise detail, log set, and edit exercise modals

## Test plan
- [ ] PWA mode on iPhone with Dynamic Island: drag handle is visible and grabbable
- [ ] Swipe-to-dismiss works on the exercise detail sheet
- [ ] Regular browser mode: no visible change (safe-area-inset-top is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)