### PR TITLE
fix: settings sheet drag handle hidden behind Dynamic Island

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -771,7 +771,7 @@ html.modal-open .tabContent {
 .settingsSheet {
   width: 100%;
   max-width: 520px;
-  max-height: 85svh;
+  max-height: calc(85svh - env(safe-area-inset-top, 0px));
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;


### PR DESCRIPTION
## Summary
- Settings sheet max-height now accounts for \`safe-area-inset-top\`
- Drag handle stays below the Dynamic Island in standalone PWA mode
- No change in browser mode (inset is 0)

## Test plan
- [ ] PWA mode: settings sheet drag handle is visible and grabbable
- [ ] Swipe-to-dismiss works on the settings sheet
- [ ] Settings content is fully scrollable within the reduced height

🤖 Generated with [Claude Code](https://claude.com/claude-code)