### PR TITLE
fix: persist standalone tags in store

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -650,9 +650,9 @@
     <div v-if="tagManagerOpen" class="repMaxOverlay" @click.self="tagManagerOpen = false" @keydown.escape="tagManagerOpen = false">
       <div class="repMaxModal" role="dialog" aria-modal="true" aria-labelledby="tag-manager-title">
         <h2 id="tag-manager-title">Manage Tags</h2>
-        <p v-if="tagManagerTags.length === 0 && !tagManagerAdding" class="wtEmpty" style="margin: var(--space-4) 0">No tags yet. Tap + to create one.</p>
+        <p v-if="store.allTags.length === 0 && !tagManagerAdding" class="wtEmpty" style="margin: var(--space-4) 0">No tags yet. Tap + to create one.</p>
         <ul class="wtTagManagerList">
-          <li v-for="tag in tagManagerTags" :key="tag" class="wtTagManagerItemWrap">
+          <li v-for="tag in store.allTags" :key="tag" class="wtTagManagerItemWrap">
             <div class="wtTagManagerItem">
               <template v-if="renamingTag === tag">
                 <input
@@ -2047,13 +2047,6 @@ const expandedTag = ref<string | null>(null)
 const tagManagerAdding = ref(false)
 const tagManagerNewName = ref('')
 const tagManagerInputEl = ref<HTMLInputElement | null>(null)
-const standaloneTags = ref<string[]>([])
-
-const tagManagerTags = computed(() => {
-  const all = new Set([...store.allTags, ...standaloneTags.value])
-  return [...all].sort()
-})
-
 function openTagManager() {
   tagManagerOpen.value = true
   renamingTag.value = null
@@ -2069,8 +2062,8 @@ function startTagManagerAdd() {
 
 function confirmTagManagerAdd() {
   const tag = tagManagerNewName.value.trim()
-  if (tag && !tagManagerTags.value.includes(tag)) {
-    standaloneTags.value.push(tag)
+  if (tag && !store.allTags.includes(tag)) {
+    store.addCustomTag(tag)
     expandedTag.value = tag
   }
   tagManagerNewName.value = ''

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -100,6 +100,7 @@ function load(): Exercise[] {
 export const useWorkoutStore = defineStore('workout', {
   state: () => ({
     exercises: load() as Exercise[],
+    customTags: JSON.parse(localStorage.getItem('lift-custom-tags') || '[]') as string[],
     _userId: null as string | null
   }),
 
@@ -107,6 +108,7 @@ export const useWorkoutStore = defineStore('workout', {
     _persist() {
       const data = JSON.stringify(this.exercises)
       localStorage.setItem(STORAGE_KEY, data)
+      localStorage.setItem('lift-custom-tags', JSON.stringify(this.customTags))
       backupToIDB(STORAGE_KEY, data)
     },
 
@@ -436,7 +438,6 @@ export const useWorkoutStore = defineStore('workout', {
       this.exercises.forEach((e: Exercise) => {
         const idx = e.tags.indexOf(oldName)
         if (idx !== -1) {
-          // Replace old tag; avoid duplicates if newName already exists on this exercise
           if (e.tags.includes(trimmed)) {
             e.tags.splice(idx, 1)
           } else {
@@ -444,6 +445,14 @@ export const useWorkoutStore = defineStore('workout', {
           }
         }
       })
+      const customIdx = this.customTags.indexOf(oldName)
+      if (customIdx !== -1) {
+        if (this.customTags.includes(trimmed)) {
+          this.customTags.splice(customIdx, 1)
+        } else {
+          this.customTags[customIdx] = trimmed
+        }
+      }
       this._persist()
 
       if (this._userId) {
@@ -462,6 +471,7 @@ export const useWorkoutStore = defineStore('workout', {
         const idx = e.tags.indexOf(tagName)
         if (idx !== -1) e.tags.splice(idx, 1)
       })
+      this.customTags = this.customTags.filter(t => t !== tagName)
       this._persist()
 
       if (this._userId) {
@@ -473,6 +483,18 @@ export const useWorkoutStore = defineStore('workout', {
           )
         })
       }
+    },
+
+    addCustomTag(name: string) {
+      const trimmed = name.trim()
+      if (!trimmed || this.customTags.includes(trimmed)) return
+      this.customTags.push(trimmed)
+      this._persist()
+    },
+
+    removeCustomTag(name: string) {
+      this.customTags = this.customTags.filter(t => t !== name)
+      this._persist()
     }
   },
 
@@ -480,6 +502,7 @@ export const useWorkoutStore = defineStore('workout', {
     allTags: (state): string[] => {
       const tagSet = new Set<string>()
       state.exercises.forEach((e: Exercise) => (e.tags || []).forEach((t: string) => tagSet.add(t)))
+      state.customTags.forEach((t: string) => tagSet.add(t))
       return [...tagSet].sort()
     },
 


### PR DESCRIPTION
## Summary
- Custom tags created in Manage Tags now persist to localStorage via the workout store
- Tags appear in filters, edit exercise pickers, and survive page reloads
- Rename and delete operations handle custom tags correctly

## Test plan
- [x] Create tag in Manage Tags → appears in tag filter bar
- [x] Create tag in Manage Tags → appears in edit exercise tag picker
- [x] Reload page → custom tag still visible
- [x] Rename custom tag → updated everywhere
- [x] Delete custom tag → removed everywhere
- [x] 1,053 tests passing, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)