### PR TITLE
fix: redesign enable prompt as iOS-style footer text

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -120,9 +120,9 @@
                 Enable Progression to unlock
               </div>
               <!-- Prompt to enable progression when off and locked themes visible -->
-              <button v-if="!progressionActive && !previewingThemeId" class="badgeEnablePrompt" @click="scrollToProgressionToggle">
-                Enable Progression to start unlocking themes
-              </button>
+              <p v-if="!progressionActive && !previewingThemeId" class="badgeEnableHint" @click="scrollToProgressionToggle">
+                Unlock more themes by enabling <span class="badgeEnableLink">Progression</span> below.
+              </p>
               <!-- Progress bar toward next unlock (verbose mode only, active progression, not when all unlocked) -->
               <div v-if="progressionActive && progressionStore.showProgression && progressionStore.nextUnlockThreshold !== null" class="badgeProgressBar">
                 <div class="badgeProgressFill" :style="{ width: progressionStore.progressPercent + '%' }"></div>

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -104,12 +104,13 @@
                 :key="s.id"
                 :class="['calSetRow', { calSetRowPR: s.isPR }]"
               >
-                <span v-if="s.isPR" class="calSetPR">🏆</span>
-                <span>{{ displayWeight(s.weight) }} {{ weightUnit }}</span>
-                <span class="calPRDetailSep">×</span>
-                <span>{{ s.reps }} reps</span>
-                <span class="calPRDetailSep">·</span>
-                <span>~{{ displayWeight(Math.round(s.estimated1RM)) }} {{ weightUnit }} e1RM</span>
+                <span class="calSetMain">
+                  <span v-if="s.isPR" class="calSetPR">🏆</span>
+                  <span class="calSetWeight">{{ displayWeight(s.weight) }} {{ weightUnit }}</span>
+                  <span class="calSetSep">×</span>
+                  <span class="calSetReps">{{ s.reps }} reps</span>
+                </span>
+                <span class="calSetE1RM">~{{ displayWeight(Math.round(s.estimated1RM)) }} {{ weightUnit }} e1RM</span>
               </div>
             </div>
           </template>
@@ -145,12 +146,13 @@
                 :key="s.id"
                 :class="['calSetRow', { calSetRowPR: s.isPR }]"
               >
-                <span v-if="s.isPR" class="calSetPR">🏆</span>
-                <span>{{ displayWeight(s.weight) }} {{ weightUnit }}</span>
-                <span class="calPRDetailSep">×</span>
-                <span>{{ s.reps }} reps</span>
-                <span class="calPRDetailSep">·</span>
-                <span>~{{ displayWeight(Math.round(s.estimated1RM)) }} {{ weightUnit }} e1RM</span>
+                <span class="calSetMain">
+                  <span v-if="s.isPR" class="calSetPR">🏆</span>
+                  <span class="calSetWeight">{{ displayWeight(s.weight) }} {{ weightUnit }}</span>
+                  <span class="calSetSep">×</span>
+                  <span class="calSetReps">{{ s.reps }} reps</span>
+                </span>
+                <span class="calSetE1RM">~{{ displayWeight(Math.round(s.estimated1RM)) }} {{ weightUnit }} e1RM</span>
               </div>
             </div>
           </template>

--- a/src/index.css
+++ b/src/index.css
@@ -1115,25 +1115,18 @@ html.modal-open .tabContent {
 
 /* ─── Badge case enable prompt ───────────────────────────────────── */
 
-.badgeEnablePrompt {
-  display: block;
-  width: 100%;
+.badgeEnableHint {
   text-align: center;
-  font-size: var(--font-caption1);
-  font-weight: 500;
-  color: var(--accent);
-  background: none;
-  border: 1px dashed var(--accent);
-  border-radius: 8px;
-  padding: 8px 16px;
-  margin: 4px 16px 12px;
+  font-size: var(--font-caption2);
+  color: var(--text-muted);
+  padding: 4px 16px 12px;
   cursor: pointer;
-  font-family: inherit;
-  transition: background 0.15s;
+  line-height: 1.4;
 }
 
-.badgeEnablePrompt:active {
-  background: var(--accent-subtle);
+.badgeEnableLink {
+  color: var(--accent);
+  font-weight: 600;
 }
 
 /* ─── Settings row highlight (scroll-to animation) ───────────────── */


### PR DESCRIPTION
Replaced the dashed-border button with native iOS settings footer text:

> Unlock more themes by enabling **Progression** below.

Small, muted, centered caption text. "Progression" is accent-colored. Still tappable — scrolls to and highlights the toggle. No borders, no boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)