### PR TITLE
fix: round displayWeight for lbs to prevent floating point overflow

### DIFF
--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -196,7 +196,7 @@ export function useTheme() {
   // Weight conversion helpers — data is always stored in lbs
   function displayWeight(lbs: number): number {
     if (weightUnit.value === 'kg') return +(lbs * 0.453592).toFixed(1)
-    return lbs
+    return +lbs.toFixed(1)
   }
   function toLbs(value: number): number {
     if (weightUnit.value === 'kg') return +(value / 0.453592).toFixed(1)


### PR DESCRIPTION
## Summary
- `displayWeight()` rounded for kg but returned raw floats for lbs
- `Math.abs(200 - 193.7)` → `6.300000000000011` caused "6.300000000000011 lbs to goal" and chart Y-axis label overflow (`9999999998 lbs`)
- Added `.toFixed(1)` rounding for lbs, matching the existing kg behavior

## Test plan
- [ ] Verify "X lbs to goal" shows clean decimal (e.g. `6.3 lbs to goal`)
- [ ] Verify chart Y-axis labels show clean values
- [ ] Verify kg mode still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)