### PR TITLE
fix: keep unlocked themes accessible when progression is disabled

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -556,7 +556,7 @@
           <div class="progressionDisclosure">
             <div class="disclosureRow disclosureOk">Your workouts and exercises will still be tracked normally.</div>
             <div class="disclosureRow disclosureWarn">You will not earn XP for sets logged while progression is off.</div>
-            <div class="disclosureRow disclosureOk">Your existing XP and unlocked themes are preserved.</div>
+            <div class="disclosureRow disclosureOk">Your existing XP and unlocked themes are preserved — unlocked themes stay usable.</div>
             <div class="disclosureRow disclosureHint">To hide XP info without losing progress, use "Show XP &amp; streaks" instead.</div>
           </div>
           <button class="unlockDismiss resetConfirmDanger" @click="confirmDisableProgression">Disable Progression</button>
@@ -1101,7 +1101,7 @@ function confirmDisableProgression() {
   disableProgressionVisible.value = false
   progressionStore.progressionEnabled = false
   progressionStore._persist()
-  currentTheme.value = 'pearl'
+  enforceThemeLock()
 }
 
 function toggleProgression() {

--- a/src/composables/__tests__/useTheme.test.ts
+++ b/src/composables/__tests__/useTheme.test.ts
@@ -182,6 +182,16 @@ describe('useTheme', () => {
       expect(theme.isThemeUnlocked('eternal')).toBe(false)
     })
 
+    it('previously unlocked themes stay available when progression is disabled', () => {
+      const store = useProgressionStore()
+      store.progressionEnabled = false
+      store.unlockedThemes = [{ id: 'pearl', unlockedAt: '2026-01-01' }, { id: 'fire', unlockedAt: '2026-01-01' }]
+
+      expect(theme.isThemeUnlocked('pearl')).toBe(true)
+      expect(theme.isThemeUnlocked('fire')).toBe(true)
+      expect(theme.isThemeUnlocked('eternal')).toBe(false)
+    })
+
     it('selectTheme persists an unlocked theme', () => {
       const store = useProgressionStore()
       store.progressionEnabled = true

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -173,7 +173,7 @@ const STARTER_THEME_IDS: ThemeId[] = ['fire', 'water', 'luck']
 
 /**
  * Check if a theme is unlocked.
- * Without progression: Pearl only.
+ * Without progression: Pearl + any previously unlocked themes.
  * With progression (trial): Pearl + all starters.
  * With progression (confirmed): based on XP unlocks.
  */
@@ -182,7 +182,9 @@ function isThemeUnlocked(id: ThemeId): boolean {
 
   const store = _getProgressionStore()
 
-  if (!store.progressionEnabled) return FREE_THEMES.includes(id)
+  if (!store.progressionEnabled) {
+    return FREE_THEMES.includes(id) || store.unlockedThemes.some(t => t.id === id)
+  }
 
   // Trial period: all starters unlocked until confirmed
   if (!store.starterConfirmed && STARTER_THEME_IDS.includes(id)) return true


### PR DESCRIPTION
## Summary
- Unlocked themes now stay usable even after disabling progression — users earned them
- Disabling progression no longer forces a reset to Pearl; current theme is kept if it was unlocked
- Updated disclosure text to clarify unlocked themes stay usable

## Test plan
- [x] New test: previously unlocked themes return `true` from `isThemeUnlocked` with progression off
- [x] All 1025 tests pass
- [ ] Manual: enable progression → unlock a theme → disable progression → verify theme still selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)