### PR TITLE
feat(MAS-358): add repeat last set one-tap button

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -400,6 +400,17 @@
             </div>
           </div>
 
+          <!-- Repeat last set quick-fill -->
+          <div v-if="lastSetForExercise && !isEditMode" class="wtRepeatLastSet" @click="repeatLastSet">
+            <div class="wtOverloadIcon wtRepeatIcon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="18" height="18"><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg>
+            </div>
+            <div class="wtOverloadContent">
+              <span class="wtOverloadTarget">Repeat {{ displayWeight(lastSetForExercise.weight) }} {{ weightUnit }} × {{ lastSetForExercise.reps }}</span>
+              <span class="wtOverloadReason">Same as your last set</span>
+            </div>
+          </div>
+
           <!-- Date: silent by default — tapping the field opens the picker.
                The input is an invisible overlay covering the field so the user's
                touch lands directly on the input (iOS requires a real touch, not
@@ -915,6 +926,20 @@ function applyOverloadSuggestion() {
   if (!overloadSuggestion.value) return
   weight.value = displayWeight(overloadSuggestion.value.weight)
   reps.value = overloadSuggestion.value.reps
+}
+
+// Last set for the current exercise (for "repeat last set" quick-fill)
+const lastSetForExercise = computed(() => {
+  const id = selectedExerciseId.value
+  if (!id || id === '__new__') return null
+  const recent = store.getRecentSets(id, 1)
+  return recent.length > 0 ? recent[0] : null
+})
+
+function repeatLastSet() {
+  if (!lastSetForExercise.value) return
+  weight.value = displayWeight(lastSetForExercise.value.weight)
+  reps.value = lastSetForExercise.value.reps
 }
 
 const modalTitle = computed(() => {

--- a/src/components/__tests__/repeatLastSet.test.ts
+++ b/src/components/__tests__/repeatLastSet.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, val: string) => { store[key] = String(val) }),
+    removeItem: vi.fn((key: string) => { delete store[key] }),
+    clear: vi.fn(() => { store = {} }),
+  }
+})()
+vi.stubGlobal('localStorage', localStorageMock)
+
+vi.mock('../../lib/supabase', () => ({ supabase: null }))
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn() }
+}))
+vi.mock('../../lib/conflictResolver', () => ({
+  mergeEntities: vi.fn(() => ({ merged: [], localOnly: [] }))
+}))
+
+import { useWorkoutStore } from '../../stores/workout'
+
+/**
+ * Tests for the "repeat last set" feature (MAS-358).
+ *
+ * The feature relies on store.getRecentSets(id, 1) to retrieve the most
+ * recent set, then pre-fills the weight and reps inputs. These tests
+ * verify the store getter returns the correct set in various scenarios.
+ */
+describe('repeat last set (MAS-358)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('returns the most recent set for an exercise', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Bench Press')!
+    store.logSet(id, 135, 10, '2026-03-01')
+    store.logSet(id, 155, 8, '2026-03-02')
+    store.logSet(id, 175, 5, '2026-03-03')
+
+    const recent = store.getRecentSets(id, 1)
+    expect(recent).toHaveLength(1)
+    expect(recent[0].weight).toBe(175)
+    expect(recent[0].reps).toBe(5)
+  })
+
+  it('returns empty array for exercise with no sets', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Squat')!
+
+    const recent = store.getRecentSets(id, 1)
+    expect(recent).toHaveLength(0)
+  })
+
+  it('returns empty array for non-existent exercise', () => {
+    const store = useWorkoutStore()
+    const recent = store.getRecentSets('non-existent', 1)
+    expect(recent).toEqual([])
+  })
+
+  it('returns the last logged set, not the highest weight', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Deadlift')!
+    // Log heavy set first, then lighter set after
+    store.logSet(id, 315, 3, '2026-03-01')
+    store.logSet(id, 225, 10, '2026-03-02')
+
+    const recent = store.getRecentSets(id, 1)
+    expect(recent).toHaveLength(1)
+    // Should return the last logged set (225×10), not the heaviest (315×3)
+    expect(recent[0].weight).toBe(225)
+    expect(recent[0].reps).toBe(10)
+  })
+
+  it('does not return sets from a different exercise', () => {
+    const store = useWorkoutStore()
+    const benchId = store.addExercise('Bench Press')!
+    const squatId = store.addExercise('Squat')!
+    store.logSet(benchId, 185, 5, '2026-03-01')
+    store.logSet(squatId, 275, 5, '2026-03-01')
+
+    const benchRecent = store.getRecentSets(benchId, 1)
+    expect(benchRecent[0].weight).toBe(185)
+
+    const squatRecent = store.getRecentSets(squatId, 1)
+    expect(squatRecent[0].weight).toBe(275)
+  })
+
+  it('updates after a new set is logged', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('OHP')!
+    store.logSet(id, 95, 8, '2026-03-01')
+
+    let recent = store.getRecentSets(id, 1)
+    expect(recent[0].weight).toBe(95)
+    expect(recent[0].reps).toBe(8)
+
+    // Log another set
+    store.logSet(id, 105, 6, '2026-03-02')
+    recent = store.getRecentSets(id, 1)
+    expect(recent[0].weight).toBe(105)
+    expect(recent[0].reps).toBe(6)
+  })
+})

--- a/src/index.css
+++ b/src/index.css
@@ -1938,6 +1938,34 @@ html.modal-open .tabContent {
   line-height: 1.3;
 }
 
+/* ─── Repeat last set quick-fill (MAS-358) ─────────────────────────────── */
+
+.wtRepeatLastSet {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 14px;
+  margin-bottom: 14px;
+  border-radius: 12px;
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.wtRepeatLastSet:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-strong);
+}
+
+.wtRepeatLastSet:active {
+  transform: scale(0.99);
+}
+
+.wtRepeatIcon {
+  background: var(--text-secondary);
+}
+
 /* ─── Modal enter animations (MAS-249) ───────────────────────────────────── */
 
 @keyframes overlayFadeIn {


### PR DESCRIPTION
## Summary
- Adds a "Repeat" quick-fill button to the set logging modal that pre-fills weight and reps from the most recent set
- Button appears below the progressive overload suggestion using subdued surface styling to differentiate the two actions
- Leverages existing `store.getRecentSets(id, 1)` getter — no store changes needed

## Test plan
- [x] 6 new tests covering getter behavior (empty exercise, cross-exercise isolation, update reactivity, last-logged vs heaviest)
- [ ] Manual: open log modal for exercise with history → verify "Repeat X × Y" button shows
- [ ] Manual: tap repeat button → verify weight and reps inputs are pre-filled
- [ ] Manual: exercise with no sets → verify repeat button does not appear
- [ ] Manual: verify styling renders correctly across all 6 themes (light + dark)

Closes MAS-358

🤖 Generated with [Claude Code](https://claude.com/claude-code)