### PR TITLE
feat: Eternal theme hidden until unlocked — mystery state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -77,14 +77,14 @@
                 <button
                   v-for="t in sortedThemes"
                   :key="t.id"
-                  :class="['themePreview', { active: currentTheme === t.id, locked: !isThemeUnlocked(t.id) }]"
-                  @click="currentTheme === t.id ? openThemeStats(t.id) : isThemeUnlocked(t.id) ? selectTheme(t.id) : handleThemePreview(t.id)"
-                  :aria-label="isThemeUnlocked(t.id) ? 'Select ' + t.label + ' theme' : t.label + ' theme — locked'"
+                  :class="['themePreview', { active: currentTheme === t.id, locked: !isThemeUnlocked(t.id), mystery: isEternalLocked(t.id) }]"
+                  @click="currentTheme === t.id ? openThemeStats(t.id) : isThemeUnlocked(t.id) ? selectTheme(t.id) : isEternalLocked(t.id) ? null : handleThemePreview(t.id)"
+                  :aria-label="isEternalLocked(t.id) ? 'Mystery theme — 1,000,000 XP' : isThemeUnlocked(t.id) ? 'Select ' + t.label + ' theme' : t.label + ' theme — locked'"
                   :aria-pressed="currentTheme === t.id"
                 >
                   <span
-                    class="themePreviewDot"
-                    :style="{
+                    :class="['themePreviewDot', { mysteryDot: isEternalLocked(t.id) }]"
+                    :style="isEternalLocked(t.id) ? {} : {
                       background: 'linear-gradient(135deg, ' + THEME_PREVIEWS[t.id]?.[resolvedMode]?.accent + ', ' + THEME_PREVIEWS[t.id]?.[resolvedMode]?.bg + ')',
                     }"
                   >
@@ -92,6 +92,7 @@
                     <svg v-else-if="t.icon === 'water'" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M2 15c0 0 2-3 4-3s4 3 6 3 4-3 6-3 4 3 4 3M2 19c0 0 2-3 4-3s4 3 6 3 4-3 6-3 4 3 4 3M2 11c0 0 2-3 4-3s4 3 6 3 4-3 6-3 4 3 4 3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
                     <svg v-else-if="t.icon === 'luck'" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M12 3C12 3 9 6 9 8.5c0 1.4.7 2.6 1.8 3.2L12 12l1.2-.3C14.3 11.1 15 9.9 15 8.5 15 6 12 3 12 3z"/><path d="M21 12c0 0-3-3-5.5-3-1.4 0-2.6.7-3.2 1.8L12 12l.3 1.2c.6 1.1 1.8 1.8 3.2 1.8C18 15 21 12 21 12z"/><path d="M12 21c0 0 3-3 3-5.5 0-1.4-.7-2.6-1.8-3.2L12 12l-1.2.3C9.7 12.9 9 14.1 9 15.5 9 18 12 21 12 21z"/><path d="M3 12c0 0 3 3 5.5 3 1.4 0 2.6-.7 3.2-1.8L12 12l-.3-1.2C11.1 9.7 9.9 9 8.5 9 6 9 3 12 3 12z"/></svg>
                     <svg v-else-if="t.icon === 'air'" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+                    <span v-else-if="t.icon === 'eternal' && isEternalLocked(t.id)" class="mysteryIcon">?</span>
                     <svg v-else-if="t.icon === 'eternal'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="20" height="20"><path d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.739-8-4.585 0-4.585 8 0 8 5.606 0 7.644-8 12.74-8z"/></svg>
                     <svg v-else-if="t.icon === 'amethyst'" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M12 2L4 9l8 13 8-13-8-7zm0 3.5L7.5 9.5 12 17l4.5-7.5L12 5.5z"/></svg>
                     <svg v-else-if="t.icon === 'sun'" viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="21" x2="12" y2="23" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="1" y1="12" x2="3" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="21" y1="12" x2="23" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
@@ -104,7 +105,7 @@
                     <!-- Checkmark for active unlocked theme -->
                     <svg v-else-if="currentTheme === t.id" class="themePreviewCheck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                   </span>
-                  <span class="themePreviewLabel">{{ t.label }}</span>
+                  <span class="themePreviewLabel">{{ isEternalLocked(t.id) ? '???' : t.label }}</span>
                   <span v-if="progressionActive && !progressionStore.starterConfirmed && isStarterTheme(t.id) && isThemeUnlocked(t.id)" class="themeTrialBadge">Trial</span>
                 </button>
               </div>
@@ -1005,6 +1006,10 @@ function scrollToProgressionToggle() {
 
 function isStarterTheme(id: ThemeId): boolean {
   return STARTER_IDS.includes(id)
+}
+
+function isEternalLocked(id: ThemeId): boolean {
+  return id === 'eternal' && !isThemeUnlocked('eternal')
 }
 
 // ── Theme stats sheet ────────────────────────────────────────────

--- a/src/index.css
+++ b/src/index.css
@@ -1007,6 +1007,32 @@ html.modal-open .tabContent {
   opacity: 0.5;
 }
 
+/* ─── Mystery theme (Eternal when locked) ────────────────────────── */
+
+.mysteryDot {
+  background: var(--bg-tertiary) !important;
+  filter: none !important;
+  opacity: 1 !important;
+  animation: mysteryShimmer 3s ease-in-out infinite;
+}
+
+@keyframes mysteryShimmer {
+  0%, 100% { box-shadow: 0 0 0 0 transparent; }
+  50% { box-shadow: 0 0 12px 2px rgba(255, 255, 255, 0.08); }
+}
+
+.mysteryIcon {
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--text-muted);
+}
+
+.themePreview.mystery .themePreviewLabel {
+  color: var(--text-muted);
+  opacity: 0.6;
+  font-style: italic;
+}
+
 .themePreviewLock {
   position: absolute;
   bottom: -2px;


### PR DESCRIPTION
## Summary

Eternal (1,000,000 XP) is now fully hidden when locked:

- **Name**: shows "???" instead of "Eternal"
- **Icon**: "?" placeholder instead of infinity symbol
- **Gradient**: hidden — neutral background with subtle shimmer animation
- **Preview**: blocked — tapping does nothing (other locked themes still preview for 3s)

Applies to everyone — progression enabled or disabled. Nobody sees Eternal until they earn it.

The mystery creates more motivation than showing the theme ever could.

## Test plan
- [x] Locked Eternal shows "???" name, "?" icon, shimmer dot
- [x] Tapping locked Eternal does not trigger preview
- [x] Other locked themes still preview normally
- [x] Unlocked Eternal shows full name, icon, gradient (existing behavior)
- [x] Works with progression off (Eternal still shows as mystery)
- [x] 1,025 tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)