### PR TITLE
style(LIFT-95): fix spacing scale violations in Vue component style bl

### DIFF
--- a/src/components/AuthScreen.vue
+++ b/src/components/AuthScreen.vue
@@ -162,7 +162,7 @@ async function handleOAuth(provider: Provider) {
 
 .authInput {
   width: 100%;
-  padding: 12px 14px;
+  padding: 12px 16px;
   min-height: 44px;
   font-size: var(--font-callout);
   font-family: inherit;
@@ -231,7 +231,7 @@ async function handleOAuth(provider: Provider) {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin: 20px 0;
+  margin: 24px 0;
 }
 
 .authDividerLine {
@@ -258,7 +258,7 @@ async function handleOAuth(provider: Provider) {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
   padding: 12px 16px;
   min-height: 44px;

--- a/src/components/BodyHeatmap.vue
+++ b/src/components/BodyHeatmap.vue
@@ -232,7 +232,7 @@ function regionStyle(group: MuscleGroup): Record<string, string> {
   background: transparent;
   border: none;
   border-radius: 6px;
-  padding: 6px 16px;
+  padding: 8px 16px;
   min-height: 32px;
   min-width: 64px;
   cursor: pointer;
@@ -275,7 +275,7 @@ function regionStyle(group: MuscleGroup): Record<string, string> {
 .heatmapLegend {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .legendLabel {

--- a/src/components/MuscleGroupChart.vue
+++ b/src/components/MuscleGroupChart.vue
@@ -116,7 +116,7 @@ const showHeatmap = ref(false)
 .mgBars {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .mgRow {

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -391,7 +391,7 @@ function chooseExplore() {
   align-items: center;
   justify-content: center;
   min-height: 80svh;
-  padding: 20px;
+  padding: 24px;
 }
 
 .obCard {
@@ -424,7 +424,7 @@ function chooseExplore() {
 .obOption {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
   width: 100%;
   padding: 16px;
   min-height: 44px;

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync } from 'fs'
 import { resolve } from 'path'
 
 const css = readFileSync(resolve(__dirname, '../../index.css'), 'utf-8')
@@ -197,6 +197,37 @@ describe('CSS regression tests', () => {
       if (violations.length > 0) {
         const report = violations.map(v => `  L${v.line}: ${v.text} (off-scale: ${v.values.join(', ')}px)`).join('\n')
         expect.fail(`Found ${violations.length} spacing scale violation(s):\n${report}`)
+      }
+    })
+
+    it('has no off-scale spacing values in Vue component style blocks', () => {
+      const componentsDir = resolve(__dirname, '../../components')
+      const vueFiles = readdirSync(componentsDir).filter((f: string) => f.endsWith('.vue'))
+      const allViolations: { file: string; line: number; text: string; values: number[] }[] = []
+
+      for (const file of vueFiles) {
+        const content = readFileSync(resolve(componentsDir, file), 'utf-8')
+        const styleMatch = content.match(/<style[^>]*>([\s\S]*?)<\/style>/)
+        if (!styleMatch) continue
+        const styleBlock = styleMatch[1]
+        const styleStartLine = content.slice(0, content.indexOf(styleMatch[0])).split('\n').length
+        styleBlock.split('\n').forEach((text, i) => {
+          if (!spacingProps.test(text)) return
+          if (text.includes('calc(') || text.includes('env(')) return
+          const offScale: number[] = []
+          let match
+          pxVal.lastIndex = 0
+          while ((match = pxVal.exec(text)) !== null) {
+            const abs = Math.abs(parseInt(match[0], 10))
+            if (abs > 2 && !isOnScale(abs)) offScale.push(abs)
+          }
+          if (offScale.length > 0) allViolations.push({ file, line: styleStartLine + i, text: text.trim(), values: offScale })
+        })
+      }
+
+      if (allViolations.length > 0) {
+        const report = allViolations.map(v => `  ${v.file}:${v.line}: ${v.text} (off-scale: ${v.values.join(', ')}px)`).join('\n')
+        expect.fail(`Found ${allViolations.length} spacing scale violation(s) in Vue components:\n${report}`)
       }
     })
   })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-95](https://github.com/aschung212/Lift/issues/95)

Picked LIFT-95 (Spacing scale violations in Vue component style blocks). This is a CLAUDE.md checklist violation — the app enforces a 4/8/12/16/24/32 spacing scale but four components had off-scale values. Clean, focused fix with a regression test to prevent recurrence.

## Changes
- Fixed 8 off-scale spacing values across 4 Vue components:
  - **AuthScreen.vue**: `14px→16px` padding, `10px→8px` gap, `20px→24px` margin
  - **BodyHeatmap.vue**: `6px→8px` padding, `6px→8px` gap
  - **MuscleGroupChart.vue**: `6px→8px` gap
  - **OnboardingScreen.vue**: `20px→24px` padding, `14px→12px` gap
- Added regression test that scans all Vue component `<style>` blocks for off-scale spacing values, extending the existing `index.css` enforcement

## Commits
- [`40a9ea1`](https://github.com/aschung212/Lift/commit/40a9ea1) style(LIFT-95): fix spacing scale violations in Vue component style blocks

## Test Results
- Before: 0 passing
- After: 836 passing (836 delta)

---
_Automated by overnight pipeline — Fri Apr  3 23:44:00 PDT 2026_