### PR TITLE
feat: PR target suggestions when logging a set

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -454,11 +454,25 @@
             </label>
           </div>
 
-          <!-- Live 1RM estimate -->
+          <!-- Live 1RM estimate / PR target -->
           <div v-if="liveEstimate" class="repMaxResult">
             <span class="repMaxResultLabel">Estimated 1RM</span>
             <span class="repMaxResultValue">{{ liveEstimate }} {{ weightUnit }}</span>
             <span v-if="isNewPR" class="wtPrBadge">New PR! 🏆</span>
+          </div>
+          <div v-else-if="prTargetWeight" class="repMaxResult repMaxResultTarget">
+            <span class="repMaxResultLabel">PR Target</span>
+            <span class="repMaxResultValue">{{ prTargetWeight }} {{ weightUnit }}</span>
+            <span class="repMaxTargetHint">to beat your PR at {{ reps }} rep{{ reps === 1 ? '' : 's' }}</span>
+          </div>
+          <div v-else-if="prTargetReps === 0" class="repMaxResult repMaxResultTarget">
+            <span class="repMaxResultLabel">PR Target</span>
+            <span class="repMaxResultValue">Any rep is a new PR! 🏆</span>
+          </div>
+          <div v-else-if="prTargetReps" class="repMaxResult repMaxResultTarget">
+            <span class="repMaxResultLabel">PR Target</span>
+            <span class="repMaxResultValue">{{ prTargetReps }} rep{{ prTargetReps === 1 ? '' : 's' }}</span>
+            <span class="repMaxTargetHint">to beat your PR at {{ displayWeight(toLbs(weight)) }} {{ weightUnit }}</span>
           </div>
 
           <div class="repMaxActions">
@@ -1329,6 +1343,33 @@ const isNewPR = computed(() => {
   if (!id || id === '__new__') return false
   const pr = store.getExercisePR(id)
   return pr > 0 && liveEstimateLbs.value > pr
+})
+
+// ── PR target suggestions (inverse Epley) ──────────────────────
+// When only one field is filled, show what's needed in the other to beat the PR
+const prTargetWeight = computed<string | null>(() => {
+  if (isEditMode.value || !reps.value || reps.value < 1) return null
+  if (weight.value && weight.value > 0) return null // both filled → show live estimate instead
+  const id = selectedExerciseId.value
+  if (!id || id === '__new__') return null
+  const pr = store.getExercisePR(id)
+  if (pr <= 0) return null
+  const target = pr + 1
+  const targetLbs = reps.value === 1 ? target : Math.ceil(target / (1 + reps.value / 30))
+  return displayWeight(targetLbs)
+})
+
+const prTargetReps = computed<number | null>(() => {
+  if (isEditMode.value || !weight.value || weight.value <= 0) return null
+  if (reps.value && reps.value >= 1) return null // both filled
+  const id = selectedExerciseId.value
+  if (!id || id === '__new__') return null
+  const pr = store.getExercisePR(id)
+  if (pr <= 0) return null
+  const wLbs = toLbs(weight.value)
+  if (wLbs >= pr + 1) return 0 // any rep beats it
+  const needed = Math.ceil(30 * ((pr + 1) / wLbs - 1))
+  return needed > 30 ? null : needed // >30 reps is impractical
 })
 
 const hasSetData = computed(() => weight.value !== null && weight.value > 0 && reps.value !== null && reps.value >= 1)

--- a/src/components/__tests__/prTarget.test.ts
+++ b/src/components/__tests__/prTarget.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Tests for the inverse Epley formulas used in PR target calculations.
+ *
+ * Epley: e1RM = weight * (1 + reps / 30)
+ * Inverse for weight: weight = e1RM / (1 + reps / 30)
+ * Inverse for reps: reps = 30 * (e1RM / weight - 1)
+ */
+
+function epley(weight: number, reps: number): number {
+  if (reps === 1) return Math.round(weight)
+  return Math.round(weight * (1 + reps / 30))
+}
+
+function prTargetWeight(currentPR: number, reps: number): number {
+  const target = currentPR + 1
+  if (reps === 1) return target
+  return Math.ceil(target / (1 + reps / 30))
+}
+
+function prTargetReps(currentPR: number, weightLbs: number): number | null {
+  const target = currentPR + 1
+  if (weightLbs >= target) return 0 // any rep beats it
+  const needed = Math.ceil(30 * (target / weightLbs - 1))
+  return needed > 30 ? null : needed
+}
+
+describe('PR target calculations (inverse Epley)', () => {
+  describe('prTargetWeight', () => {
+    it('computes weight needed to beat PR at given reps', () => {
+      // PR is 300 lbs. At 5 reps, need weight such that epley(w, 5) > 300
+      const w = prTargetWeight(300, 5)
+      expect(epley(w, 5)).toBeGreaterThan(300)
+      // One less pound should NOT beat it
+      expect(epley(w - 1, 5)).toBeLessThanOrEqual(300)
+    })
+
+    it('at 1 rep, weight = PR + 1', () => {
+      expect(prTargetWeight(300, 1)).toBe(301)
+    })
+
+    it('at higher reps, less weight is needed', () => {
+      const w5 = prTargetWeight(400, 5)
+      const w10 = prTargetWeight(400, 10)
+      expect(w10).toBeLessThan(w5)
+    })
+  })
+
+  describe('prTargetReps', () => {
+    it('computes reps needed to beat PR at given weight', () => {
+      // PR is 300 lbs. At 225 lbs, need enough reps to beat 300
+      const r = prTargetReps(300, 225)
+      expect(r).not.toBeNull()
+      expect(epley(225, r!)).toBeGreaterThan(300)
+    })
+
+    it('returns 0 when weight alone exceeds PR', () => {
+      // Weight of 350 at 1 rep = 350, which beats PR of 300
+      expect(prTargetReps(300, 350)).toBe(0)
+    })
+
+    it('returns null when reps needed exceeds 30', () => {
+      // Very light weight relative to PR
+      expect(prTargetReps(400, 100)).toBeNull()
+    })
+
+    it('returns correct reps at weight equal to PR', () => {
+      // Weight equals PR exactly — need at least 1 rep at higher e1RM
+      const r = prTargetReps(300, 300)
+      // 300 * (1 + r/30) > 300 → r > 0, so minimum is 1
+      expect(r).toBe(1)
+    })
+  })
+})

--- a/src/index.css
+++ b/src/index.css
@@ -2054,6 +2054,17 @@ button, [role="tab"], [role="switch"], a {
   line-height: 1;
 }
 
+.repMaxResultTarget {
+  border: 1px dashed var(--accent);
+  background: transparent;
+}
+
+.repMaxTargetHint {
+  font-size: var(--font-caption1);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
 .repMaxActions {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary
- Enter reps only → shows weight needed to beat your PR at that rep count
- Enter weight only → shows reps needed to beat your PR at that weight
- Enter both → shows the existing live 1RM estimate (unchanged)
- Dashed border distinguishes targets from actual estimates
- Handles edge cases: no PR history, weight exceeds PR, >30 reps (hidden), 1-rep

## Test plan
- [ ] Open Log a Set for exercise with PR history
- [ ] Enter only reps (e.g., 5) → shows \"PR Target: X lbs\" with hint
- [ ] Enter only weight (e.g., 225) → shows \"PR Target: X reps\" with hint
- [ ] Enter both → shows \"Estimated 1RM\" as before
- [ ] New exercise (no PR) → no target shown
- [ ] Edit mode → no target shown
- [x] 7 unit tests for inverse Epley math pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)