### PR TITLE
fix: remove keyboard offset causing modal shift

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -213,7 +213,7 @@
 
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
-    <div v-if="showModal" class="repMaxOverlay" :style="keyboardHeight > 0 ? { paddingBottom: keyboardHeight + 'px' } : undefined" @click.self="onOverlayClick" @keydown.escape="closeModal">
+    <div v-if="showModal" class="repMaxOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
       <div class="repMaxModal" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
 
         <!-- Rest timer view -->
@@ -625,14 +625,12 @@ import { useTheme } from '../composables/useTheme'
 import { useUndoToast } from '../composables/useUndoToast'
 import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
-import { useKeyboardOffset } from '../composables/useKeyboardOffset'
 import ExerciseGraph from './ExerciseGraph.vue'
 
 const store = useWorkoutStore()
 const { logEvent } = useAnalytics()
 const { show: showUndo } = useUndoToast()
 const { restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs } = useTheme()
-const { keyboardHeight } = useKeyboardOffset()
 
 // ── Search & tag filtering ──────────────────────────────────────
 const searchQuery = ref('')


### PR DESCRIPTION
## Summary
- Removed \`paddingBottom: keyboardHeight\` from the log set modal overlay
- iOS natively adjusts the viewport for centered flex modals — the manual offset was redundant and caused jarring shifts when switching between keyboard types
- Removed unused \`useKeyboardOffset\` import

## Test plan
- [ ] Open New Exercise modal, tap between name/weight/reps fields — no shifting
- [ ] Open Log a Set for existing exercise — modal stays stable when keyboard appears
- [ ] All fields remain visible above the keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)