### PR TITLE
fix: tappable preview overlay + spacing scale violation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,7 @@
               <div v-if="previewingThemeId && !isThemeUnlocked(previewingThemeId) && progressionActive" class="badgePreviewOverlay">
                 {{ xpToUnlockPreview.toLocaleString() }} XP to unlock
               </div>
-              <div v-else-if="previewingThemeId && !isThemeUnlocked(previewingThemeId) && !progressionActive" class="badgePreviewOverlay">
+              <div v-else-if="previewingThemeId && !isThemeUnlocked(previewingThemeId) && !progressionActive" class="badgePreviewOverlay" style="cursor:pointer" @click="scrollToProgressionToggle">
                 Enable Progression to unlock
               </div>
               <!-- Prompt to enable progression when off and locked themes visible -->

--- a/src/index.css
+++ b/src/index.css
@@ -4117,7 +4117,7 @@ html.theme-fading .settingsSheet {
 .calSetMain {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .calSetWeight {


### PR DESCRIPTION
- "Enable Progression to unlock" overlay scrolls to Progression toggle when tapped
- Fix `gap: 6px` → `8px` in `.calSetMain` (spacing scale violation from #149 blocking CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)