### PR TITLE
feat: show est. 1RM on exercise list on all screen sizes

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -72,12 +72,13 @@
             class="wtExerciseRow"
             @click="openDetailModal(exercise.id)"
           >
-            <span class="wtExerciseName">{{ exercise.name }}</span>
-            <span class="wtExerciseMeta">
-              PR: {{ store.getExercisePR(exercise.id) ? displayWeight(store.getExercisePR(exercise.id)) : '—' }} {{ weightUnit }}
-              &nbsp;·&nbsp;
-              {{ exercise.sets.length }} set{{ exercise.sets.length !== 1 ? 's' : '' }}
-            </span>
+            <div class="wtExerciseNameBlock">
+              <span class="wtExerciseName">{{ exercise.name }}</span>
+              <span class="wtExerciseMeta">
+                Est. 1RM: <template v-if="store.getExercisePR(exercise.id)">{{ displayWeight(store.getExercisePR(exercise.id)) }} {{ weightUnit }}</template><template v-else>—</template>
+                · {{ exercise.sets.length }} set{{ exercise.sets.length !== 1 ? 's' : '' }}
+              </span>
+            </div>
             <span class="wtChevron">›</span>
           </button>
           <button

--- a/src/index.css
+++ b/src/index.css
@@ -1115,8 +1115,15 @@ html.modal-open .tabContent {
 
 .wtExerciseRow:hover { background: var(--bg-hover); }
 
-.wtExerciseName {
+.wtExerciseNameBlock {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.wtExerciseName {
   font-weight: 600;
   font-size: var(--font-footnote);
   color: var(--text-primary);
@@ -1126,11 +1133,10 @@ html.modal-open .tabContent {
 }
 
 .wtExerciseMeta {
-  font-size: var(--font-caption1);
+  font-size: var(--font-caption2);
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
-  flex-shrink: 0;
 }
 
 .wtChevron {
@@ -3333,7 +3339,6 @@ html.modal-open .tabContent {
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 480px) {
-  .wtExerciseMeta { display: none; }
 
   .wtInputRow {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Exercise meta (est. 1RM + set count) moved to second line below exercise name
- Always visible on mobile — removed \`display: none\` at 480px breakpoint
- Renamed \"PR\" to \"Est. 1RM\" for consistency
- Wrapped name + meta in \`.wtExerciseNameBlock\` flex column

## Test plan
- [ ] Exercise list shows \"Est. 1RM: 420 lbs · 34 sets\" below each exercise name
- [ ] Visible on mobile screens (no longer hidden)
- [ ] Exercise with no sets shows \"Est. 1RM: — · 0 sets\"
- [ ] Long exercise names still truncate properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)