### PR TITLE
feat(LIFT-191): add app version and user ID hash metadata to data expo

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+declare const __APP_VERSION__: string
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
     languageOptions: {
       globals: {
         ...globals.browser,
+        __APP_VERSION__: 'readonly',
       },
     },
     rules: {

--- a/src/App.vue
+++ b/src/App.vue
@@ -770,6 +770,7 @@ import { isMigrated, markMigrated, clearMigrationFlag, computeRetroactiveXP } fr
 import { requestPersistentStorage, ensureLocalStorage, clearIDB } from './lib/durableStorage'
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
+import { hashUserId, buildJsonExport, buildCsvExport } from './lib/dataExport'
 import { usePreferencesStore } from './stores/preferences'
 import type { WeightGoalDirection } from './stores/preferences'
 import { useWorkoutStore } from './stores/workout'
@@ -1442,65 +1443,30 @@ async function executeDeleteAccount() {
   }
 }
 
-function exportData(format: 'csv' | 'json') {
+async function exportData(format: 'csv' | 'json') {
   const workoutStore = useWorkoutStore()
   const bwStore = useBodyweightStore()
   const timestamp = new Date().toISOString().slice(0, 10)
+  const appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'unknown'
+  const userIdHash = user.value?.id ? await hashUserId(user.value.id) : 'anonymous'
+  const metadata = { exportDate: new Date().toISOString(), appVersion, userIdHash }
 
   if (format === 'json') {
-    const data = {
-      exportDate: new Date().toISOString(),
-      exercises: workoutStore.exercises.map(e => ({
-        name: e.name,
-        tags: e.tags,
-        sets: e.sets.map(s => ({
-          date: s.date,
-          weight: s.weight,
-          reps: s.reps,
-          estimated1RM: s.estimated1RM,
-        })),
-      })),
-      bodyweight: bwStore.sortedEntries.map(e => ({
-        date: e.date,
-        weight: e.weight,
-      })),
-      progression: {
-        totalXP: progressionStore.totalXP,
-        epoch: progressionStore.epoch,
-        streakWeeks: progressionStore.streakWeeks,
-        weeklyTarget: progressionStore.weeklyTarget,
-        starterTheme: progressionStore.starterTheme,
-        unlockedThemes: progressionStore.unlockedThemes,
-        xpPerSet: progressionStore.xpPerSet,
-      },
-    }
+    const data = buildJsonExport(metadata, workoutStore.exercises, bwStore.sortedEntries, {
+      totalXP: progressionStore.totalXP,
+      epoch: progressionStore.epoch,
+      streakWeeks: progressionStore.streakWeeks,
+      weeklyTarget: progressionStore.weeklyTarget,
+      starterTheme: progressionStore.starterTheme,
+      unlockedThemes: progressionStore.unlockedThemes,
+      xpPerSet: progressionStore.xpPerSet,
+    })
     downloadFile(`lift-export-${timestamp}.json`, JSON.stringify(data, null, 2), 'application/json')
   } else {
-    const lines = ['Exercise,Date,Weight,Reps,Estimated 1RM,Tags']
-    for (const ex of workoutStore.exercises) {
-      for (const s of ex.sets) {
-        const date = s.date.slice(0, 10)
-        const tags = ex.tags.join(';')
-        lines.push(`${csvEscape(ex.name)},${date},${s.weight},${s.reps},${s.estimated1RM},${csvEscape(tags)}`)
-      }
-    }
-    if (bwStore.sortedEntries.length > 0) {
-      lines.push('')
-      lines.push('Date,Body Weight')
-      for (const e of bwStore.sortedEntries) {
-        lines.push(`${e.date.slice(0, 10)},${e.weight}`)
-      }
-    }
-    downloadFile(`lift-export-${timestamp}.csv`, lines.join('\n'), 'text/csv')
+    const csv = buildCsvExport(metadata, workoutStore.exercises, bwStore.sortedEntries)
+    downloadFile(`lift-export-${timestamp}.csv`, csv, 'text/csv')
   }
   logEvent('data_export', { format })
-}
-
-function csvEscape(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
-    return `"${value.replace(/"/g, '""')}"`
-  }
-  return value
 }
 
 function downloadFile(filename: string, content: string, mimeType: string) {

--- a/src/lib/__tests__/dataExport.test.ts
+++ b/src/lib/__tests__/dataExport.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest'
+import { hashUserId, buildJsonExport, buildCsvExport, csvEscape } from '../dataExport'
+
+const metadata = {
+  exportDate: '2026-04-05T12:00:00.000Z',
+  appVersion: '1.0.0',
+  userIdHash: 'abc123',
+}
+
+const exercises = [
+  {
+    id: '1',
+    name: 'Bench Press',
+    tags: ['chest', 'push'],
+    sets: [
+      { id: 's1', date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+    ],
+  },
+]
+
+const bodyweight = [
+  { id: 'bw1', date: '2026-04-05T08:00:00.000Z', weight: 185 },
+]
+
+const progression = {
+  totalXP: 5000,
+  epoch: 1,
+  streakWeeks: 3,
+  weeklyTarget: 4,
+  starterTheme: 'fire' as const,
+  unlockedThemes: [],
+  xpPerSet: {},
+}
+
+describe('dataExport', () => {
+  describe('hashUserId', () => {
+    it('returns a 64-character hex string for a valid input', async () => {
+      const hash = await hashUserId('test-user-id')
+      expect(hash).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('returns deterministic output for the same input', async () => {
+      const a = await hashUserId('same-id')
+      const b = await hashUserId('same-id')
+      expect(a).toBe(b)
+    })
+
+    it('returns different hashes for different inputs', async () => {
+      const a = await hashUserId('user-1')
+      const b = await hashUserId('user-2')
+      expect(a).not.toBe(b)
+    })
+  })
+
+  describe('buildJsonExport', () => {
+    it('includes appVersion and userIdHash in output', () => {
+      const data = buildJsonExport(metadata, exercises, bodyweight, progression)
+      expect(data.appVersion).toBe('1.0.0')
+      expect(data.userIdHash).toBe('abc123')
+    })
+
+    it('includes exportDate in output', () => {
+      const data = buildJsonExport(metadata, exercises, bodyweight, progression)
+      expect(data.exportDate).toBe('2026-04-05T12:00:00.000Z')
+    })
+
+    it('serializes exercises with sets', () => {
+      const data = buildJsonExport(metadata, exercises, bodyweight, progression)
+      expect(data.exercises).toHaveLength(1)
+      expect(data.exercises[0].name).toBe('Bench Press')
+      expect(data.exercises[0].tags).toEqual(['chest', 'push'])
+      expect(data.exercises[0].sets).toHaveLength(1)
+      expect(data.exercises[0].sets[0].weight).toBe(225)
+    })
+
+    it('does not leak exercise or set IDs into export', () => {
+      const data = buildJsonExport(metadata, exercises, bodyweight, progression)
+      const json = JSON.stringify(data)
+      expect(json).not.toContain('"id"')
+    })
+
+    it('includes bodyweight entries', () => {
+      const data = buildJsonExport(metadata, exercises, bodyweight, progression)
+      expect(data.bodyweight).toHaveLength(1)
+      expect(data.bodyweight[0].weight).toBe(185)
+    })
+
+    it('includes progression snapshot', () => {
+      const data = buildJsonExport(metadata, exercises, bodyweight, progression)
+      expect(data.progression.totalXP).toBe(5000)
+      expect(data.progression.starterTheme).toBe('fire')
+    })
+  })
+
+  describe('buildCsvExport', () => {
+    it('includes metadata comment header with version and user hash', () => {
+      const csv = buildCsvExport(metadata, exercises, bodyweight)
+      const lines = csv.split('\n')
+      expect(lines[0]).toBe('# Lift Export — 2026-04-05 — v1.0.0 — abc123')
+    })
+
+    it('includes column header row', () => {
+      const csv = buildCsvExport(metadata, exercises, bodyweight)
+      const lines = csv.split('\n')
+      expect(lines[1]).toBe('Exercise,Date,Weight,Reps,Estimated 1RM,Tags')
+    })
+
+    it('includes exercise set data rows', () => {
+      const csv = buildCsvExport(metadata, exercises, bodyweight)
+      const lines = csv.split('\n')
+      expect(lines[2]).toBe('Bench Press,2026-04-05,225,5,253,chest;push')
+    })
+
+    it('includes bodyweight section when entries exist', () => {
+      const csv = buildCsvExport(metadata, exercises, bodyweight)
+      expect(csv).toContain('Date,Body Weight')
+      expect(csv).toContain('2026-04-05,185')
+    })
+
+    it('omits bodyweight section when no entries', () => {
+      const csv = buildCsvExport(metadata, exercises, [])
+      expect(csv).not.toContain('Body Weight')
+    })
+  })
+
+  describe('csvEscape', () => {
+    it('returns plain strings unchanged', () => {
+      expect(csvEscape('Bench Press')).toBe('Bench Press')
+    })
+
+    it('wraps strings with commas in quotes', () => {
+      expect(csvEscape('chest,push')).toBe('"chest,push"')
+    })
+
+    it('escapes internal double quotes', () => {
+      expect(csvEscape('12" curl')).toBe('"12"" curl"')
+    })
+
+    it('wraps strings with newlines', () => {
+      expect(csvEscape('line1\nline2')).toBe('"line1\nline2"')
+    })
+  })
+})

--- a/src/lib/dataExport.ts
+++ b/src/lib/dataExport.ts
@@ -1,0 +1,98 @@
+import type { Exercise } from '../stores/workout'
+
+interface BodyweightEntry {
+  date: string
+  weight: number
+}
+
+interface ProgressionSnapshot {
+  totalXP: number
+  epoch: number
+  streakWeeks: number
+  weeklyTarget: number
+  starterTheme: string | null
+  unlockedThemes: unknown[]
+  xpPerSet: Record<string, unknown>
+}
+
+export interface ExportMetadata {
+  exportDate: string
+  appVersion: string
+  userIdHash: string
+}
+
+export interface JsonExportData extends ExportMetadata {
+  exercises: {
+    name: string
+    tags: string[]
+    sets: { date: string; weight: number; reps: number; estimated1RM: number }[]
+  }[]
+  bodyweight: { date: string; weight: number }[]
+  progression: ProgressionSnapshot
+}
+
+export async function hashUserId(uid: string): Promise<string> {
+  const encoded = new TextEncoder().encode(uid)
+  const buffer = await crypto.subtle.digest('SHA-256', encoded)
+  return Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+export function buildJsonExport(
+  metadata: ExportMetadata,
+  exercises: Exercise[],
+  bodyweight: BodyweightEntry[],
+  progression: ProgressionSnapshot,
+): JsonExportData {
+  return {
+    ...metadata,
+    exercises: exercises.map(e => ({
+      name: e.name,
+      tags: e.tags,
+      sets: e.sets.map(s => ({
+        date: s.date,
+        weight: s.weight,
+        reps: s.reps,
+        estimated1RM: s.estimated1RM,
+      })),
+    })),
+    bodyweight: bodyweight.map(e => ({
+      date: e.date,
+      weight: e.weight,
+    })),
+    progression,
+  }
+}
+
+export function csvEscape(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+export function buildCsvExport(
+  metadata: ExportMetadata,
+  exercises: Exercise[],
+  bodyweight: BodyweightEntry[],
+): string {
+  const timestamp = metadata.exportDate.slice(0, 10)
+  const lines = [
+    `# Lift Export — ${timestamp} — v${metadata.appVersion} — ${metadata.userIdHash}`,
+    'Exercise,Date,Weight,Reps,Estimated 1RM,Tags',
+  ]
+  for (const ex of exercises) {
+    for (const s of ex.sets) {
+      const date = s.date.slice(0, 10)
+      const tags = ex.tags.join(';')
+      lines.push(`${csvEscape(ex.name)},${date},${s.weight},${s.reps},${s.estimated1RM},${csvEscape(tags)}`)
+    }
+  }
+  if (bodyweight.length > 0) {
+    lines.push('')
+    lines.push('Date,Body Weight')
+    for (const e of bodyweight) {
+      lines.push(`${e.date.slice(0, 10)},${e.weight}`)
+    }
+  }
+  return lines.join('\n')
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,14 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { VitePWA } from 'vite-plugin-pwa'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { readFileSync } from 'fs'
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   build: {
     target: 'es2022',
     sourcemap: true,


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-191](https://github.com/aschung212/Lift/issues/191)

Picked LIFT-191 — export missing app version and user ID hash metadata per spec. This was the highest priority actionable issue since LIFT-189's core export already exists and just needed the metadata fields added.

## Changes
- Added `__APP_VERSION__` build-time constant via Vite `define` (reads from package.json)
- Added TypeScript declaration for `__APP_VERSION__` in `env.d.ts`
- Added ESLint global for `__APP_VERSION__` to prevent `no-undef` errors
- Created `src/lib/dataExport.ts` — extracted export logic into testable pure functions:
  - `hashUserId()` — SHA-256 hash of user ID for privacy-safe identification
  - `buildJsonExport()` — builds full JSON export with `appVersion` and `userIdHash` metadata
  - `buildCsvExport()` — builds CSV with metadata comment header (`# Lift Export — date — version — hash`)
  - `csvEscape()` — handles commas, quotes, newlines in CSV values
- Updated `App.vue` to use extracted functions, removing duplicated inline logic
- Added 18 tests covering metadata inclusion, hash determinism, CSV escaping, and no-ID-leakage

## Commits
- [`7234914`](https://github.com/aschung212/Lift/commit/7234914) feat(LIFT-191): add app version and user ID hash metadata to data exports

## Test Results
- Before: 1054 passing
- After: 1072 passing (18 delta)

---
_Automated by overnight pipeline — Sun Apr  5 03:16:10 PDT 2026_