### PR TITLE
fix: enforce theme lock and require real starter choice

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -923,6 +923,7 @@ function confirmStarterPick() {
   progressionStore.setStarterTheme(starterPickerSelection.value)
   currentTheme.value = starterPickerSelection.value
   runMigrationIfNeeded()
+  enforceThemeLock()
 }
 
 function skipStarterPick() {
@@ -934,6 +935,14 @@ function skipStarterPick() {
   }
   progressionStore._persist()
   runMigrationIfNeeded()
+}
+
+/** If current theme is locked, switch to starter or pearl. */
+function enforceThemeLock() {
+  if (!isThemeUnlocked(currentTheme.value as ThemeId)) {
+    const fallback = progressionStore.starterTheme || 'pearl'
+    currentTheme.value = fallback
+  }
 }
 
 function runMigrationIfNeeded() {
@@ -962,17 +971,21 @@ function toggleProgression() {
     progressionStore.progressionEnabled = false
     progressionStore._persist()
   } else {
-    if (progressionStore.starterTheme) {
-      // Re-enable with existing starter
+    const realStarters: ThemeId[] = ['fire', 'water', 'luck']
+    const hasRealStarter = progressionStore.starterTheme && realStarters.includes(progressionStore.starterTheme)
+    if (hasRealStarter) {
+      // Re-enable with existing real starter
       progressionStore.progressionEnabled = true
-      const starter = progressionStore.starterTheme
+      const starter = progressionStore.starterTheme!
       if (!progressionStore.unlockedThemes.some(t => t.id === starter)) {
         progressionStore.unlockedThemes.push({ id: starter, unlockedAt: new Date().toISOString() })
       }
       progressionStore._persist()
+      enforceThemeLock()
       runMigrationIfNeeded()
     } else {
-      // No starter chosen — show the picker
+      // No real starter chosen — clear pearl default, show explainer + picker
+      progressionStore.starterTheme = null
       starterPickerSelection.value = null
       starterPickerStep.value = 'explainer'
       starterPickerVisible.value = true
@@ -1227,6 +1240,7 @@ onMounted(() => {
   logEvent('session_start')
 
   runMigrationIfNeeded()
+  enforceThemeLock()
 })
 onUnmounted(() => {
   window.removeEventListener('beforeunload', onBeforeUnload)


### PR DESCRIPTION
## Summary

Two production bugs from existing user migration:

1. **Starter picker skipped** — `starterTheme='pearl'` (old default) was treated as a real choice. Now only Fire/Water/Luck count. Pearl default is cleared and picker is shown.

2. **Locked themes selectable** — users with Eternal/etc set before progression launched kept using them. `enforceThemeLock()` reverts to starter or Pearl if current theme is locked. Runs on startup, after migration, and after toggling progression on.

## Test plan
- [x] Existing user toggles Progression ON → explainer → starter picker (not skipped)
- [x] User with Eternal theme → app loads → reverts to Pearl
- [x] 1,001 tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)