### PR TITLE
fix: standalone set content dedup for pre-existing duplicates

### DIFF
--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -29,7 +29,10 @@ vi.mock('../../stores/progression', () => ({
   })
 }))
 
-vi.mock('../../lib/uuid', () => ({ uuid: () => 'test-uuid' }))
+vi.mock('../../lib/uuid', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, uuid: () => 'test-uuid' }
+})
 
 import { getLocalStorageMock } from '../../__tests__/helpers'
 const localStorageMock = getLocalStorageMock()

--- a/src/lib/__tests__/csvImport.test.ts
+++ b/src/lib/__tests__/csvImport.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi } from 'vitest'
 import { importCSV } from '../csvImport'
 
-vi.mock('../uuid', () => ({ uuid: () => 'test-uuid' }))
+vi.mock('../uuid', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, uuid: () => 'test-uuid' }
+})
 
 describe('csvImport', () => {
   describe('Strong format', () => {

--- a/src/lib/csvImport.ts
+++ b/src/lib/csvImport.ts
@@ -1,4 +1,4 @@
-import { uuid } from './uuid'
+import { uuid, endOfDayISO } from './uuid'
 import type { Exercise } from '../stores/workout'
 
 export interface ImportResult {
@@ -80,13 +80,13 @@ function parseDate(dateStr: string): string {
   const trimmed = dateStr.trim()
   // ISO format: 2026-04-05 or 2026-04-05T23:59:59Z
   if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) {
-    return trimmed.slice(0, 10) + 'T23:59:59.000Z'
+    return endOfDayISO(trimmed.slice(0, 10))
   }
   // US format: 04/05/2026 or 4/5/2026
   const usMatch = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})/)
   if (usMatch) {
     const [, m, d, y] = usMatch
-    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}T23:59:59.000Z`
+    return endOfDayISO(`${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`)
   }
   // Fallback: try Date.parse
   const parsed = new Date(trimmed)

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,3 +1,12 @@
+/** Build an end-of-day ISO timestamp with random seconds/ms jitter (23:59:00–23:59:59.999).
+ *  Keeps the set on the correct calendar day while making each timestamp unique
+ *  so the dedup logic never drops intentional duplicate-looking sets. */
+export function endOfDayISO(dateStr: string): string {
+  const ss = String(Math.floor(Math.random() * 60)).padStart(2, '0')
+  const ms = String(Math.floor(Math.random() * 1000)).padStart(3, '0')
+  return `${dateStr}T23:59:${ss}.${ms}Z`
+}
+
 export function uuid(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
     return crypto.randomUUID()

--- a/src/stores/__tests__/bodyweight.test.ts
+++ b/src/stores/__tests__/bodyweight.test.ts
@@ -3,7 +3,10 @@ import { setActivePinia, createPinia } from 'pinia'
 import { useBodyweightStore } from '../bodyweight'
 import { getLocalStorageMock } from '../../__tests__/helpers'
 
-vi.mock('../../lib/uuid', () => ({ uuid: () => 'bw-uuid-' + Math.random().toString(36).slice(2, 8) }))
+vi.mock('../../lib/uuid', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual, uuid: () => 'bw-uuid-' + Math.random().toString(36).slice(2, 8) }
+})
 
 const localStorageMock = getLocalStorageMock()
 

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { supabase, isPreviewMode } from '../lib/supabase'
 import { syncQueue } from '../lib/syncQueue'
 import { mergeEntities } from '../lib/conflictResolver'
-import { uuid } from '../lib/uuid'
+import { uuid, endOfDayISO } from '../lib/uuid'
 import { backupToIDB } from '../lib/durableStorage'
 import { logError, logWarn } from '../lib/logger'
 import { addTombstone, removeTombstone, isTombstoned, cleanupTombstones } from '../lib/tombstones'
@@ -171,7 +171,7 @@ export const useBodyweightStore = defineStore('bodyweight', {
 
     addEntry(weight: number, dateStr?: string, { sync = true }: { sync?: boolean } = {}): string {
       const date = dateStr
-        ? dateStr + 'T23:59:59.000Z'
+        ? endOfDayISO(dateStr)
         : new Date().toISOString()
       const id = uuid()
       this.entries.push({ id, date, weight, updated_at: new Date().toISOString() })
@@ -190,7 +190,7 @@ export const useBodyweightStore = defineStore('bodyweight', {
       if (!entry) return
       entry.weight = weight
       if (dateStr) {
-        entry.date = dateStr + 'T23:59:59.000Z'
+        entry.date = endOfDayISO(dateStr)
       }
       entry.updated_at = new Date().toISOString()
       this._persist()

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -3,7 +3,7 @@ import { supabase, isPreviewMode } from '../lib/supabase'
 import { syncQueue } from '../lib/syncQueue'
 import { backupToIDB } from '../lib/durableStorage'
 import { mergeEntities } from '../lib/conflictResolver'
-import { uuid } from '../lib/uuid'
+import { uuid, endOfDayISO } from '../lib/uuid'
 import { logError, logWarn } from '../lib/logger'
 import { addTombstone, removeTombstone, isTombstoned, cleanupTombstones } from '../lib/tombstones'
 
@@ -256,6 +256,43 @@ export const useWorkoutStore = defineStore('workout', {
         }
       }
 
+      // Deduplicate sets within each exercise by content (date+weight+reps).
+      // This catches duplicates already baked into a single exercise from
+      // a previous sync cycle that merged duplicate exercise rows.
+      //
+      // Only dedup sets whose timestamps match the old hardcoded format
+      // (T23:59:59.000Z) — these are from the code that created the sync
+      // duplicates. Sets with jitter or real-time timestamps are guaranteed
+      // unique and are never deduped, even if they share weight/reps.
+      const dupSetIds: string[] = []
+      for (const ex of deduped.exercises) {
+        const seen = new Map<string, string>()
+        const uniqueSets: WorkoutSet[] = []
+        for (const set of ex.sets) {
+          const key = `${set.date}|${set.weight}|${set.reps}`
+          const isOldFixedTimestamp = set.date.endsWith('T23:59:59.000Z')
+          if (!seen.has(key)) {
+            seen.set(key, set.id)
+            uniqueSets.push(set)
+          } else if (isOldFixedTimestamp) {
+            // Duplicate with old fixed timestamp — sync artifact, delete it
+            dupSetIds.push(set.id)
+          } else {
+            // Duplicate content but unique timestamp — legitimate set, keep it
+            uniqueSets.push(set)
+          }
+        }
+        ex.sets = uniqueSets
+      }
+      if (supabase && this._userId && dupSetIds.length > 0) {
+        const userId = this._userId
+        for (const setId of dupSetIds) {
+          syncQueue.enqueue(`set:${setId}`, () =>
+            supabase!.from('sets').delete().eq('id', setId).eq('user_id', userId)
+          )
+        }
+      }
+
       this.exercises = deduped.exercises
       this._persist()
 
@@ -375,7 +412,7 @@ export const useWorkoutStore = defineStore('workout', {
       const exercise = this.exercises.find((e: Exercise) => e.id === exerciseId)
       if (!exercise) return
       const date = dateStr
-        ? dateStr + 'T23:59:59.000Z'
+        ? endOfDayISO(dateStr)
         : new Date().toISOString()
       const id = uuid()
       const estimated1RM = epley(weight, reps)
@@ -400,7 +437,7 @@ export const useWorkoutStore = defineStore('workout', {
       set.reps = reps
       set.estimated1RM = epley(weight, reps)
       if (dateStr) {
-        set.date = dateStr + 'T23:59:59.000Z'
+        set.date = endOfDayISO(dateStr)
       }
       exercise.updated_at = new Date().toISOString()
       this._persist()


### PR DESCRIPTION
## Summary

- Adds standalone content dedup pass during sync that catches duplicate sets already baked into a single exercise from previous sync cycles
- Only dedupes sets with the old `T23:59:59.000Z` fixed timestamp format — the code that created the sync duplicates
- Sets with jitter (from `endOfDayISO`) or real-time timestamps are never deduped, preserving legitimate identical sets
- Date-picked sets now use `endOfDayISO()` with random second/ms jitter to prevent future collisions

Fixes the issue where the previous PR (#229) merged duplicate exercise rows but left their triplicated sets intact because `deduplicateByName` only fires when `group.length > 1`.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run build` passes  
- [x] All 1101 tests pass
- [ ] Load app in prod — verify Bench Press shows 3 sets (not 9) for Apr 5
- [ ] Log two identical sets via date picker — verify both are preserved
- [ ] Codex review: no P1 findings, safe to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)