### PR TITLE
feat: show PR set details instead of set count

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -74,9 +74,9 @@
           >
             <div class="wtExerciseNameBlock">
               <span class="wtExerciseName">{{ exercise.name }}</span>
-              <span class="wtExerciseMeta">
-                Est. 1RM: <template v-if="store.getExercisePR(exercise.id)">{{ displayWeight(store.getExercisePR(exercise.id)) }} {{ weightUnit }}</template><template v-else>—</template>
-                · {{ exercise.sets.length }} set{{ exercise.sets.length !== 1 ? 's' : '' }}
+              <span v-if="store.getExercisePRSet(exercise.id)" class="wtExerciseMeta">
+                Est. 1RM: {{ displayWeight(store.getExercisePRSet(exercise.id).estimated1RM) }} {{ weightUnit }}
+                ({{ displayWeight(store.getExercisePRSet(exercise.id).weight) }} × {{ store.getExercisePRSet(exercise.id).reps }})
               </span>
             </div>
             <span class="wtChevron">›</span>

--- a/src/components/__tests__/WorkoutTracker.test.js
+++ b/src/components/__tests__/WorkoutTracker.test.js
@@ -88,6 +88,12 @@ function getExercisePR(id) {
   return Math.max(...ex.sets.map(s => s.estimated1RM))
 }
 
+function getExercisePRSet(id) {
+  const ex = exercises.find(e => e.id === id)
+  if (!ex || ex.sets.length === 0) return null
+  return ex.sets.reduce((best, s) => s.estimated1RM > best.estimated1RM ? s : best)
+}
+
 function getAllTags() {
   const tags = new Set()
   exercises.forEach(e => (e.tags || []).forEach(t => tags.add(t)))
@@ -100,6 +106,7 @@ vi.mock('../../stores/workout', () => ({
     set exercises(v) { exercises = v },
     get allTags() { return getAllTags() },
     getExercisePR,
+    getExercisePRSet,
     addExercise: vi.fn(),
     logSet: vi.fn(),
     updateSet: vi.fn(),
@@ -157,32 +164,28 @@ describe('WorkoutTracker', () => {
       expect(items.length).toBe(3)
     })
 
-    it('displays exercise name and set count', () => {
+    it('displays exercise name', () => {
       const wrapper = mountTracker()
       const rows = wrapper.findAll('.wtExerciseRow')
       expect(rows[0].text()).toContain('Bench Press')
-      expect(rows[0].text()).toContain('2 sets')
       expect(rows[1].text()).toContain('Squat')
-      expect(rows[1].text()).toContain('1 set')
     })
 
-    it('uses singular "set" for exercises with 1 set', () => {
+    it('displays est. 1RM with the PR set weight × reps', () => {
       const wrapper = mountTracker()
       const meta = wrapper.findAll('.wtExerciseMeta')
-      expect(meta[1].text()).toMatch(/1 set$/)
-    })
-
-    it('displays PR value for exercises with sets', () => {
-      const wrapper = mountTracker()
-      const meta = wrapper.findAll('.wtExerciseMeta')
+      // Bench PR set: 195 × 5 = e1RM 228
       expect(meta[0].text()).toContain('228')
-      expect(meta[0].text()).toContain('lbs')
+      expect(meta[0].text()).toContain('195')
+      expect(meta[0].text()).toContain('5')
     })
 
-    it('shows dash for PR when exercise has no sets', () => {
+    it('hides meta for exercise with no sets', () => {
       const wrapper = mountTracker()
-      const meta = wrapper.findAll('.wtExerciseMeta')
-      expect(meta[2].text()).toContain('—')
+      // ex-3 (Deadlift) has no sets — meta should not render
+      const items = wrapper.findAll('.wtExerciseItem')
+      const deadliftMeta = items[2].find('.wtExerciseMeta')
+      expect(deadliftMeta.exists()).toBe(false)
     })
 
     it('shows "+ Log" button for each exercise', () => {

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -376,6 +376,14 @@ export const useWorkoutStore = defineStore('workout', {
       return Math.max(...exercise.sets.map((s: WorkoutSet) => s.estimated1RM))
     },
 
+    getExercisePRSet: (state) => (exerciseId: string): WorkoutSet | null => {
+      const exercise = state.exercises.find((e: Exercise) => e.id === exerciseId)
+      if (!exercise || exercise.sets.length === 0) return null
+      return exercise.sets.reduce((best: WorkoutSet, s: WorkoutSet) =>
+        s.estimated1RM > best.estimated1RM ? s : best
+      )
+    },
+
     getRecentSets: (state) => (exerciseId: string, limit = 5): WorkoutSet[] => {
       const exercise = state.exercises.find((e: Exercise) => e.id === exerciseId)
       if (!exercise) return []


### PR DESCRIPTION
## Summary
- Exercise list meta now shows \"Est. 1RM: 420 lbs (335 × 7)\" instead of \"PR: 420 lbs · 34 sets\"
- Shows the weight × reps that produced the best estimated 1RM
- Added \`getExercisePRSet\` getter to workout store
- Exercises with no sets hide the meta line entirely

## Test plan
- [ ] Exercise with sets shows est. 1RM and the set that achieved it
- [ ] Exercise with no sets shows just the name, no meta line
- [ ] Values update when new sets are logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)