### PR TITLE
fix: skip onboarding for returning users after sign-out

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
     <AuthScreen v-else-if="!user" />
 
     <!-- Onboarding -->
-    <OnboardingScreen v-else-if="showOnboarding" @complete="onOnboardingComplete" />
+    <OnboardingScreen v-else-if="showOnboarding" @complete="onOnboardingComplete" @started="onboardingInProgress = true" />
 
     <!-- Authenticated app -->
     <template v-else>
@@ -929,7 +929,7 @@ const bodyweightStoreForOnboarding = useBodyweightStore()
 // Reactive so it catches data that loads asynchronously after auth.
 // onboardingInProgress prevents the watcher from firing when the onboarding
 // screen itself adds exercises (e.g. Popular Exercises option).
-const onboardingInProgress = ref(!onboardingComplete.value)
+const onboardingInProgress = ref(false)
 watch(
   () => workoutStoreForOnboarding.exercises.length + bodyweightStoreForOnboarding.entries.length,
   (total) => {

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -56,7 +56,7 @@ import { useTheme, type ThemeId } from '../composables/useTheme'
 import { useAnalytics } from '../composables/useAnalytics'
 import StarterPickerFlow from './StarterPickerFlow.vue'
 
-const emit = defineEmits<{ complete: [] }>()
+const emit = defineEmits<{ complete: []; started: [] }>()
 const workoutStore = useWorkoutStore()
 const bwStore = useBodyweightStore()
 const progressionStore = useProgressionStore()
@@ -402,11 +402,13 @@ function handleStarterSkip() {
 
 function chooseEmpty() {
   logEvent('onboarding_choice', { choice: 'empty' })
+  emit('started')
   goToStarter(false)
 }
 
 function chooseStarter() {
   logEvent('onboarding_choice', { choice: 'starter' })
+  emit('started')
   for (const ex of STARTER_EXERCISES) {
     workoutStore.addExercise(ex.name, ex.tags)
   }
@@ -417,6 +419,7 @@ const noSync = { sync: false }
 
 function chooseExplore() {
   logEvent('onboarding_choice', { choice: 'explore' })
+  emit('started')
   // Add exercises with sample sets — skip Supabase sync for sample data (MAS-197)
   for (const group of SAMPLE_SETS) {
     const starter = STARTER_EXERCISES.find(e => e.name === group.exercise)


### PR DESCRIPTION
## Summary
- Returning users who sign out and back in were shown the onboarding screen despite having existing data
- Root cause: sign-out clears `onboarding-complete` from localStorage, and the auto-skip watcher was blocked by `onboardingInProgress` being initialized to `true`
- Fix: initialize `onboardingInProgress` to `false`, set it `true` only when the user interacts with onboarding (new `started` event)
- When Supabase data loads after auth, the watcher fires and auto-completes onboarding

## Test plan
- [x] 1105 tests pass, clean typecheck
- [x] Gemini review: no issues found
- [ ] Manual: sign out → sign back in → should skip onboarding and show exercises
- [ ] Manual: fresh account → should still see onboarding normally
- [ ] Manual: onboarding explore flow → exercises added during onboarding should not trigger auto-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)