### PR TITLE
fix: restore exercise list scroll padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -520,13 +520,13 @@ button, [role="tab"], [role="switch"], a {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
+  padding-top: 12px;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 110px);
 }
 
 html.modal-open .tabContent {
   overflow: hidden;
   touch-action: none;
-  padding-top: 12px;
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 110px);
 }
 
 


### PR DESCRIPTION
## Summary
- Moved \`padding-top\` and \`padding-bottom\` back to base \`.tabContent\` rule
- They were accidentally placed inside the \`html.modal-open .tabContent\` override
- Without bottom padding, content couldn't scroll past the fixed tab bar

## Test plan
- [ ] Exercise list scrolls freely — all exercises reachable
- [ ] Last exercise visible above the tab bar and rest timer
- [ ] Modal scroll lock still works when modals are open

🤖 Generated with [Claude Code](https://claude.com/claude-code)