### PR TITLE
a11y(LIFT-131): add aria-labels to all BodyHeatmap SVG muscle regions

### DIFF
--- a/src/components/BodyHeatmap.vue
+++ b/src/components/BodyHeatmap.vue
@@ -70,6 +70,8 @@
             d="M142,82 Q148,78 152,84 L156,96 L148,100 L142,98 Z"
             :style="regionStyle('Shoulders')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Right shoulder: ${getSetCount('Shoulders')} sets`"
           />
           <!-- Left Bicep -->
           <path
@@ -77,13 +79,15 @@
             :style="regionStyle('Biceps')"
             class="muscleRegion"
             role="img"
-            :aria-label="`Biceps: ${getSetCount('Biceps')} sets`"
+            :aria-label="`Left bicep: ${getSetCount('Biceps')} sets`"
           />
           <!-- Right Bicep -->
           <path
             d="M152,100 L156,96 L162,136 Q162,142 158,144 L152,144 Q148,142 148,136 L146,108 Z"
             :style="regionStyle('Biceps')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Right bicep: ${getSetCount('Biceps')} sets`"
           />
           <!-- Core / Abs -->
           <path
@@ -99,13 +103,15 @@
             :style="regionStyle('Legs')"
             class="muscleRegion"
             role="img"
-            :aria-label="`Legs: ${getSetCount('Legs')} sets`"
+            :aria-label="`Left quad: ${getSetCount('Legs')} sets`"
           />
           <!-- Right Quad -->
           <path
             d="M132,200 Q134,204 136,216 L142,290 Q140,296 134,296 L118,296 Q114,290 114,280 L112,240 Q110,220 110,210 Z"
             :style="regionStyle('Legs')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Right quad: ${getSetCount('Legs')} sets`"
           />
         </g>
 
@@ -123,6 +129,8 @@
             d="M78,132 Q76,134 74,142 L72,164 Q70,178 76,190 L80,198 Q88,206 100,208 Q112,206 120,198 L124,190 Q130,178 128,164 L126,142 Q124,134 122,132 Z"
             :style="regionStyle('Back')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Lower back: ${getSetCount('Back')} sets`"
           />
           <!-- Left Rear Shoulder -->
           <path
@@ -130,13 +138,15 @@
             :style="regionStyle('Shoulders')"
             class="muscleRegion"
             role="img"
-            :aria-label="`Shoulders: ${getSetCount('Shoulders')} sets`"
+            :aria-label="`Left shoulder: ${getSetCount('Shoulders')} sets`"
           />
           <!-- Right Rear Shoulder -->
           <path
             d="M142,82 Q148,78 152,84 L156,96 L148,100 L142,98 Z"
             :style="regionStyle('Shoulders')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Right shoulder: ${getSetCount('Shoulders')} sets`"
           />
           <!-- Left Tricep -->
           <path
@@ -144,13 +154,15 @@
             :style="regionStyle('Triceps')"
             class="muscleRegion"
             role="img"
-            :aria-label="`Triceps: ${getSetCount('Triceps')} sets`"
+            :aria-label="`Left tricep: ${getSetCount('Triceps')} sets`"
           />
           <!-- Right Tricep -->
           <path
             d="M152,100 L156,96 L162,136 Q162,142 158,144 L152,144 Q148,142 148,136 L146,108 Z"
             :style="regionStyle('Triceps')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Right tricep: ${getSetCount('Triceps')} sets`"
           />
           <!-- Left Hamstring / Glute -->
           <path
@@ -158,13 +170,15 @@
             :style="regionStyle('Legs')"
             class="muscleRegion"
             role="img"
-            :aria-label="`Legs: ${getSetCount('Legs')} sets`"
+            :aria-label="`Left hamstring: ${getSetCount('Legs')} sets`"
           />
           <!-- Right Hamstring / Glute -->
           <path
             d="M132,200 Q134,204 136,216 L142,290 Q140,296 134,296 L118,296 Q114,290 114,280 L112,240 Q110,220 110,210 Z"
             :style="regionStyle('Legs')"
             class="muscleRegion"
+            role="img"
+            :aria-label="`Right hamstring: ${getSetCount('Legs')} sets`"
           />
         </g>
       </svg>

--- a/src/components/__tests__/BodyHeatmap.test.ts
+++ b/src/components/__tests__/BodyHeatmap.test.ts
@@ -70,6 +70,33 @@ describe('BodyHeatmap', () => {
       const coreRegion = wrapper.find('[aria-label="Core: 4 sets"]')
       expect(coreRegion.exists()).toBe(true)
     })
