### PR TITLE
chore(MAS-338): add eslint-plugin-vuejs-accessibility for automated a1

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,12 +1,14 @@
 import js from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import pluginVue from 'eslint-plugin-vue'
+import vuejsAccessibility from 'eslint-plugin-vuejs-accessibility'
 import globals from 'globals'
 
 export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs['flat/recommended'],
+  ...vuejsAccessibility.configs['flat/recommended'],
   {
     files: ['src/**/*.{js,ts,vue}'],
     languageOptions: {
@@ -30,6 +32,13 @@ export default [
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       'vue/no-v-html': 'warn',
+      // Accessibility rules — warn-only to avoid breaking CI on existing violations.
+      // Goal: fix existing violations incrementally, then promote to 'error'.
+      'vuejs-accessibility/click-events-have-key-events': 'warn',
+      'vuejs-accessibility/form-control-has-label': 'warn',
+      'vuejs-accessibility/interactive-supports-focus': 'warn',
+      'vuejs-accessibility/label-has-for': 'warn',
+      'vuejs-accessibility/no-static-element-interactions': 'warn',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@vue/test-utils": "^2.4.6",
         "eslint": "^10.1.0",
         "eslint-plugin-vue": "^10.8.0",
+        "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "globals": "^17.4.0",
         "happy-dom": "^20.8.9",
         "husky": "^9.1.7",
@@ -4312,6 +4313,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -5414,6 +5425,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz",
+      "integrity": "sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.0",
+        "vue-eslint-parser": "^9.0.0 || ^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "globals": ">= 13.12.1"
       }
     },
     "node_modules/eslint-scope": {
@@ -9798,7 +9827,6 @@
       "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0 || ^9.0.0",
@@ -9823,7 +9851,6 @@
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@vue/test-utils": "^2.4.6",
     "eslint": "^10.1.0",
     "eslint-plugin-vue": "^10.8.0",
+    "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "globals": "^17.4.0",
     "happy-dom": "^20.8.9",
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary
**Issue:** [MAS-338](https://linear.app/masterchung/issue/MAS-338)

Picked MAS-338 (Add eslint-plugin-vuejs-accessibility) — small complexity, high ongoing value. Adds automated a11y linting that catches ~30-57% of WCAG violations at dev time. Rules set to warn-only to avoid breaking CI on 43 pre-existing violations, allowing incremental fixes.

## Changes
- Installed `eslint-plugin-vuejs-accessibility@2.5.0` as a dev dependency
- Added `flat/recommended` config spread to ESLint config
- Downgraded the 5 rules with existing violations to `warn` level to avoid CI breakage
- Left all other recommended rules at `error` (default) to catch new violations immediately

## Commits
- [`65d37ee`](https://github.com/aschung212/Lift/commit/65d37ee) chore(MAS-338): add eslint-plugin-vuejs-accessibility for automated a11y linting

## Test Results
- Before: 586 passing
- After: 586 passing (0 delta)

## Review Status
Quick review: **minor-only**

---
_Automated by overnight pipeline — Thu Apr  2 14:05:25 PDT 2026_