### PR TITLE
feat: theme renames, Pearl-only free tier, starter trial period

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -510,7 +510,7 @@
           <!-- Step 2: Starter pick -->
           <template v-else>
             <div class="unlockTitle" style="color: var(--text-primary)">Pick Your Starter</div>
-            <div class="resetConfirmText">This theme unlocks immediately. Earn XP to unlock the rest.</div>
+            <div class="resetConfirmText">Try all three freely until you log your first set. Then your choice locks in.</div>
             <div class="obStarterGridInline">
               <button
                 v-for="s in STARTER_THEMES"
@@ -893,8 +893,8 @@ const starterPickerStep = ref<'explainer' | 'pick'>('explainer')
 const starterPickerSelection = ref<ThemeId | null>(null)
 
 const STARTER_THEMES: { id: ThemeId; label: string }[] = [
-  { id: 'fire', label: 'Fire' },
-  { id: 'water', label: 'Water' },
+  { id: 'fire', label: 'Intensity' },
+  { id: 'water', label: 'Flow' },
   { id: 'luck', label: 'Luck' },
 ]
 

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -53,7 +53,7 @@
       <!-- Step 3: Starter pick -->
       <template v-else-if="step === 'starter'">
         <div class="obLogo">Lift</div>
-        <p class="obTagline">This theme unlocks immediately. Earn XP to unlock the rest.</p>
+        <p class="obTagline">Try all three freely until you log your first set. Then your choice locks in.</p>
 
         <div class="obStarterGrid">
           <button
