### PR TITLE
test(LIFT-94): verify 44px touch target via CSS regression instead of 

### DIFF
--- a/src/components/__tests__/MuscleGroupChart.test.ts
+++ b/src/components/__tests__/MuscleGroupChart.test.ts
@@ -114,13 +114,17 @@ describe('MuscleGroupChart', () => {
   })
 
   describe('touch target compliance', () => {
-    it('view toggle button meets 44px iOS HIG minimum touch target', () => {
+    // NOTE: jsdom does not apply scoped CSS from Vue SFCs, so getComputedStyle
+    // cannot verify the actual 44px sizing here. The actual 44px rule is verified
+    // via CSS regression tests in cssRegression.test.ts which read the stylesheet
+    // source directly. This test verifies the element has the correct class and
+    // no inline style overrides that would shrink it below 44px.
+    it('view toggle has mgViewToggle class (44px verified in CSS regression tests)', () => {
       const wrapper = mountChart()
       const toggle = wrapper.find('.mgViewToggle')
-      const style = getComputedStyle(toggle.element)
-      // The scoped CSS sets width/height to 44px — verify the class is applied
+      expect(toggle.exists()).toBe(true)
       expect(toggle.classes()).toContain('mgViewToggle')
-      // Verify inline styles don't override to a smaller size
+      // Ensure no inline styles override the CSS-defined 44px touch target
       const inlineWidth = toggle.element.style.width
       const inlineHeight = toggle.element.style.height
       if (inlineWidth) expect(parseInt(inlineWidth)).toBeGreaterThanOrEqual(44)

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -12,20 +12,27 @@ const css = readFileSync(resolve(__dirname, '../../index.css'), 'utf-8')
  */
 
 // Helper: extract lines between a selector and its closing brace
-function getRuleLines(selector: string): string[] {
+function getRuleLines(selector: string, source = css): string[] {
   // Match the selector at the start of a line to avoid matching it inside another selector
   const needle = '\n' + selector + ' {'
-  const idx = css.indexOf(needle)
+  const idx = source.indexOf(needle)
   if (idx === -1) return []
-  const start = css.indexOf('{', idx) + 1
+  const start = source.indexOf('{', idx) + 1
   let depth = 1
   let end = start
-  while (depth > 0 && end < css.length) {
-    if (css[end] === '{') depth++
-    if (css[end] === '}') depth--
+  while (depth > 0 && end < source.length) {
+    if (source[end] === '{') depth++
+    if (source[end] === '}') depth--
     end++
   }
-  return css.slice(start, end - 1).split('\n').map((l: string) => l.trim()).filter(Boolean)
+  return source.slice(start, end - 1).split('\n').map((l: string) => l.trim()).filter(Boolean)
+}
+
+// Helper: extract the <style> block from a Vue SFC
+function getVueStyleBlock(componentPath: string): string {
+  const content = readFileSync(resolve(__dirname, '../../components', componentPath), 'utf-8')
+  const match = content.match(/<style[^>]*>([\s\S]*?)<\/style>/)
+  return match ? match[1] : ''
 }
 
 describe('CSS regression tests', () => {
@@ -164,6 +171,25 @@ describe('CSS regression tests', () => {
 
     it('has min-height for touch targets', () => {
       expect(lines.some(l => l.includes('min-height') && l.includes('44px'))).toBe(true)
+    })
+  })
+
+  describe('Vue component touch target compliance', () => {
+    // jsdom does not apply scoped CSS from Vue SFCs, so getComputedStyle
+    // cannot verify sizing in component tests. These CSS regression tests
+    // read the stylesheet source directly to assert 44px touch targets.
+
+    describe('.mgViewToggle in MuscleGroupChart', () => {
+      const style = getVueStyleBlock('MuscleGroupChart.vue')
+      const lines = getRuleLines('.mgViewToggle', style)
+
+      it('has width: 44px for iOS HIG touch target', () => {
+        expect(lines.some(l => l.includes('width') && l.includes('44px'))).toBe(true)
+      })
+
+      it('has height: 44px for iOS HIG touch target', () => {
+        expect(lines.some(l => l.includes('height') && l.includes('44px'))).toBe(true)
+      })
     })
   })
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-94](https://github.com/aschung212/Lift/issues/94)

Picked LIFT-94 — the touch target test for MuscleGroupChart wasn't actually verifying the 44px size due to jsdom's inability to apply scoped CSS. Added CSS regression tests that read the Vue SFC stylesheet source directly, following the existing pattern in `cssRegression.test.ts`.

## Changes
- Added `getVueStyleBlock()` helper to `cssRegression.test.ts` for reading `<style>` blocks from Vue SFCs
- Added CSS regression tests asserting `.mgViewToggle` has `width: 44px` and `height: 44px` in the actual stylesheet
- Updated the component test to document the jsdom limitation and reference the CSS regression tests as the authoritative check

## Verification

### Steps to test
1. Open the app on iPhone in PWA standalone mode
2. Navigate to the Workout tab — scroll to the "Weekly Volume by Muscle Group" chart
3. Tap the view toggle button (switches between bar chart and body heatmap)
4. Verify the toggle button is comfortably tappable (44x44px target)

### Expected behavior
No visual changes — this is a test-only fix. The toggle button should continue to work as before with a comfortable touch target.

### What to watch for
This is test-only — no runtime code changed. The only risk is if the CSS regression test helper has a parsing edge case, which would manifest as a failing test, not a UI issue.

### Risk assessment
- **Scope:** Narrow — test files only, no runtime code changes
- **Confidence:** High — tests pass, pattern matches existing CSS regression tests
- **Rollback:** Revert single commit

## Commits
- [`b6b516f`](https://github.com/aschung212/Lift/commit/b6b516f) test(LIFT-94): verify 44px touch target via CSS regression instead of jsdom

## Test Results
- Before: 1086 passing
- After: 1088 passing (2 delta)

---
_Automated by overnight pipeline — Mon Apr  6 13:01:47 PDT 2026_

## Preview
📱 Test on your phone: https://lift-5j4ofxoeg-aschung212-1101s-projects.vercel.app