### PR TITLE
fix: set esbuild target to es2022 for dep optimization

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,11 @@ export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: 'es2022',
+    },
+  },
   build: {
     target: 'es2022',
     sourcemap: true,


### PR DESCRIPTION
## Summary
`@vercel/analytics` v2 and `@vercel/speed-insights` v2 use modern JS that the default esbuild serve target (es2020) can't transform. Dev server was crashing on page load. Set `optimizeDeps.esbuildOptions.target` to `es2022` to match the build target.

## Test plan
- [x] Dev server starts and serves pages without transform errors
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)