@@ -98,8 +98,8 @@ const selectedStarter = ref<ThemeId | null>(null)
 let pendingSampleData = false
 
 const STARTER_THEMES = [
-  { id: 'fire' as ThemeId, label: 'Fire', accent: THEME_PREVIEWS.fire.dark.accent, bg: THEME_PREVIEWS.fire.dark.bg },
-  { id: 'water' as ThemeId, label: 'Water', accent: THEME_PREVIEWS.water.dark.accent, bg: THEME_PREVIEWS.water.dark.bg },
+  { id: 'fire' as ThemeId, label: 'Intensity', accent: THEME_PREVIEWS.fire.dark.accent, bg: THEME_PREVIEWS.fire.dark.bg },
+  { id: 'water' as ThemeId, label: 'Flow', accent: THEME_PREVIEWS.water.dark.accent, bg: THEME_PREVIEWS.water.dark.bg },
   { id: 'luck' as ThemeId, label: 'Luck', accent: THEME_PREVIEWS.luck.dark.accent, bg: THEME_PREVIEWS.luck.dark.bg },
 ]
 

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -231,8 +231,8 @@ describe('OnboardingScreen', () => {
     it('shows three starter theme options after explainer', async () => {
       await goToStarterPicker()
       expect(wrapper.findAll('.obStarterCard')).toHaveLength(3)
-      expect(wrapper.text()).toContain('Fire')
-      expect(wrapper.text()).toContain('Water')
+      expect(wrapper.text()).toContain('Intensity')
+      expect(wrapper.text()).toContain('Flow')
       expect(wrapper.text()).toContain('Luck')
     })
 

--- a/src/composables/__tests__/useTheme.test.ts
+++ b/src/composables/__tests__/useTheme.test.ts
@@ -146,22 +146,23 @@ describe('useTheme', () => {
       connectProgressionStore(() => useProgressionStore())
     })
 
-    it('only free themes unlocked when progression is not enabled', () => {
+    it('only Pearl unlocked when progression is not enabled', () => {
       expect(theme.isThemeUnlocked('pearl')).toBe(true)
-      expect(theme.isThemeUnlocked('fire')).toBe(true)
-      expect(theme.isThemeUnlocked('water')).toBe(true)
-      expect(theme.isThemeUnlocked('luck')).toBe(true)
+      expect(theme.isThemeUnlocked('fire')).toBe(false)
       expect(theme.isThemeUnlocked('eternal')).toBe(false)
-      expect(theme.isThemeUnlocked('amethyst')).toBe(false)
     })
 
-    it('choosing a starter activates progression (locks other themes)', () => {
+    it('choosing a starter activates progression with trial period', () => {
       const store = useProgressionStore()
       store.setStarterTheme('fire')
       expect(store.progressionEnabled).toBe(true)
       expect(theme.isThemeUnlocked('pearl')).toBe(true)
+      // Trial period: all starters unlocked
       expect(theme.isThemeUnlocked('fire')).toBe(true)
-      expect(theme.isThemeUnlocked('water')).toBe(false)
+      expect(theme.isThemeUnlocked('water')).toBe(true)
+      expect(theme.isThemeUnlocked('luck')).toBe(true)
+      // Non-starters still locked
+      expect(theme.isThemeUnlocked('eternal')).toBe(false)
     })
 
     it('pearl is always unlocked when progression is enabled', () => {
@@ -171,12 +172,14 @@ describe('useTheme', () => {
       expect(theme.isThemeUnlocked('pearl')).toBe(true)
     })
 
-    it('locked theme returns false when progression is enabled', () => {
+    it('locked theme returns false when starter is confirmed', () => {
       const store = useProgressionStore()
       store.progressionEnabled = true
+      store.starterConfirmed = true
       store.unlockedThemes = [{ id: 'pearl', unlockedAt: '2026-01-01' }, { id: 'fire', unlockedAt: '2026-01-01' }]
       expect(theme.isThemeUnlocked('fire')).toBe(true)
-      expect(theme.isThemeUnlocked('water')).toBe(false)
+      expect(theme.isThemeUnlocked('water')).toBe(false) // no longer in trial
+      expect(theme.isThemeUnlocked('eternal')).toBe(false)
     })
 
     it('selectTheme persists an unlocked theme', () => {

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -18,16 +18,16 @@ interface ThemePreviewColors {
 }
 
 export const THEMES: ThemeOption[] = [
-  { id: 'eternal',  label: 'Eternal',  icon: 'eternal' },
-  { id: 'pearl',    label: 'Pearl',    icon: 'pearl' },
-  { id: 'midnight', label: 'Midnight', icon: 'midnight' },
-  { id: 'fire',     label: 'Fire',     icon: 'fire' },
-  { id: 'water',    label: 'Water',    icon: 'water' },
-  { id: 'earth',    label: 'Earth',    icon: 'earth' },
-  { id: 'luck',     label: 'Luck',     icon: 'luck' },
-  { id: 'amethyst', label: 'Amethyst', icon: 'amethyst' },
-  { id: 'air',      label: 'Air',      icon: 'air' },
-  { id: 'love',     label: 'Love',     icon: 'love' },
+  { id: 'eternal',  label: 'Eternal',    icon: 'eternal' },
+  { id: 'pearl',    label: 'Origin',     icon: 'pearl' },
+  { id: 'midnight', label: 'Fortitude',  icon: 'midnight' },
+  { id: 'fire',     label: 'Intensity',  icon: 'fire' },
+  { id: 'water',    label: 'Flow',       icon: 'water' },
+  { id: 'earth',    label: 'Stability',  icon: 'earth' },
+  { id: 'luck',     label: 'Luck',       icon: 'luck' },
+  { id: 'amethyst', label: 'Focus',      icon: 'amethyst' },
+  { id: 'air',      label: 'Spirit',     icon: 'air' },
+  { id: 'love',     label: 'Love',       icon: 'love' },
 ]
 
 export const THEME_PREVIEWS: Record<ThemeId, { dark: ThemePreviewColors; light: ThemePreviewColors }> = {
@@ -158,20 +158,24 @@ watch(weightUnit, (v) => localStorage.setItem('weight-unit', v))
  * Progression store accessor — set lazily after Pinia is initialized.
  * Uses a getter function so it always reads current Pinia state.
  */
-let _getProgressionStore: (() => { progressionEnabled: boolean; unlockedThemes: { id: ThemeId }[] }) | null = null
+let _getProgressionStore: (() => { progressionEnabled: boolean; starterConfirmed: boolean; unlockedThemes: { id: ThemeId }[] }) | null = null
 
 /** Connect the progression store. Call once after Pinia is ready. */
-export function connectProgressionStore(getter: () => { progressionEnabled: boolean; unlockedThemes: { id: ThemeId }[] }): void {
+export function connectProgressionStore(getter: () => { progressionEnabled: boolean; starterConfirmed: boolean; unlockedThemes: { id: ThemeId }[] }): void {
   _getProgressionStore = getter
 }
 
 /** Themes available without progression enabled */
-const FREE_THEMES: ThemeId[] = ['pearl', 'fire', 'water', 'luck']
+const FREE_THEMES: ThemeId[] = ['pearl']
+
+/** Starter themes available during trial period */
+const STARTER_THEME_IDS: ThemeId[] = ['fire', 'water', 'luck']
 
 /**
  * Check if a theme is unlocked.
- * Without progression: only Pearl + starter trio (Fire/Water/Luck) are available.
- * With progression: based on XP unlocks.
+ * Without progression: Pearl only.
+ * With progression (trial): Pearl + all starters.
+ * With progression (confirmed): based on XP unlocks.
  */
 function isThemeUnlocked(id: ThemeId): boolean {
   if (!_getProgressionStore) return FREE_THEMES.includes(id)
@@ -179,6 +183,9 @@ function isThemeUnlocked(id: ThemeId): boolean {
   const store = _getProgressionStore()
 
   if (!store.progressionEnabled) return FREE_THEMES.includes(id)
+
+  // Trial period: all starters unlocked until confirmed
+  if (!store.starterConfirmed && STARTER_THEME_IDS.includes(id)) return true
 
   return store.unlockedThemes.some(t => t.id === id)
 }

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -79,6 +79,7 @@ export interface ProgressionState {
   epoch: number                        // progression epoch (increments on reset, enables prestige)
   unlockedThemes: ThemeUnlock[]        // themes with unlock timestamps
   starterTheme: ThemeId | null
+  starterConfirmed: boolean            // false = trial period, all starters unlocked
   streakHistory: StreakWeekEntry[]     // append-only
   xpPerSet: Record<string, SetXPEntry | number>  // setId → XP data (number = legacy format)
   bodyweightXPDates: string[]         // dates that earned bodyweight XP
@@ -98,8 +99,8 @@ export const UNLOCK_TIERS: UnlockTier[] = [
   { level: 2, xpRequired: 15_000, themeId: 'air' },
   { level: 3, xpRequired: 40_000, themeId: 'amethyst' },
   { level: 4, xpRequired: 80_000, themeId: 'midnight' },
-  { level: 5, xpRequired: 150_000, themeId: 'love' },
-  { level: 6, xpRequired: 300_000, themeId: 'earth' },
+  { level: 5, xpRequired: 150_000, themeId: 'earth' },
+  { level: 6, xpRequired: 300_000, themeId: 'love' },
   { level: 7, xpRequired: 500_000, themeId: null },    // remaining starter themes fill these
   { level: 8, xpRequired: 1_000_000, themeId: 'eternal' },
 ]
@@ -117,6 +118,7 @@ function defaultState(): ProgressionState {
     epoch: 1,
     unlockedThemes: [{ id: 'pearl', unlockedAt: new Date().toISOString() }],
     starterTheme: null,
+    starterConfirmed: false,
     streakHistory: [],
     xpPerSet: {},
     bodyweightXPDates: [],
@@ -243,6 +245,10 @@ export const useProgressionStore = defineStore('progression', {
         ? { xp, theme: meta.theme, epoch: meta.epoch, zone: meta.zone, isPR: meta.isPR, isRepPR: meta.isRepPR }
         : xp
       this.totalXP += xp
+      // Confirm starter on first set logged
+      if (!this.starterConfirmed && this.starterTheme) {
+        this.starterConfirmed = true
+      }
       this._persist()
       this._syncToSupabase()
     },


### PR DESCRIPTION
## Summary

### Theme renames (personality traits, not objects)
| Old | New | ID (unchanged) |
|---|---|---|
| Pearl | Origin | pearl |
| Fire | Intensity | fire |
| Water | Flow | water |
| Air | Spirit | air |
| Amethyst | Focus | amethyst |
| Midnight | Fortitude | midnight |
| Earth | Stability | earth |
| Love, Luck, Eternal | unchanged | — |

### Pearl-only free tier
Non-progression users now only have Origin (Pearl). Previously Fire/Water/Luck were free, which undermined the incentive to enable progression.

### Starter trial period
- Pick a starter → all three (Intensity/Flow/Luck) are unlocked for trial
- Log your first set → choice locks in, unchosen starters become earnable
- Zero-pressure decision: try all three before committing

### Unlock order swap
Stability (earth) moved to L5 (150k), Love to L6 (300k). Desirability escalates toward Eternal.

## Test plan
- [x] Non-progression: only Origin available
- [x] Starter trial: all three starters accessible before first set
- [x] First set confirms starter, locks others
- [x] Theme labels display new names throughout
- [x] 1,001 tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)