### PR TITLE
fix: preview overlay scrolls to Progression toggle

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1216,6 +1216,10 @@ html.theme-fading .settingsSheet {
   padding: 4px 16px 8px;
 }
 
+.badgePreviewTappable {
+  cursor: pointer;
+}
+
 /* ─── Badge progress bar ─────────────────────────────────────────── */
 
 .badgeProgressBar {


### PR DESCRIPTION
"Enable Progression to unlock" overlay (shown when previewing a locked theme) now taps to scroll to and highlight the Progression toggle — same behavior as the footer hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)