### PR TITLE
feat(LIFT-99): complete analytics instrumentation for user funnel trac

### DIFF
--- a/src/components/AuthScreen.vue
+++ b/src/components/AuthScreen.vue
@@ -64,8 +64,10 @@
 import { ref } from 'vue'
 import type { Provider } from '@supabase/supabase-js'
 import { useAuth } from '../composables/useAuth'
+import { useAnalytics } from '../composables/useAnalytics'
 
 const { signInWithProvider, signInWithEmail, signUp, devSignIn } = useAuth()
+const { logEvent } = useAnalytics()
 const isDev = import.meta.env.DEV
 
 const email = ref('')
@@ -83,22 +85,29 @@ function toggleMode() {
 async function handleEmailSubmit() {
   message.value = ''
   submitting.value = true
+  const method = isSignUp.value ? 'sign_up' : 'sign_in'
+  logEvent(`auth_${method}_start`, { provider: 'email' })
 
   if (isSignUp.value) {
     const { error, needsConfirmation } = await signUp(email.value, password.value)
     if (error) {
       isError.value = true
       message.value = error.message
+      logEvent('auth_sign_up_error')
     } else if (needsConfirmation) {
       isError.value = false
       message.value = 'Check your email to confirm your account.'
       isSignUp.value = false
+      logEvent('auth_sign_up_success')
     }
   } else {
     const { error } = await signInWithEmail(email.value, password.value)
     if (error) {
       isError.value = true
       message.value = error.message
+      logEvent('auth_sign_in_error')
+    } else {
+      logEvent('auth_sign_in_success', { provider: 'email' })
     }
   }
 
@@ -107,10 +116,12 @@ async function handleEmailSubmit() {
 
 async function handleOAuth(provider: Provider) {
   message.value = ''
+  logEvent('auth_sign_in_start', { provider })
   const { error } = await signInWithProvider(provider)
   if (error) {
     isError.value = true
     message.value = error.message
+    logEvent('auth_sign_in_error', { provider })
   }
 }
 </script>

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -7,7 +7,7 @@
         <p class="obTagline">How would you like to get started?</p>
 
         <div class="obOptions">
-          <button class="obOption" @click="chooseEmpty">
+          <button class="obOption" @click="chooseEmpty" aria-label="Start Empty — Add your own exercises from scratch">
             <span class="obOptionIcon">🚀</span>
             <span class="obOptionText">
               <strong>Start Empty</strong>
@@ -15,7 +15,7 @@
             </span>
           </button>
 
-          <button class="obOption" @click="chooseStarter">
+          <button class="obOption" @click="chooseStarter" aria-label="Popular Exercises — Pre-load 6 common lifts with tags">
             <span class="obOptionIcon">💪</span>
             <span class="obOptionText">
               <strong>Popular Exercises</strong>
@@ -23,7 +23,7 @@
             </span>
           </button>
 
-          <button class="obOption" @click="chooseExplore">
+          <button class="obOption" @click="chooseExplore" aria-label="Explore First — See the app with sample data, clear it when ready">
             <span class="obOptionIcon">👀</span>
             <span class="obOptionText">
               <strong>Explore First</strong>
@@ -88,11 +88,13 @@ import { useWorkoutStore } from '../stores/workout'
 import { useBodyweightStore } from '../stores/bodyweight'
 import { useProgressionStore } from '../stores/progression'
 import { useTheme, THEME_PREVIEWS, type ThemeId } from '../composables/useTheme'
+import { useAnalytics } from '../composables/useAnalytics'
 
 const emit = defineEmits<{ complete: [] }>()
 const workoutStore = useWorkoutStore()
 const bwStore = useBodyweightStore()
 const progressionStore = useProgressionStore()
+const { logEvent } = useAnalytics()
 
 const step = ref<'setup' | 'explainer' | 'starter'>('setup')
 const selectedStarter = ref<ThemeId | null>(null)
@@ -431,10 +433,12 @@ function skipStarter() {
 }
 
 function chooseEmpty() {
+  logEvent('onboarding_choice', { choice: 'empty' })
   goToStarter(false)
 }
 
 function chooseStarter() {
+  logEvent('onboarding_choice', { choice: 'starter' })
   for (const ex of STARTER_EXERCISES) {
     workoutStore.addExercise(ex.name, ex.tags)
   }
@@ -444,6 +448,7 @@ function chooseStarter() {
 const noSync = { sync: false }
 
 function chooseExplore() {
+  logEvent('onboarding_choice', { choice: 'explore' })
   // Add exercises with sample sets — skip Supabase sync for sample data (MAS-197)
   for (const group of SAMPLE_SETS) {
     const starter = STARTER_EXERCISES.find(e => e.name === group.exercise)

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1619,7 +1619,7 @@ function saveSet() {
     if (hasSetData.value && weight.value !== null && reps.value !== null) {
       const wasPR = isNewPR.value
       store.logSet(exerciseId, toLbs(weight.value), reps.value, date.value)
-      logEvent('set_log')
+      logEvent('set_log', { exercise: selectedExerciseName.value, isPR: wasPR })
       // XP: get the just-logged set (last in array) and compute XP
       const exercise = store.exercises.find(e => e.id === exerciseId)
       if (exercise && exercise.sets.length > 0) {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-99](https://github.com/aschung212/Lift/issues/99)

Picked LIFT-99 (Set up analytics dashboard). Vercel Analytics infrastructure was already in place, but key user funnel events were missing — auth flow, onboarding choices, and enriched set logging. Added these to provide the usage pattern data needed for growth decisions.

## Changes
- Added auth funnel tracking to AuthScreen: `auth_sign_in_start`, `auth_sign_up_start`, `auth_sign_in_success`, `auth_sign_up_success`, `auth_sign_in_error`, `auth_sign_up_error` with provider info
- Added onboarding choice tracking to OnboardingScreen: `onboarding_choice` with choice type (empty/starter/explore)
- Enriched `set_log` event in WorkoutTracker with exercise name and PR status (`isPR` boolean)

## Commits
- [`44cce50`](https://github.com/aschung212/Lift/commit/44cce50) feat(LIFT-99): complete analytics instrumentation for user funnel tracking

## Test Results
- Before: 0 passing
- After: 835 passing (835 delta)

---
_Automated by overnight pipeline — Fri Apr  3 23:11:15 PDT 2026_