### PR TITLE
chore: optimize Vercel config — caching, headers, deploy notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,22 @@ jobs:
 
       - run: npx vitest run --coverage
 
+  # Notify Slack on post-merge success (push to master only)
+  notify-deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - name: Notify Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
+          COMMIT_URL="${{ github.event.head_commit.url }}"
+          MSG="✅ *Deployed to production*\nCommit: <${COMMIT_URL}|${COMMIT_MSG}>"
+          payload=$(printf '{"text": %s}' "$(echo "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+          curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-Type: application/json' -d "$payload"
+
   # Notify Slack on post-merge failure (push to master only)
   notify-failure:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ android/
 
 # Claude Code worktree metadata (not part of the public repo)
 .claude/
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,50 @@
 {
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "trailingSlash": false,
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- src/ public/ index.html vite.config.js package.json",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "headers": [
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(.*).html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" },
+        { "key": "Service-Worker-Allowed", "value": "/" }
+      ]
+    },
+    {
+      "source": "/workbox-(.*).js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache" }
+      ]
+    },
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
+  ],
+  "redirects": [
+    {
+      "source": "/(.*).map",
+      "destination": "/",
+      "statusCode": 404
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Immutable caching for Vite hashed assets (1yr), no-cache for SW/HTML
- Security headers: X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy
- `ignoreCommand` to skip builds when only non-app files change (saves Hobby build minutes)
- Block `.map` files from being served publicly (belt-and-suspenders with Sentry deletion)
- Slack notification on successful production deploy (complements existing failure notification)
- `.vercel` added to gitignore from project linking

## Test plan
- [ ] Verify preview deploy succeeds on this PR
- [ ] Merge and confirm Slack deploy notification fires in #lift-automation
- [ ] Spot-check response headers on production (`curl -I`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)