### PR TITLE
feat: CSV import from Strong, Hevy, and Lift formats

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -346,6 +346,17 @@
                   <button class="exportBtn" @click="exportData('json')" aria-label="Export data as JSON">JSON</button>
                 </div>
               </div>
+              <div class="settingsRow">
+                <span class="settingsLabel">Import</span>
+                <div class="exportBtnGroup">
+                  <button class="exportBtn" @click="triggerImport" aria-label="Import workout data from CSV">CSV</button>
+                </div>
+                <input ref="importFileInput" type="file" accept=".csv" class="hiddenFileInput" @change="handleImportFile" />
+              </div>
+              <div v-if="importResult" class="settingsImportResult" role="status">
+                <span v-if="importResult.error" class="settingsImportError">{{ importResult.error }}</span>
+                <span v-else class="settingsImportSuccess">Imported {{ importResult.exercises }} exercise{{ importResult.exercises !== 1 ? 's' : '' }} with {{ importResult.sets }} sets ({{ importResult.format }})</span>
+              </div>
               <div class="privacyTransparency" role="region" aria-label="Data transparency">
                 <div class="privacyRow">
                   <svg class="privacyIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M12 12h.01"/></svg>
@@ -724,6 +735,7 @@ import { requestPersistentStorage, ensureLocalStorage, clearIDB } from './lib/du
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
 import { hashUserId, buildJsonExport, buildCsvExport } from './lib/dataExport'
+import { importCSV } from './lib/csvImport'
 import { usePreferencesStore } from './stores/preferences'
 import type { WeightGoalDirection } from './stores/preferences'
 import { useWorkoutStore } from './stores/workout'
