### PR TITLE
fix: replace tag manager gear emoji with tag icon

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -26,7 +26,7 @@
           class="wtTagChip wtTagChipManage"
           @click="openTagManager"
           aria-label="Manage tags"
-        >⚙</button>
+        ><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></button>
       </div>
     </template>
 

--- a/src/index.css
+++ b/src/index.css
@@ -1294,8 +1294,10 @@ button, [role="tab"], [role="switch"], a {
 .wtTagChipManage {
   border-color: var(--border);
   color: var(--text-secondary);
-  font-size: var(--font-callout);
   padding: 8px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* ─── Tag manager modal ────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Replaced ⚙ emoji on tag manager button with an SVG tag/label icon
- Distinguishes tag management from app settings at a glance
- Consistent SVG stroke icon style (14x14, stroke-width 2)

## Test plan
- [ ] Tag filter bar shows a tag icon button instead of a gear emoji
- [ ] Tapping it still opens the tag manager modal
- [ ] Icon is visible and properly centered across all themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)