### PR TITLE
refactor: remove dead code and unused store actions

### DIFF
--- a/src/__tests__/progressionIntegration.test.ts
+++ b/src/__tests__/progressionIntegration.test.ts
@@ -29,7 +29,6 @@ import {
   calculateSetXP,
   calculateBest1RM,
   applyStreakMultiplier,
-  calculateBodyweightXP,
   checkRepPR,
   XP_CONFIG,
   type StreakHistoryEntry,
@@ -184,11 +183,6 @@ describe('Progression Integration', () => {
   // ── Bodyweight XP ─────────────────────────────────────────────
 
   describe('bodyweight XP', () => {
-    it('awards 100 XP per unique date', () => {
-      expect(calculateBodyweightXP('2026-04-01', [])).toBe(100)
-      expect(calculateBodyweightXP('2026-04-01', ['2026-04-01'])).toBe(0)
-    })
-
     it('integrates with progression store', () => {
       const store = useProgressionStore()
       store.progressionEnabled = true
@@ -253,14 +247,14 @@ describe('Progression Integration', () => {
       expect(store.weeklyTarget).toBe(2) // change applied
     })
 
-    it('revert target preserves streak', () => {
+    it('clearing pending target preserves streak', () => {
       const store = useProgressionStore()
       store.evaluateWeek(3, '2026-03-16')
       store.evaluateWeek(3, '2026-03-23')
       expect(store.streakWeeks).toBe(2)
 
       store.setWeeklyTarget(6)
-      store.revertTargetChange()
+      store.pendingTargetChange = null
       store.evaluateWeek(3, '2026-03-30')
       expect(store.streakWeeks).toBe(3) // preserved
     })

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -106,12 +106,9 @@ const mockAddExercise = vi.fn()
 const mockLogSet = vi.fn()
 const mockUpdateSet = vi.fn()
 const mockDeleteSet = vi.fn()
-const mockClearSets = vi.fn()
 const mockDeleteExercise = vi.fn()
 const mockRestoreSet = vi.fn()
 const mockSyncDeleteSet = vi.fn()
-const mockRestoreSets = vi.fn()
-const mockSyncDeleteSets = vi.fn()
 const mockRestoreExercise = vi.fn()
 const mockSyncDeleteExercise = vi.fn()
 const mockRenameExercise = vi.fn()
@@ -130,12 +127,9 @@ vi.mock('../../stores/workout', () => ({
     logSet: mockLogSet,
     updateSet: mockUpdateSet,
     deleteSet: mockDeleteSet,
-    clearSets: mockClearSets,
     deleteExercise: mockDeleteExercise,
     restoreSet: mockRestoreSet,
     syncDeleteSet: mockSyncDeleteSet,
-    restoreSets: mockRestoreSets,
-    syncDeleteSets: mockSyncDeleteSets,
     restoreExercise: mockRestoreExercise,
     syncDeleteExercise: mockSyncDeleteExercise,
     renameExercise: mockRenameExercise,

--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import {
   calculateSetXP,
   calculateBest1RM,
-  calculateBodyweightXP,
   applyStreakMultiplier,
   checkRepPR,
   XP_CONFIG,
@@ -280,32 +279,6 @@ describe('calculateBest1RM', () => {
       makeSet({ estimated1RM: 100, date: '2026-03-20T10:00:00Z' }),
     ]
     expect(calculateBest1RM(sets, { windowMonths: 1 })).toBe(100)
-  })
-})
-
-// --- calculateBodyweightXP ---
-
-describe('calculateBodyweightXP', () => {
-  it('returns 100 for a new date', () => {
-    expect(calculateBodyweightXP('2026-04-01', [])).toBe(100)
-  })
-
-  it('returns 0 for a duplicate date', () => {
-    expect(calculateBodyweightXP('2026-04-01', ['2026-04-01'])).toBe(0)
-  })
-
-  it('matches on date portion only (ignores time)', () => {
-    expect(calculateBodyweightXP(
-      '2026-04-01T15:30:00Z',
-      ['2026-04-01T08:00:00Z']
-    )).toBe(0)
-  })
-
-  it('returns 100 when existing dates are different days', () => {
-    expect(calculateBodyweightXP(
-      '2026-04-02',
-      ['2026-04-01', '2026-04-03']
-    )).toBe(100)
   })
 })
 

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -193,19 +193,6 @@ export function calculateBest1RM(
 }
 
 /**
- * Calculate bodyweight logging XP.
- * Returns bodyweightXP if the date hasn't already been credited, 0 otherwise.
- */
-export function calculateBodyweightXP(
-  date: string,
-  existingDates: string[]
-): number {
-  const dateKey = date.slice(0, 10)
-  const credited = existingDates.some(d => d.slice(0, 10) === dateKey)
-  return credited ? 0 : XP_CONFIG.bodyweightXP
-}
-
-/**
  * Look up the streak multiplier for a given date.
  *
  * Multiplier = durationMultiplier × targetMultiplier

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -49,34 +49,6 @@ describe('usePreferencesStore', () => {
     })
   })
 
-  describe('setFeature', () => {
-    it('explicitly sets a feature to disabled', () => {
-      store.setFeature('weight', false)
-      expect(store.features.weight).toBe(false)
-    })
-
-    it('explicitly sets a feature to enabled', () => {
-      store.setFeature('weight', false)
-      store.setFeature('weight', true)
-      expect(store.features.weight).toBe(true)
-    })
-  })
-
-  describe('setFeature edge cases', () => {
-    it('allows disabling the last feature (no guard like toggleFeature)', () => {
-      store.setFeature('calendar', false)
-      store.setFeature('weight', false)
-      store.setFeature('workouts', false)
-      expect(store.enabledCount).toBe(0)
-    })
-
-    it('handles unknown feature keys', () => {
-      store.setFeature('analytics', true)
-      expect(store.features.analytics).toBe(true)
-      expect(store.enabledCount).toBe(4)
-    })
-  })
-
   describe('toggleFeature edge cases', () => {
     it('toggling multiple features tracks enabledCount correctly', () => {
       expect(store.enabledCount).toBe(3)

--- a/src/stores/__tests__/progression.test.ts
+++ b/src/stores/__tests__/progression.test.ts
@@ -161,7 +161,7 @@ describe('progression store', () => {
     })
   })
 
-  // ── setWeeklyTarget / revertTargetChange ──────────────────────
+  // ── setWeeklyTarget ────────────────────────────────────────────
 
   describe('weekly target management', () => {
     it('stages a target change without immediately applying', () => {
@@ -170,14 +170,6 @@ describe('progression store', () => {
       store.setWeeklyTarget(5)
       expect(store.weeklyTarget).toBe(3) // unchanged until evaluateWeek
       expect(store.pendingTargetChange).toBe(5)
-    })
-
-    it('can revert a staged change', () => {
-      const store = useProgressionStore()
-      store.setWeeklyTarget(5)
-      store.revertTargetChange()
-      expect(store.pendingTargetChange).toBeNull()
-      expect(store.weeklyTarget).toBe(3)
     })
 
     it('clamps target to 1-7', () => {
@@ -547,17 +539,17 @@ describe('progression store', () => {
   // ── Full streak lifecycle ─────────────────────────────────────
 
   describe('streak lifecycle', () => {
-    it('revert before evaluation preserves streak', () => {
+    it('clearing pending change before evaluation preserves streak', () => {
       const store = useProgressionStore()
       // Build a 2-week streak
       store.evaluateWeek(3, '2026-03-16')
       store.evaluateWeek(4, '2026-03-23')
       expect(store.streakWeeks).toBe(2)
 
-      // Stage a change mid-week, then revert
+      // Stage a change mid-week, then clear it
       store.setWeeklyTarget(6)
       expect(store.pendingTargetChange).toBe(6)
-      store.revertTargetChange()
+      store.pendingTargetChange = null
 
       // Evaluate the current week — streak should continue normally
       store.evaluateWeek(3, '2026-03-30')

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -291,38 +291,8 @@ describe('workout store', () => {
     })
   })
 
-  // ── moveExercise / reorderExercise ─────────────────────────────
-  describe('moveExercise / reorderExercise', () => {
-    it('moves exercise down', () => {
-      const store = useWorkoutStore()
-      store.addExercise('Bench')
-      store.addExercise('Squat')
-      store.addExercise('Deadlift')
-      const benchId = store.exercises[0].id
-      store.moveExercise(benchId, 1)
-      expect(store.exercises[0].name).toBe('Squat')
-      expect(store.exercises[1].name).toBe('Bench')
-    })
-
-    it('moves exercise up', () => {
-      const store = useWorkoutStore()
-      store.addExercise('Bench')
-      store.addExercise('Squat')
-      const squatId = store.exercises[1].id
-      store.moveExercise(squatId, -1)
-      expect(store.exercises[0].name).toBe('Squat')
-      expect(store.exercises[1].name).toBe('Bench')
-    })
-
-    it('does nothing for out-of-bounds move', () => {
-      const store = useWorkoutStore()
-      store.addExercise('Bench')
-      store.addExercise('Squat')
-      const benchId = store.exercises[0].id
-      store.moveExercise(benchId, -1) // Can't move first item up
-      expect(store.exercises[0].name).toBe('Bench')
-    })
-
+  // ── reorderExercise ─────────────────────────────────────────────
+  describe('reorderExercise', () => {
     it('reorders exercise from one index to another', () => {
       const store = useWorkoutStore()
       store.addExercise('A')

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -117,11 +117,6 @@ export const usePreferencesStore = defineStore('preferences', {
       this._persist()
     },
 
-    setFeature(featureId: string, enabled: boolean) {
-      this.features[featureId] = enabled
-      this._persist()
-    },
-
     setWeightGoalDirection(direction: WeightGoalDirection) {
       this.weightGoal.direction = direction
       this._persist()

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -330,12 +330,6 @@ export const useProgressionStore = defineStore('progression', {
       this._syncToSupabase()
     },
 
-    revertTargetChange() {
-      this.pendingTargetChange = null
-      this._persist()
-      this._syncToSupabase()
-    },
-
     /**
      * Evaluate the completed week. Called at week boundary (Monday).
      * @param daysTrainedThisWeek - number of unique training days in the completed week

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -413,16 +413,6 @@ export const useWorkoutStore = defineStore('workout', {
       }
     },
 
-    moveExercise(exerciseId: string, direction: number) {
-      const idx = this.exercises.findIndex((e: Exercise) => e.id === exerciseId)
-      if (idx === -1) return
-      const newIdx = idx + direction
-      if (newIdx < 0 || newIdx >= this.exercises.length) return
-      const [item] = this.exercises.splice(idx, 1)
-      this.exercises.splice(newIdx, 0, item)
-      this._persist()
-    },
-
     reorderExercise(fromIndex: number, toIndex: number) {
       if (fromIndex === toIndex) return
       if (fromIndex < 0 || toIndex < 0) return


### PR DESCRIPTION
## Summary
- Removed 3 dead store actions: `moveExercise`, `revertTargetChange`, `setFeature`
- Removed dead library function: `calculateBodyweightXP`
- Cleaned up 3 dead test mocks and 13 tests for removed functions
- Net: -147 lines deleted, +8 lines added

## Why
Dead code increases cognitive load and maintenance risk. These functions were superseded by better alternatives (`reorderExercise`, `toggleFeature`) or had their logic inlined into store actions.

## What I didn't touch
- `plateDelta`/`formatDelta`/`syncSummary` — only used in tests but are tested utility functions with future value
- WorkoutTracker.vue (2200 lines) — large but has clear section boundaries and all patterns are settled per CLAUDE.md

## Test plan
- [x] 1068 tests pass (13 removed with dead code, no regressions)
- [x] TypeScript strict mode passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)