### PR TITLE
feat: progression UX — enable prompt, scroll-to toggle, disable disclosure

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -119,6 +119,10 @@
               <div v-else-if="previewingThemeId && !isThemeUnlocked(previewingThemeId) && !progressionActive" class="badgePreviewOverlay">
                 Enable Progression to unlock
               </div>
+              <!-- Prompt to enable progression when off and locked themes visible -->
+              <button v-if="!progressionActive && !previewingThemeId" class="badgeEnablePrompt" @click="scrollToProgressionToggle">
+                Enable Progression to start unlocking themes
+              </button>
               <!-- Progress bar toward next unlock (verbose mode only, active progression, not when all unlocked) -->
               <div v-if="progressionActive && progressionStore.showProgression && progressionStore.nextUnlockThreshold !== null" class="badgeProgressBar">
                 <div class="badgeProgressFill" :style="{ width: progressionStore.progressPercent + '%' }"></div>
@@ -194,7 +198,7 @@
                   <span class="glassToggleThumb"></span>
                 </button>
               </div>
-              <div class="settingsRow">
+              <div ref="progressionToggleEl" class="settingsRow">
                 <span class="settingsLabel">Progression</span>
                 <button
                   :class="['glassToggle', { on: progressionActive }]"
@@ -538,6 +542,25 @@
             <button class="unlockDismiss" :disabled="!starterPickerSelection" @click="confirmStarterPick">{{ starterPickerSelection ? 'Choose ' + STARTER_THEMES.find(s => s.id === starterPickerSelection)?.label : 'Choose' }}</button>
             <button class="resetConfirmCancel" @click="skipStarterPick">Skip</button>
           </template>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+
+  <!-- Disable progression disclosure -->
+  <Teleport to="body">
+    <transition name="unlockFade">
+      <div v-if="disableProgressionVisible" class="unlockOverlay" @click.self="disableProgressionVisible = false">
+        <div class="unlockModal">
+          <div class="unlockTitle" style="color: var(--text-primary)">Disable Progression?</div>
+          <div class="progressionDisclosure">
+            <div class="disclosureRow disclosureOk">Your workouts and exercises will still be tracked normally.</div>
+            <div class="disclosureRow disclosureWarn">You will not earn XP for sets logged while progression is off.</div>
+            <div class="disclosureRow disclosureOk">Your existing XP and unlocked themes are preserved.</div>
+            <div class="disclosureRow disclosureHint">To hide XP info without losing progress, use "Show XP &amp; streaks" instead.</div>
+          </div>
+          <button class="unlockDismiss resetConfirmDanger" @click="confirmDisableProgression">Disable Progression</button>
+          <button class="resetConfirmCancel" @click="disableProgressionVisible = false">Cancel</button>
         </div>
       </div>
     </transition>
@@ -970,6 +993,16 @@ const STARTER_THEMES: { id: ThemeId; label: string }[] = [
 ]
 
 const STARTER_IDS: ThemeId[] = ['fire', 'water', 'luck']
+const progressionToggleEl = ref<HTMLElement | null>(null)
+
+function scrollToProgressionToggle() {
+  const el = progressionToggleEl.value
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  el.classList.add('settingsRowHighlight')
+  setTimeout(() => el.classList.remove('settingsRowHighlight'), 2000)
+}
+
 function isStarterTheme(id: ThemeId): boolean {
   return STARTER_IDS.includes(id)
 }
@@ -1062,12 +1095,20 @@ function runMigrationIfNeeded() {
   }
 }
 
+const disableProgressionVisible = ref(false)
+
+function confirmDisableProgression() {
+  disableProgressionVisible.value = false
+  progressionStore.progressionEnabled = false
+  progressionStore._persist()
+  currentTheme.value = 'pearl'
+}
+
 function toggleProgression() {
   if (progressionActive.value) {
-    progressionStore.progressionEnabled = false
-    progressionStore._persist()
-    // Force switch to Origin — only free theme without progression
-    currentTheme.value = 'pearl'
+    // Show disclosure before disabling
+    disableProgressionVisible.value = true
+    return
   } else {
     const realStarters: ThemeId[] = ['fire', 'water', 'luck']
     const hasRealStarter = progressionStore.starterTheme && realStarters.includes(progressionStore.starterTheme)

--- a/src/index.css
+++ b/src/index.css
@@ -1113,6 +1113,72 @@ html.modal-open .tabContent {
   padding: 32px 0;
 }
 
+/* ─── Badge case enable prompt ───────────────────────────────────── */
+
+.badgeEnablePrompt {
+  display: block;
+  width: 100%;
+  text-align: center;
+  font-size: var(--font-caption1);
+  font-weight: 500;
+  color: var(--accent);
+  background: none;
+  border: 1px dashed var(--accent);
+  border-radius: 8px;
+  padding: 8px 16px;
+  margin: 4px 16px 12px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+}
+
+.badgeEnablePrompt:active {
+  background: var(--accent-subtle);
+}
+
+/* ─── Settings row highlight (scroll-to animation) ───────────────── */
+
+.settingsRowHighlight {
+  animation: rowPulse 2s ease;
+}
+
+@keyframes rowPulse {
+  0%, 100% { background: transparent; }
+  20%, 60% { background: var(--accent-subtle); }
+}
+
+/* ─── Progression disable disclosure ─────────────────────────────── */
+
+.progressionDisclosure {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+  text-align: left;
+}
+
+.disclosureRow {
+  font-size: var(--font-footnote);
+  line-height: 1.4;
+  padding-left: 8px;
+}
+
+.disclosureOk {
+  color: var(--text-secondary);
+  border-left: 3px solid var(--success);
+}
+
+.disclosureWarn {
+  color: var(--text-secondary);
+  border-left: 3px solid var(--danger);
+}
+
+.disclosureHint {
+  color: var(--text-muted);
+  border-left: 3px solid var(--accent);
+  font-style: italic;
+}
+
 /* ─── Theme preview fade transition ──────────────────────────────── */
 
 html.theme-fading,


### PR DESCRIPTION
## Summary

Three UX improvements to help users understand and interact with the progression system:

### 1. Badge case enable prompt
When progression is off, a dashed-border prompt appears below the locked themes: "Enable Progression to start unlocking themes." Tappable — scrolls to and highlights the Progression toggle.

### 2. Scroll-to with highlight
Tapping the prompt smoothly scrolls to the Progression toggle in the Features section and pulses it with an accent highlight for 2 seconds.

### 3. Disable disclosure
Toggling progression off shows a confirmation modal with color-coded consequences:
- ✅ Workouts and exercises still tracked normally
- 🔴 No XP earned for sets logged while off
- ✅ Existing XP and unlocked themes preserved
- 💡 Suggests "Show XP & streaks" toggle as a less drastic alternative

## Test plan
- [x] Prompt visible when progression off, hidden when on
- [x] Tapping prompt scrolls to toggle and highlights it
- [x] Disabling shows disclosure, cancel keeps progression on
- [x] Confirm disable → switches to Origin, progression off
- [x] 1,024 tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)