### PR TITLE
fix: prevent background scroll behind modals on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1532,6 +1532,7 @@ button, [role="tab"], [role="switch"], a {
   background: var(--bg-secondary);
   border-radius: 16px;
   overflow: hidden;
+  touch-action: auto;
 }
 
 .wtDetailHeader {
@@ -1952,12 +1953,15 @@ button, [role="tab"], [role="switch"], a {
   z-index: 100;
   padding: 20px;
   padding-top: calc(env(safe-area-inset-top, 0px) + 20px);
+  touch-action: none;
+  overscroll-behavior: contain;
   animation: overlayFadeIn 0.2s ease-out;
 }
 
 .repMaxModal {
   position: relative;
   overflow: hidden;
+  touch-action: auto;
   background: var(--glass-fill, var(--bg-elevated));
   backdrop-filter: blur(32px) saturate(180%);
   -webkit-backdrop-filter: blur(32px) saturate(180%);
@@ -3679,6 +3683,8 @@ button, [role="tab"], [role="switch"], a {
   justify-content: center;
   z-index: 250;
   padding: 20px;
+  touch-action: none;
+  overscroll-behavior: contain;
   animation: overlayFadeIn 0.2s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- Added \`touch-action: none\` to \`.repMaxOverlay\` and \`.confirmOverlay\`
- Added \`touch-action: auto\` to \`.repMaxModal\` and \`.wtDetailModal\` so modal content remains interactive
- Added \`overscroll-behavior: contain\` as secondary guard

## Test plan
- [ ] Open Log a Set, tap weight field (keyboard appears) — try scrolling on the overlay area, background should NOT scroll
- [ ] Modal inputs still accept touch/tap normally
- [ ] Detail sheet content still scrolls internally
- [ ] Confirm dialog overlay blocks background scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)