### PR TITLE
fix: clarify PR target means 1RM record

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -461,21 +461,19 @@
             <span v-if="isNewPR" class="wtPrBadge">New PR! 🏆</span>
           </div>
           <div v-else-if="prTargetWeight" class="repMaxResult repMaxResultTarget">
-            <span class="repMaxResultLabel">To Beat Your PR</span>
+            <span class="repMaxResultLabel">To Beat Your 1RM Record</span>
             <span class="repMaxResultValue">{{ prTargetWeight }} {{ weightUnit }} × {{ reps }}</span>
-            <span class="repMaxTargetHint">based on estimated 1RM</span>
-            <span v-if="bestWeightAtReps" class="repMaxPersonalBest">Your best: {{ displayWeight(bestWeightAtReps) }} {{ weightUnit }} × {{ reps }}</span>
+            <span v-if="bestWeightAtReps" class="repMaxPersonalBest">Your best at {{ reps }} rep{{ reps === 1 ? '' : 's' }}: {{ displayWeight(bestWeightAtReps) }} {{ weightUnit }}</span>
           </div>
           <div v-else-if="prTargetReps === 0" class="repMaxResult repMaxResultTarget">
-            <span class="repMaxResultLabel">To Beat Your PR</span>
-            <span class="repMaxResultValue">Any rep is a new PR! 🏆</span>
-            <span v-if="bestRepsAtWeight" class="repMaxPersonalBest">Your best: {{ displayWeight(toLbs(weight)) }} {{ weightUnit }} × {{ bestRepsAtWeight }}</span>
+            <span class="repMaxResultLabel">To Beat Your 1RM Record</span>
+            <span class="repMaxResultValue">Any rep is a new 1RM! 🏆</span>
+            <span v-if="bestRepsAtWeight" class="repMaxPersonalBest">Your best at {{ displayWeight(toLbs(weight)) }} {{ weightUnit }}: {{ bestRepsAtWeight }} rep{{ bestRepsAtWeight === 1 ? '' : 's' }}</span>
           </div>
           <div v-else-if="prTargetReps" class="repMaxResult repMaxResultTarget">
-            <span class="repMaxResultLabel">To Beat Your PR</span>
+            <span class="repMaxResultLabel">To Beat Your 1RM Record</span>
             <span class="repMaxResultValue">{{ displayWeight(toLbs(weight)) }} {{ weightUnit }} × {{ prTargetReps }}</span>
-            <span class="repMaxTargetHint">based on estimated 1RM</span>
-            <span v-if="bestRepsAtWeight" class="repMaxPersonalBest">Your best: {{ displayWeight(toLbs(weight)) }} {{ weightUnit }} × {{ bestRepsAtWeight }}</span>
+            <span v-if="bestRepsAtWeight" class="repMaxPersonalBest">Your best at {{ displayWeight(toLbs(weight)) }} {{ weightUnit }}: {{ bestRepsAtWeight }} rep{{ bestRepsAtWeight === 1 ? '' : 's' }}</span>
           </div>
 
           <div class="repMaxActions">


### PR DESCRIPTION
## Summary
- Label: \"To Beat Your PR\" → \"To Beat Your 1RM Record\"
- Removed redundant \"based on estimated 1RM\" hint (label now conveys this)
- \"Your best\" reworded: \"Your best at 5 reps: 275 lbs\" / \"Your best at 155 lbs: 10 reps\"
- Makes it unambiguous that the target is about the estimated 1RM, not a weight- or rep-specific record

## Test plan
- [ ] Enter weight only → \"To Beat Your 1RM Record: 155 lbs × 11\" + \"Your best at 155 lbs: 10 reps\"
- [ ] Enter reps only → \"To Beat Your 1RM Record: 290 lbs × 5\" + \"Your best at 5 reps: 275 lbs\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)