### PR TITLE
fix: raise sync rate limit for dedup cleanup

### DIFF
--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -217,25 +217,25 @@ describe('SyncQueue', () => {
   it('should defer operations when rate limit is exceeded', async () => {
     const queue = new SyncQueue(100)
 
-    // Enqueue 60 operations rapidly — rate limit is 50/minute
-    const ops = Array.from({ length: 60 }, (_, i) => vi.fn().mockResolvedValue(i))
-    for (let i = 0; i < 60; i++) {
+    // Enqueue 250 operations rapidly — rate limit is 200/minute
+    const ops = Array.from({ length: 250 }, (_, i) => vi.fn().mockResolvedValue(i))
+    for (let i = 0; i < 250; i++) {
       queue.enqueue(`rate-${i}`, ops[i])
     }
 
-    // All 60 should be tracked (50 in queue + 10 deferred)
-    expect(queue.pending).toBe(60)
+    // All 250 should be tracked (200 in queue + 50 deferred)
+    expect(queue.pending).toBe(250)
 
-    // Flush the main queue — only the first 50 should run
+    // Flush the main queue — only the first 200 should run
     await queue.flush()
     const calledCount = ops.filter(op => op.mock.calls.length > 0).length
-    expect(calledCount).toBe(50)
+    expect(calledCount).toBe(200)
 
     // After the rate window resets, deferred ops move into the queue
     await vi.advanceTimersByTimeAsync(60_000)
     await queue.flush()
     const totalCalled = ops.filter(op => op.mock.calls.length > 0).length
-    expect(totalCalled).toBe(60)
+    expect(totalCalled).toBe(250)
   })
 
   it('should update syncStatus through lifecycle', async () => {

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -8,7 +8,7 @@ type SyncOperation = () => PromiseLike<unknown>
 export const syncStatus = ref<'synced' | 'syncing' | 'error' | 'offline'>('synced')
 
 // Rate limiting: max operations per window
-const RATE_LIMIT_MAX = 50
+const RATE_LIMIT_MAX = 200
 const RATE_LIMIT_WINDOW = 60_000 // 1 minute
 let _rateCount = 0
 let _rateResetTimer: ReturnType<typeof setTimeout> | null = null


### PR DESCRIPTION
## Summary

Raises sync queue rate limit from 50 to 200 ops/minute. The one-time dedup cleanup generates 100+ delete operations for duplicate sets, overwhelming the previous limit and causing all deletions to be deferred indefinitely (visible as 1,900+ "deferring operation" warnings in console).

## Test plan
- [x] All 1101 tests pass
- [ ] Reload app — dedup deletes should complete without rate limit warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)