### PR TITLE
fix: lock background scroll when modals open on iOS

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1610,5 +1610,13 @@ watch(tagManagerOpen, async (open) => {
   }
 })
 
-onUnmounted(() => stopTimer())
+// ── Lock background scroll when any modal is open (iOS) ────────
+watch(
+  () => showModal.value || !!detailExerciseId.value || editTarget.value !== null || tagManagerOpen.value,
+  (open) => { document.documentElement.classList.toggle('modal-open', open) },
+)
+onUnmounted(() => {
+  stopTimer()
+  document.documentElement.classList.remove('modal-open')
+})
 </script>

--- a/src/index.css
+++ b/src/index.css
@@ -520,6 +520,11 @@ button, [role="tab"], [role="switch"], a {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
+}
+
+html.modal-open .tabContent {
+  overflow: hidden;
+  touch-action: none;
   padding-top: 12px;
   padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 110px);
 }


### PR DESCRIPTION
## Summary
- Adds \`html.modal-open .tabContent { overflow: hidden; touch-action: none }\`
- WorkoutTracker toggles \`.modal-open\` on \`documentElement\` when any modal is open
- Directly locks the scroll container instead of relying on overlay-level touch-action

## Test plan
- [ ] Open Log a Set with keyboard up — try scrolling the visible area, exercise list should NOT scroll
- [ ] Open exercise detail sheet — background should not scroll
- [ ] Close modal — scroll returns to normal
- [ ] Modal content (inputs, buttons) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)