@@ -1426,6 +1438,43 @@ function downloadFile(filename: string, content: string, mimeType: string) {
   a.click()
   document.body.removeChild(a)
   URL.revokeObjectURL(url)
+}
+
+// ── CSV Import ──────────────────────────────────────────────────
+const importFileInput = ref<HTMLInputElement | null>(null)
+const importResult = ref<{ exercises: number; sets: number; format: string; error?: string } | null>(null)
+
+function triggerImport() {
+  importResult.value = null
+  importFileInput.value?.click()
+}
+
+function handleImportFile(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  const reader = new FileReader()
+  reader.onload = () => {
+    const text = reader.result as string
+    const result = importCSV(text)
+    if (result.format === 'unknown' || result.exercises.length === 0) {
+      importResult.value = { exercises: 0, sets: 0, format: 'unknown', error: 'Unrecognized format. Supported: Strong, Hevy, Lift CSV.' }
+      return
+    }
+    // Merge imported exercises into the store
+    const workoutStore = useWorkoutStore()
+    for (const ex of result.exercises) {
+      const existingId = workoutStore.addExercise(ex.name, ex.tags, { sync: false })
+      if (!existingId) continue
+      for (const set of ex.sets) {
+        workoutStore.logSet(existingId, set.weight, set.reps, set.date.slice(0, 10), { sync: false })
+      }
+    }
+    importResult.value = { exercises: result.exercises.length, sets: result.totalSets, format: result.format }
+    logEvent('data_import', { format: result.format, exercises: result.exercises.length, sets: result.totalSets })
+  }
+  reader.readAsText(file)
+  // Reset input so the same file can be re-selected
+  if (importFileInput.value) importFileInput.value.value = ''
 }
 
 function toggleFeature(featureId: string) {

--- a/src/index.css
+++ b/src/index.css
@@ -1613,6 +1613,28 @@ html.theme-fading .settingsSheet {
 }
 .exportBtn:active { opacity: 0.6; }
 
+.hiddenFileInput {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.settingsImportResult {
+  padding: 8px 16px;
+  font-size: var(--font-caption2);
+  line-height: 1.4;
+}
+
+.settingsImportSuccess {
+  color: var(--success);
+}
+
+.settingsImportError {
+  color: var(--danger);
+}
+
 /* ─── Dev tools ──────────────────────────────────────────────────────────── */
 
 .devToolsGrid {

--- a/src/lib/__tests__/csvImport.test.ts
+++ b/src/lib/__tests__/csvImport.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest'
+import { importCSV } from '../csvImport'
+
+vi.mock('../uuid', () => ({ uuid: () => 'test-uuid' }))
+
+describe('csvImport', () => {
+  describe('Strong format', () => {
+    it('parses basic Strong CSV', () => {
+      const csv = `Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE
+2026-04-01,Morning,Bench Press,1,185,5,,,,,
+2026-04-01,Morning,Bench Press,2,185,5,,,,,
+2026-04-01,Morning,Squat,1,225,3,,,,,`
+
+      const result = importCSV(csv)
+      expect(result.format).toBe('strong')
+      expect(result.exercises).toHaveLength(2)
+      expect(result.totalSets).toBe(3)
+      expect(result.skippedRows).toBe(0)
+
+      const bench = result.exercises.find(e => e.name === 'Bench Press')!
+      expect(bench.sets).toHaveLength(2)
+      expect(bench.sets[0].weight).toBe(185)
+      expect(bench.sets[0].reps).toBe(5)
+      expect(bench.sets[0].estimated1RM).toBe(216) // 185 * (1 + 5/30)
+    })
+
+    it('skips rows with no weight and no reps', () => {
+      const csv = `Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE
+2026-04-01,Morning,Bench Press,1,185,5,,,,,
+2026-04-01,Morning,Bench Press,2,0,0,,,,,`
+
+      const result = importCSV(csv)
+      expect(result.totalSets).toBe(1)
+      expect(result.skippedRows).toBe(1)
+    })
+
+    it('handles US date format', () => {
+      const csv = `Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE
+04/01/2026,Morning,Bench Press,1,185,5,,,,,`
+
+      const result = importCSV(csv)
+      expect(result.exercises[0].sets[0].date).toContain('2026-04-01')
+    })
+
+    it('deduplicates exercises by name (case-insensitive)', () => {
+      const csv = `Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE
+2026-04-01,Morning,Bench Press,1,185,5,,,,,
+2026-04-01,Morning,bench press,2,185,5,,,,,`
+
+      const result = importCSV(csv)
+      expect(result.exercises).toHaveLength(1)
+      expect(result.exercises[0].sets).toHaveLength(2)
+    })
+  })
+
+  describe('Hevy format', () => {
+    it('parses basic Hevy CSV and converts kg to lbs', () => {
+      const csv = `title,start_time,end_time,exercise_title,superset_id,exercise_notes,set_index,set_type,weight_kg,reps,distance_km,duration_seconds,rpe
+Morning,2026-04-01T08:00:00Z,2026-04-01T09:00:00Z,Bench Press,,,,normal,84,5,,,,
+Morning,2026-04-01T08:00:00Z,2026-04-01T09:00:00Z,Squat,,,,normal,100,3,,,,`
+
+      const result = importCSV(csv)
+      expect(result.format).toBe('hevy')
+      expect(result.exercises).toHaveLength(2)
+      expect(result.totalSets).toBe(2)
+
+      const bench = result.exercises.find(e => e.name === 'Bench Press')!
+      // 84 kg * 2.20462 = 185.2 → rounded to 185.2
+      expect(bench.sets[0].weight).toBeCloseTo(185.2, 0)
+      expect(bench.sets[0].reps).toBe(5)
+    })
+  })
+
+  describe('Lift format', () => {
+    it('parses Lift CSV with tags', () => {
+      const csv = `# Lift Export — 2026-04-05 — v1.0.0
+Exercise,Date,Weight,Reps,Estimated 1RM,Tags
+Bench Press,2026-04-01,185,5,216,Push;Chest
+Bench Press,2026-04-01,185,5,216,Push;Chest
+Squat,2026-04-01,225,3,248,Legs`
+
+      const result = importCSV(csv)
+      expect(result.format).toBe('lift')
+      expect(result.exercises).toHaveLength(2)
+
+      const bench = result.exercises.find(e => e.name === 'Bench Press')!
+      expect(bench.tags).toEqual(['Push', 'Chest'])
+      expect(bench.sets).toHaveLength(2)
+    })
+  })
+
+  describe('unknown format', () => {
+    it('returns unknown for unrecognized headers', () => {
+      const csv = `foo,bar,baz
+1,2,3`
+
+      const result = importCSV(csv)
+      expect(result.format).toBe('unknown')
+      expect(result.exercises).toHaveLength(0)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty input', () => {
+      const result = importCSV('')
+      expect(result.exercises).toHaveLength(0)
+      expect(result.format).toBe('unknown')
+    })
+
+    it('handles quoted fields with commas', () => {
+      const csv = `Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE
+2026-04-01,"My, Workout","Bench Press",1,185,5,,,,,`
+
+      const result = importCSV(csv)
+      expect(result.exercises[0].name).toBe('Bench Press')
+    })
+  })
+})

--- a/src/lib/csvImport.ts
+++ b/src/lib/csvImport.ts
@@ -1,0 +1,252 @@
+import { uuid } from './uuid'
+import type { Exercise } from '../stores/workout'
+
+export interface ImportResult {
+  exercises: Exercise[]
+  totalSets: number
+  skippedRows: number
+  format: 'strong' | 'hevy' | 'lift' | 'unknown'
+}
+
+/** Epley formula: weight × (1 + reps / 30) */
+function estimated1RM(weight: number, reps: number): number {
+  if (reps <= 0 || weight <= 0) return 0
+  if (reps === 1) return weight
+  return Math.round(weight * (1 + reps / 30))
+}
+
+/** Convert kg to lbs */
+function kgToLbs(kg: number): number {
+  return Math.round(kg * 2.20462 * 10) / 10
+}
+
+/** Parse a CSV string into rows of string arrays, handling quoted fields */
+function parseCSV(text: string): string[][] {
+  const rows: string[][] = []
+  let i = 0
+  while (i < text.length) {
+    const row: string[] = []
+    while (i < text.length) {
+      if (text[i] === '"') {
+        // Quoted field
+        i++
+        let field = ''
+        while (i < text.length) {
+          if (text[i] === '"') {
+            if (text[i + 1] === '"') {
+              field += '"'
+              i += 2
+            } else {
+              i++ // closing quote
+              break
+            }
+          } else {
+            field += text[i]
+            i++
+          }
+        }
+        row.push(field)
+        if (text[i] === ',') i++
+        else if (text[i] === '\n' || text[i] === '\r') break
+      } else {
+        // Unquoted field
+        let field = ''
+        while (i < text.length && text[i] !== ',' && text[i] !== '\n' && text[i] !== '\r') {
+          field += text[i]
+          i++
+        }
+        row.push(field)
+        if (text[i] === ',') i++
+        else break
+      }
+    }
+    // Skip line endings
+    if (text[i] === '\r') i++
+    if (text[i] === '\n') i++
+    if (row.length > 0 && row.some(f => f.trim())) rows.push(row)
+  }
+  return rows
+}
+
+function detectFormat(headers: string[]): 'strong' | 'hevy' | 'lift' | 'unknown' {
+  const lower = headers.map(h => h.toLowerCase().trim())
+  if (lower.includes('exercise name') && lower.includes('set order')) return 'strong'
+  if (lower.includes('exercise_title') && lower.includes('set_index')) return 'hevy'
+  if (lower.includes('exercise') && lower.includes('estimated 1rm')) return 'lift'
+  return 'unknown'
+}
+
+function parseDate(dateStr: string): string {
+  const trimmed = dateStr.trim()
+  // ISO format: 2026-04-05 or 2026-04-05T12:00:00Z
+  if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) {
+    return trimmed.slice(0, 10) + 'T12:00:00.000Z'
+  }
+  // US format: 04/05/2026 or 4/5/2026
+  const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/)
+  if (usMatch) {
+    const [, m, d, y] = usMatch
+    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T12:00:00.000Z`
+  }
+  // Fallback: try Date.parse
+  const parsed = new Date(trimmed)
+  if (!isNaN(parsed.getTime())) {
+    return parsed.toISOString()
+  }
+  return ''
+}
+
+function importStrong(rows: string[][], headers: string[]): ImportResult {
+  const col = (name: string) => headers.findIndex(h => h.toLowerCase().trim() === name.toLowerCase())
+  const iDate = col('date')
+  const iExercise = col('exercise name')
+  const iWeight = col('weight')
+  const iReps = col('reps')
+
+  const exerciseMap = new Map<string, Exercise>()
+  let totalSets = 0
+  let skippedRows = 0
+
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r]
+    const name = row[iExercise]?.trim()
+    const weight = parseFloat(row[iWeight] || '0') || 0
+    const reps = parseInt(row[iReps] || '0') || 0
+    const date = parseDate(row[iDate] || '')
+
+    if (!name || !date || (weight === 0 && reps === 0)) {
+      skippedRows++
+      continue
+    }
+
+    if (!exerciseMap.has(name.toLowerCase())) {
+      exerciseMap.set(name.toLowerCase(), { id: uuid(), name, tags: [], sets: [] })
+    }
+    const exercise = exerciseMap.get(name.toLowerCase())!
+    exercise.sets.push({
+      id: uuid(),
+      date,
+      weight,
+      reps,
+      estimated1RM: estimated1RM(weight, reps),
+    })
+    totalSets++
+  }
+
+  return { exercises: [...exerciseMap.values()], totalSets, skippedRows, format: 'strong' }
+}
+
+function importHevy(rows: string[][], headers: string[]): ImportResult {
+  const col = (name: string) => headers.findIndex(h => h.toLowerCase().trim() === name.toLowerCase())
+  const iDate = col('start_time')
+  const iExercise = col('exercise_title')
+  const iWeight = col('weight_kg')
+  const iReps = col('reps')
+
+  const exerciseMap = new Map<string, Exercise>()
+  let totalSets = 0
+  let skippedRows = 0
+
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r]
+    const name = row[iExercise]?.trim()
+    const weightKg = parseFloat(row[iWeight] || '0') || 0
+    const weight = kgToLbs(weightKg)
+    const reps = parseInt(row[iReps] || '0') || 0
+    const date = parseDate(row[iDate] || '')
+
+    if (!name || !date || (weight === 0 && reps === 0)) {
+      skippedRows++
+      continue
+    }
+
+    if (!exerciseMap.has(name.toLowerCase())) {
+      exerciseMap.set(name.toLowerCase(), { id: uuid(), name, tags: [], sets: [] })
+    }
+    const exercise = exerciseMap.get(name.toLowerCase())!
+    exercise.sets.push({
+      id: uuid(),
+      date,
+      weight,
+      reps,
+      estimated1RM: estimated1RM(weight, reps),
+    })
+    totalSets++
+  }
+
+  return { exercises: [...exerciseMap.values()], totalSets, skippedRows, format: 'hevy' }
+}
+
+function importLift(rows: string[][], headers: string[]): ImportResult {
+  const col = (name: string) => headers.findIndex(h => h.toLowerCase().trim() === name.toLowerCase())
+  const iExercise = col('exercise')
+  const iDate = col('date')
+  const iWeight = col('weight')
+  const iReps = col('reps')
+  const iTags = col('tags')
+
+  const exerciseMap = new Map<string, Exercise>()
+  let totalSets = 0
+  let skippedRows = 0
+
+  for (let r = 1; r < rows.length; r++) {
+    const row = rows[r]
+    const name = row[iExercise]?.trim()
+    const weight = parseFloat(row[iWeight] || '0') || 0
+    const reps = parseInt(row[iReps] || '0') || 0
+    const date = parseDate(row[iDate] || '')
+    const tags = row[iTags]?.split(';').map(t => t.trim()).filter(Boolean) || []
+
+    if (!name || !date || (weight === 0 && reps === 0)) {
+      skippedRows++
+      continue
+    }
+
+    const key = name.toLowerCase()
+    if (!exerciseMap.has(key)) {
+      exerciseMap.set(key, { id: uuid(), name, tags, sets: [] })
+    }
+    const exercise = exerciseMap.get(key)!
+    // Merge tags from multiple rows
+    for (const tag of tags) {
+      if (!exercise.tags.includes(tag)) exercise.tags.push(tag)
+    }
+    exercise.sets.push({
+      id: uuid(),
+      date,
+      weight,
+      reps,
+      estimated1RM: estimated1RM(weight, reps),
+    })
+    totalSets++
+  }
+
+  return { exercises: [...exerciseMap.values()], totalSets, skippedRows, format: 'lift' }
+}
+
+/**
+ * Parse a CSV file and return exercises with sets.
+ * Auto-detects Strong, Hevy, and Lift formats.
+ */
+export function importCSV(text: string): ImportResult {
+  // Skip comment lines (Lift export starts with #)
+  const lines = text.split('\n')
+  const dataStart = lines.findIndex(l => !l.startsWith('#') && l.trim())
+  const cleanText = lines.slice(dataStart).join('\n')
+
+  const rows = parseCSV(cleanText)
+  if (rows.length < 2) {
+    return { exercises: [], totalSets: 0, skippedRows: 0, format: 'unknown' }
+  }
+
+  const headers = rows[0]
+  const format = detectFormat(headers)
+
+  switch (format) {
+    case 'strong': return importStrong(rows, headers)
+    case 'hevy': return importHevy(rows, headers)
+    case 'lift': return importLift(rows, headers)
+    default:
+      return { exercises: [], totalSets: 0, skippedRows: rows.length - 1, format: 'unknown' }
+  }
+}


### PR DESCRIPTION
## Summary
Import workout history from CSV files. Auto-detects Strong, Hevy, and Lift export formats.

- Settings → Data → Import CSV button
- Exercises merged with existing data (dedup by name)
- Hevy weights auto-converted from kg to lbs
- Success/error feedback shown inline

## Why
The #1 adoption barrier. Users switching from Strong or Hevy don't want to re-enter months of history. This removes that friction completely.

## Test plan
- [x] 1082 tests pass (9 new CSV import tests)
- [x] TypeScript passes
- [ ] Export from app as CSV, then re-import — exercises should merge, sets should double
- [ ] Import a Strong-format CSV — exercises and sets should appear
- [ ] Try importing a random .txt file — should show error message

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)