### PR TITLE
fix: clarify PR target label as estimated 1RM

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -461,20 +461,20 @@
             <span v-if="isNewPR" class="wtPrBadge">New PR! 🏆</span>
           </div>
           <div v-else-if="prTargetWeight" class="repMaxResult repMaxResultTarget">
-            <span class="repMaxResultLabel">PR Target</span>
+            <span class="repMaxResultLabel">Est. 1RM Target</span>
             <span class="repMaxResultValue">{{ prTargetWeight }} {{ weightUnit }}</span>
-            <span class="repMaxTargetHint">to beat your PR at {{ reps }} rep{{ reps === 1 ? '' : 's' }}</span>
+            <span class="repMaxTargetHint">to beat your estimated 1RM at {{ reps }} rep{{ reps === 1 ? '' : 's' }}</span>
             <span v-if="bestWeightAtReps" class="repMaxPersonalBest">Your best: {{ displayWeight(bestWeightAtReps) }} {{ weightUnit }} × {{ reps }}</span>
           </div>
           <div v-else-if="prTargetReps === 0" class="repMaxResult repMaxResultTarget">
-            <span class="repMaxResultLabel">PR Target</span>
+            <span class="repMaxResultLabel">Est. 1RM Target</span>
             <span class="repMaxResultValue">Any rep is a new PR! 🏆</span>
             <span v-if="bestRepsAtWeight" class="repMaxPersonalBest">Your best: {{ displayWeight(toLbs(weight)) }} {{ weightUnit }} × {{ bestRepsAtWeight }}</span>
           </div>
           <div v-else-if="prTargetReps" class="repMaxResult repMaxResultTarget">
-            <span class="repMaxResultLabel">PR Target</span>
+            <span class="repMaxResultLabel">Est. 1RM Target</span>
             <span class="repMaxResultValue">{{ prTargetReps }} rep{{ prTargetReps === 1 ? '' : 's' }}</span>
-            <span class="repMaxTargetHint">to beat your PR at {{ displayWeight(toLbs(weight)) }} {{ weightUnit }}</span>
+            <span class="repMaxTargetHint">to beat your estimated 1RM at {{ displayWeight(toLbs(weight)) }} {{ weightUnit }}</span>
             <span v-if="bestRepsAtWeight" class="repMaxPersonalBest">Your best: {{ displayWeight(toLbs(weight)) }} {{ weightUnit }} × {{ bestRepsAtWeight }}</span>
           </div>
 


### PR DESCRIPTION
## Summary
- Label changed from \"PR Target\" to \"Est. 1RM Target\"
- Hint text now says \"to beat your estimated 1RM\" instead of \"to beat your PR\"
- Makes it clear the target is formula-derived, while \"Your best\" is actual data

## Test plan
- [ ] Enter reps only → label says \"Est. 1RM Target\", hint mentions \"estimated 1RM\"
- [ ] Enter weight only → same labeling
- [ ] \"Your best\" line unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)