+
+    it('all front regions have role="img" and aria-label', () => {
+      const wrapper = mountHeatmap()
+      const regions = wrapper.findAll('.muscleRegion')
+      for (const region of regions) {
+        expect(region.attributes('role')).toBe('img')
+        expect(region.attributes('aria-label')).toBeTruthy()
+      }
+    })
+
+    it('shows left/right shoulder aria labels', () => {
+      const wrapper = mountHeatmap()
+      expect(wrapper.find('[aria-label="Left shoulder: 6 sets"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Right shoulder: 6 sets"]').exists()).toBe(true)
+    })
+
+    it('shows left/right bicep aria labels', () => {
+      const wrapper = mountHeatmap()
+      expect(wrapper.find('[aria-label="Left bicep: 3 sets"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Right bicep: 3 sets"]').exists()).toBe(true)
+    })
+
+    it('shows left/right quad aria labels', () => {
+      const wrapper = mountHeatmap()
+      expect(wrapper.find('[aria-label="Left quad: 10 sets"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Right quad: 10 sets"]').exists()).toBe(true)
+    })
   })
 
   describe('back view muscle regions', () => {
@@ -88,11 +115,41 @@ describe('BodyHeatmap', () => {
       expect(backRegion.exists()).toBe(true)
     })
 
-    it('shows triceps aria label with correct set count', async () => {
+    it('shows lower back aria label', async () => {
       const wrapper = mountHeatmap()
       await wrapper.findAll('[role="tab"]')[1].trigger('click')
-      const tricepRegion = wrapper.find('[aria-label="Triceps: 5 sets"]')
-      expect(tricepRegion.exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Lower back: 8 sets"]').exists()).toBe(true)
+    })
+
+    it('shows left/right tricep aria labels', async () => {
+      const wrapper = mountHeatmap()
+      await wrapper.findAll('[role="tab"]')[1].trigger('click')
+      expect(wrapper.find('[aria-label="Left tricep: 5 sets"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Right tricep: 5 sets"]').exists()).toBe(true)
+    })
+
+    it('shows left/right shoulder aria labels', async () => {
+      const wrapper = mountHeatmap()
+      await wrapper.findAll('[role="tab"]')[1].trigger('click')
+      expect(wrapper.find('[aria-label="Left shoulder: 6 sets"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Right shoulder: 6 sets"]').exists()).toBe(true)
+    })
+
+    it('shows left/right hamstring aria labels', async () => {
+      const wrapper = mountHeatmap()
+      await wrapper.findAll('[role="tab"]')[1].trigger('click')
+      expect(wrapper.find('[aria-label="Left hamstring: 10 sets"]').exists()).toBe(true)
+      expect(wrapper.find('[aria-label="Right hamstring: 10 sets"]').exists()).toBe(true)
+    })
+
+    it('all back regions have role="img" and aria-label', async () => {
+      const wrapper = mountHeatmap()
+      await wrapper.findAll('[role="tab"]')[1].trigger('click')
+      const regions = wrapper.findAll('.muscleRegion')
+      for (const region of regions) {
+        expect(region.attributes('role')).toBe('img')
+        expect(region.attributes('aria-label')).toBeTruthy()
+      }
     })
   })
 
@@ -107,7 +164,7 @@ describe('BodyHeatmap', () => {
     it('applies scaled opacity for partial-volume group', () => {
       const wrapper = mountHeatmap()
       // Core has 4 sets, maxSets 12 → ratio = 4/12 ≈ 0.333, opacity ≈ 0.15 + 0.333 * 0.70 ≈ 0.383
-      const coreRegion = wrapper.find('[aria-label="Core: 4 sets"]')
+      const coreRegion = wrapper.find('[aria-label*="Core: 4 sets"]')
       const style = coreRegion.attributes('style') || ''
       const match = style.match(/fill-opacity:\s*([\d.]+)/)
       expect(match).toBeTruthy()


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-131](https://github.com/aschung212/Lift/issues/131)

Picked LIFT-131 (BodyHeatmap SVG muscle regions missing aria-labels on right side). The only open backlog issue — a clean a11y fix adding missing `role="img"` and `aria-label` attributes to all right-side SVG muscle regions.

## Changes
- Added `role="img"` and `aria-label` to 7 SVG muscle regions that were missing them: right shoulder (front+back), right bicep, right quad, lower back, right tricep, right hamstring
- Improved label specificity for all paired regions — now use "Left/Right" prefixes instead of generic group names (e.g., "Left bicep" / "Right bicep" instead of just "Biceps")
- Distinguished "Lower back" from "Back" (upper) label
- Added 8 new regression tests verifying all regions have aria attributes in both front and back views

## Commits
- [`dc69925`](https://github.com/aschung212/Lift/commit/dc69925) a11y(LIFT-131): add aria-labels to all BodyHeatmap SVG muscle regions

## Test Results
- Before: 0 passing
- After: 0 passing (0 delta)

---
_Automated by overnight pipeline — Fri Apr  3 23:33:03 PDT 2026_