### PR TITLE
fix: restyle calendar set detail rows as iOS grouped table cells

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -92,12 +92,15 @@
             </span>
           </div>
 
-          <template v-for="ex in trainingMap[selectedDay]" :key="ex">
-            <button
-              :class="['calDetailTag', { calDetailTagPR: isPRExercise(selectedDay, ex) }]"
-              :aria-expanded="detailKey === `${selectedDay}::${ex}`"
-              @click="toggleDetail(selectedDay, ex)"
-            >{{ isPRExercise(selectedDay, ex) ? '🏆 ' : '' }}{{ ex }} <span class="calTagCount">{{ getSetCount(selectedDay, ex) }}</span></button>
+          <button
+            v-for="ex in trainingMap[selectedDay]"
+            :key="ex"
+            :class="['calDetailTag', { calDetailTagPR: isPRExercise(selectedDay, ex) }]"
+            :aria-expanded="detailKey === `${selectedDay}::${ex}`"
+            @click="toggleDetail(selectedDay, ex)"
+          >{{ isPRExercise(selectedDay, ex) ? '🏆 ' : '' }}{{ ex }} <span class="calTagCount">{{ getSetCount(selectedDay, ex) }}</span></button>
+
+          <template v-for="ex in trainingMap[selectedDay]" :key="`detail-${ex}`">
             <div v-if="detailKey === `${selectedDay}::${ex}`" class="calSetList">
               <div
                 v-for="s in getSetsForDay(selectedDay, ex)"
@@ -132,13 +135,15 @@
         </div>
         <div class="calWeekContent">
           <span v-if="day.exercises.length === 0" class="calWeekRest">Rest</span>
-          <template v-for="ex in day.exercises" :key="ex">
+          <button
+            v-for="ex in day.exercises"
+            :key="ex"
+            :class="['calWeekTag', { calWeekTagPR: isPRExercise(day.dateStr, ex) }]"
+            :aria-expanded="detailKey === `${day.dateStr}::${ex}`"
+            @click="toggleDetail(day.dateStr, ex)"
+          >{{ isPRExercise(day.dateStr, ex) ? '🏆 ' : '' }}{{ ex }} <span class="calTagCount">{{ getSetCount(day.dateStr, ex) }}</span></button>
 
-            <button
-              :class="['calWeekTag', { calWeekTagPR: isPRExercise(day.dateStr, ex) }]"
-              :aria-expanded="detailKey === `${day.dateStr}::${ex}`"
-              @click="toggleDetail(day.dateStr, ex)"
-            >{{ isPRExercise(day.dateStr, ex) ? '🏆 ' : '' }}{{ ex }} <span class="calTagCount">{{ getSetCount(day.dateStr, ex) }}</span></button>
+          <template v-for="ex in day.exercises" :key="`detail-${ex}`">
             <div v-if="detailKey === `${day.dateStr}::${ex}`" class="calSetList">
               <div
                 v-for="s in getSetsForDay(day.dateStr, ex)"

--- a/src/index.css
+++ b/src/index.css
@@ -4091,37 +4091,66 @@ html.theme-fading .settingsSheet {
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-top: 4px;
+  margin-top: 8px;
   margin-bottom: 4px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
 }
 
 .calSetRow {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: var(--font-caption1);
+  justify-content: space-between;
+  min-height: 44px;
+  padding: 12px 16px;
+  font-size: var(--font-body);
   color: var(--text);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 4px 12px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+}
+
+.calSetRow:last-child {
+  border-bottom: none;
 }
 
 .calSetRowPR {
   background: var(--pr-subtle);
-  border-color: var(--pr);
   color: var(--pr);
 }
 
-.calSetPR {
-  font-size: var(--font-caption2);
-  line-height: 1;
+.calSetMain {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.calPRDetailSep {
+.calSetWeight {
+  font-weight: 600;
+  font-size: var(--font-body);
+}
+
+.calSetSep {
   color: var(--text-muted);
-  font-size: var(--font-caption2);
+  font-size: var(--font-footnote);
+}
+
+.calSetReps {
+  color: var(--text-secondary);
+  font-size: var(--font-body);
+}
+
+.calSetE1RM {
+  font-size: var(--font-footnote);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.calSetPR {
+  font-size: var(--font-footnote);
+  line-height: 1;
 }
 
 .calWeekRest {


### PR DESCRIPTION
## Summary
- Restyled set detail rows from cramped 12px pills to iOS-native grouped table cells (44px min-height, 17px body font, inset dividers, two-column layout with weight×reps left and e1RM right)
- Fixed bug where expanding one exercise's details would push other exercise chips off-screen by separating the chip row from the detail panel
- Applied to both month and week calendar views

## Test plan
- [x] Verified on localhost:5173 — rows render with proper size and hierarchy
- [x] Expanding any exercise keeps all chips visible
- [x] PR rows still highlighted correctly
- [ ] Verify on iPhone over local network
- [ ] Check all 9 themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)