### PR TITLE
test: regression tests for swipe-to-dismiss and auth bug fixes

### DIFF
--- a/src/composables/__tests__/useAuth.test.js
+++ b/src/composables/__tests__/useAuth.test.js
@@ -147,5 +147,24 @@ describe('useAuth', () => {
       await signOut()
       expect(user.value).toBeNull()
     })
+
+    // Regression: signOut must clear user even when supabase.auth.signOut() throws
+    it('clears user even when supabase signOut throws', async () => {
+      mockSignOut.mockRejectedValueOnce(new Error('Network error'))
+      const { signOut, user, devSignIn } = useAuth()
+      await devSignIn()
+      expect(user.value).not.toBeNull()
+      await signOut()
+      expect(user.value).toBeNull()
+    })
+  })
+
+  describe('devSignIn', () => {
+    it('sets user to local-dev', async () => {
+      const { devSignIn, user } = useAuth()
+      expect(user.value).toBeNull()
+      await devSignIn()
+      expect(user.value).toEqual({ id: 'local-dev', email: 'dev@localhost' })
+    })
   })
 })

--- a/src/composables/__tests__/useSwipeToDismiss.test.ts
+++ b/src/composables/__tests__/useSwipeToDismiss.test.ts
@@ -176,6 +176,87 @@ describe('useSwipeToDismiss', () => {
     wrapper.unmount()
   })
 
+  // Regression: attach(container, handle) should bind touch events only to the handle
+  it('supports separate handle element for touch events', () => {
+    const Comp = defineComponent({
+      setup() {
+        const swipe = useSwipeToDismiss({
+          threshold: 80,
+          onDismiss: onDismiss,
+        })
+        return { ...swipe }
+      },
+      mounted() {
+        const container = this.$el as HTMLElement
+        const handle = container.querySelector('.handle') as HTMLElement
+        this.attach(container, handle)
+      },
+      template: '<div style="height:400px"><div class="handle" style="height:40px"></div><div class="content">scrollable</div></div>',
+    })
+    const wrapper = mount(Comp, { attachTo: document.body })
+    const container = wrapper.element as HTMLElement
+    const handle = container.querySelector('.handle') as HTMLElement
+
+    // Touch on the handle should start tracking
+    handle.dispatchEvent(createTouchEvent('touchstart', 100))
+    handle.dispatchEvent(createTouchEvent('touchmove', 160))
+    expect(wrapper.vm.offsetY).toBe(60)
+
+    handle.dispatchEvent(createTouchEvent('touchend', 160))
+
+    // Touch on the container directly should NOT start tracking
+    // (offsetY was reset by the snap-back on touchend)
+    container.dispatchEvent(createTouchEvent('touchstart', 100))
+    container.dispatchEvent(createTouchEvent('touchmove', 200))
+    expect(wrapper.vm.offsetY).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  // Regression: upward swipe when scrollTop > 0 should not trigger drag
+  it('allows scroll-up without triggering drag when scrollTop > 0', () => {
+    const wrapper = createWrapper({ onDismiss })
+    const el = wrapper.element as HTMLElement
+
+    Object.defineProperty(el, 'scrollTop', { value: 100, writable: true })
+
+    el.dispatchEvent(createTouchEvent('touchstart', 200))
+    // Swipe up (negative delta)
+    el.dispatchEvent(createTouchEvent('touchmove', 150))
+    expect(wrapper.vm.isDragging).toBe(false)
+    expect(wrapper.vm.offsetY).toBe(0)
+
+    // Even a downward move shouldn't drag because scrollTop > 0
+    el.dispatchEvent(createTouchEvent('touchmove', 250))
+    expect(wrapper.vm.isDragging).toBe(false)
+    expect(wrapper.vm.offsetY).toBe(0)
+
+    wrapper.unmount()
+  })
+
+  // Regression: new touch after scroll-down-then-release should not auto-dismiss
+  it('does not carry drag state across separate touch gestures', () => {
+    const wrapper = createWrapper({ onDismiss })
+    const el = wrapper.element as HTMLElement
+
+    // First gesture: start at scrollTop=0, drag down a bit, release
+    el.dispatchEvent(createTouchEvent('touchstart', 100))
+    el.dispatchEvent(createTouchEvent('touchmove', 130))
+    expect(wrapper.vm.isDragging).toBe(true)
+    el.dispatchEvent(createTouchEvent('touchend', 130))
+    expect(wrapper.vm.isDragging).toBe(false)
+
+    // Second gesture: now scrollTop > 0 (user scrolled content)
+    Object.defineProperty(el, 'scrollTop', { value: 50, writable: true })
+    el.dispatchEvent(createTouchEvent('touchstart', 200))
+    el.dispatchEvent(createTouchEvent('touchmove', 250))
+    // Should NOT drag — scrollTop > 0
+    expect(wrapper.vm.isDragging).toBe(false)
+    expect(wrapper.vm.offsetY).toBe(0)
+
+    wrapper.unmount()
+  })
+
   it('cleans up on unmount', () => {
     const wrapper = createWrapper({ onDismiss })
     const el = wrapper.element as HTMLElement

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -89,6 +89,8 @@ async function devSignIn(): Promise<void> {
 async function signOut(): Promise<void> {
   try {
     await supabase?.auth.signOut()
+  } catch {
+    // Network errors during sign-out should not block clearing the user
   } finally {
     user.value = null
   }


### PR DESCRIPTION
## Summary
5 new regression tests covering bugs found and fixed today:

**Swipe-to-dismiss (3 tests):**
- \`attach(container, handle)\` binds touch events only to the handle
- Scroll-up with \`scrollTop > 0\` does not trigger drag mode
- Drag state resets between separate touch gestures

**Auth (2 tests):**
- \`signOut()\` clears user even when \`supabase.auth.signOut()\` throws a network error
- \`devSignIn()\` sets user correctly

Also fixed \`signOut\` to catch (not just finally) thrown errors so they don't propagate to callers.

## Why existing tests missed these
- Swipe tests only covered single-element attach — the handle pattern was untested
- Auth signOut test verified the happy path but not error conditions
- No test verified state isolation across multiple touch gesture lifecycles

## Test plan
- [x] All 571 tests pass
- [x] Build succeeds
- [x] Lint clean (only pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)