### PR TITLE
fix(LIFT-143): prevent unlock queue race condition on rapid dismiss

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -576,7 +576,7 @@
   <!-- Global XP toast -->
   <Teleport to="body">
     <transition name="xpGlobalFade">
-      <div v-if="xpToast.visible" class="xpGlobalToast" role="status" aria-live="polite">
+      <div v-if="xpToast.visible" :class="['xpGlobalToast', { 'xpGlobalToast--pr': xpToast.isPR }]" role="status" aria-live="polite">
         <div class="xpToastEarned">{{ xpToast.text }}</div>
         <div class="xpToastTotal">{{ xpToast.nextThresholdXP ? `${xpToast.totalXP.toLocaleString()} / ${xpToast.nextThresholdXP.toLocaleString()} XP` : `${xpToast.totalXP.toLocaleString()} XP` }}</div>
         <div v-if="xpToast.nextThresholdXP" class="xpToastProgress">
@@ -696,6 +696,10 @@
   <Teleport to="body">
     <transition name="unlockFade">
       <div v-if="unlockCelebration.visible" class="unlockOverlay" @click.self="dismissUnlockCelebration">
+        <!-- Confetti particles -->
+        <div class="confettiContainer" aria-hidden="true">
+          <span v-for="i in 24" :key="i" class="confettiPiece" :style="confettiStyle(i)"></span>
+        </div>
         <div class="unlockModal" role="alert" aria-live="assertive">
           <div class="unlockIcon">
             <span
@@ -740,7 +744,7 @@ const BodyweightTracker = defineAsyncComponent({
   delay: 100,
 })
 import { useTheme, connectProgressionStore, type ThemeId } from './composables/useTheme'
-import { useProgressionStore, UNLOCK_TIERS, xpToast, unlockCelebration, dismissUnlockCelebration, showUnlockCelebration, showXPToast } from './stores/progression'
+import { useProgressionStore, UNLOCK_TIERS, xpToast, unlockCelebration, dismissUnlockCelebration, queueUnlockCelebrations, showXPToast } from './stores/progression'
 import { computeThemeStats, type ThemeStats } from './lib/themeStats'
 import { isMigrated, markMigrated, clearMigrationFlag, computeRetroactiveXP } from './lib/xpMigration'
 import { requestPersistentStorage, ensureLocalStorage, clearIDB } from './lib/durableStorage'
@@ -1121,6 +1125,27 @@ watch(starterPickerVisible, (visible) => { if (!visible) revertPreview() })
 const STARTER_IDS: ThemeId[] = ['fire', 'water', 'luck']
 const progressionToggleEl = ref<HTMLElement | null>(null)
 
+// Confetti particle styles — deterministic per index for consistent rendering
+const CONFETTI_COLORS = ['#FFD700', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD', '#FF8C42']
+function confettiStyle(i: number) {
+  const angle = (i / 24) * 360
+  const distance = 120 + (i % 5) * 40
+  const size = 6 + (i % 3) * 3
+  const color = CONFETTI_COLORS[i % CONFETTI_COLORS.length]
+  const delay = (i % 6) * 0.05
+  const rotation = (i * 47) % 360
+  return {
+    '--confetti-x': `${Math.cos(angle * Math.PI / 180) * distance}px`,
+    '--confetti-y': `${Math.sin(angle * Math.PI / 180) * distance}px`,
+    '--confetti-rotate': `${rotation}deg`,
+    '--confetti-delay': `${delay}s`,
+    width: `${size}px`,
+    height: `${size}px`,
+    background: color,
+    borderRadius: i % 3 === 0 ? '50%' : '2px',
+  }
+}
+
 function scrollToProgressionToggle() {
   const el = progressionToggleEl.value
   if (!el) return
@@ -1265,12 +1290,13 @@ function runMigrationIfNeeded() {
       progressionStore._persist()
       // Show celebration for each unlocked theme sequentially
       if (newUnlocks.length > 0) {
-        newUnlocks.forEach((themeId, i) => {
-          const theme = THEMES.find(t => t.id === themeId)
-          if (theme) {
-            setTimeout(() => showUnlockCelebration(theme.id, theme.label), 500 + i * 2500)
-          }
-        })
+        const unlockData = newUnlocks
+          .map(id => THEMES.find(t => t.id === id))
+          .filter((t): t is (typeof THEMES)[number] => !!t)
+          .map(t => ({ themeId: t.id, themeName: t.label }))
+        if (unlockData.length > 0) {
+          setTimeout(() => queueUnlockCelebrations(unlockData), 500)
+        }
       }
     }
     markMigrated()

--- a/src/components/BodyweightTracker.vue
+++ b/src/components/BodyweightTracker.vue
@@ -235,7 +235,7 @@ import { useTheme } from '../composables/useTheme'
 import { useUndoToast } from '../composables/useUndoToast'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { usePreferencesStore } from '../stores/preferences'
-import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
+import { useProgressionStore, showXPToast, queueUnlockCelebrations } from '../stores/progression'
 import { THEMES } from '../composables/useTheme'
 import { XP_CONFIG } from '../lib/xp'
 import { logBodyweightXPEvent } from '../lib/xpInstrumentation'
@@ -318,9 +318,12 @@ function save() {
       progressionStore.logBodyweightXP(date.value)
       const newUnlocks = progressionStore.checkUnlocks()
       if (newUnlocks.length > 0) {
-        const theme = THEMES.find(t => t.id === newUnlocks[0])
-        if (theme) {
-          setTimeout(() => showUnlockCelebration(theme.id, theme.label), progressionStore.showProgression ? 1500 : 500)
+        const unlockData = newUnlocks
+          .map(id => THEMES.find(t => t.id === id))
+          .filter((t): t is (typeof THEMES)[number] => !!t)
+          .map(t => ({ themeId: t.id, themeName: t.label }))
+        if (unlockData.length > 0) {
+          setTimeout(() => queueUnlockCelebrations(unlockData), progressionStore.showProgression ? 1500 : 500)
         }
       }
       if (!alreadyCredited) {

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -867,7 +867,7 @@ import { useUndoToast } from '../composables/useUndoToast'
 import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
-import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
+import { useProgressionStore, showXPToast, showUnlockCelebration, queueUnlockCelebrations } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
 import { calculateSetXP, calculateBest1RM, applyStreakMultiplier, checkRepPR, isExerciseEstablished, XP_CONFIG } from '../lib/xp'
@@ -945,10 +945,13 @@ function computeAndLogXP(exerciseId: string, setId: string, estimated1RM: number
     }
     const newUnlocks = progressionStore.checkUnlocks()
     if (newUnlocks.length > 0) {
-      const theme = THEMES.find(t => t.id === newUnlocks[0])
-      if (theme) {
+      const unlockData = newUnlocks
+        .map(id => THEMES.find(t => t.id === id))
+        .filter((t): t is (typeof THEMES)[number] => !!t)
+        .map(t => ({ themeId: t.id, themeName: t.label }))
+      if (unlockData.length > 0) {
         setTimeout(() => {
-          showUnlockCelebration(theme.id, theme.label)
+          queueUnlockCelebrations(unlockData)
           notifySuccess()
         }, progressionStore.showProgression ? 1500 : 500)
       }
@@ -987,7 +990,7 @@ function computeAndLogXP(exerciseId: string, setId: string, estimated1RM: number
     if (mult > 1) parts.push(`${mult}x streak`)
     parts.push(`${xp} XP`)
 
-    showXPToast(parts.join(' · '), progressionStore.progressPercent, progressionStore.totalXP, progressionStore.nextUnlockThreshold)
+    showXPToast(parts.join(' · '), progressionStore.progressPercent, progressionStore.totalXP, progressionStore.nextUnlockThreshold, isPR || isRepPR)
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -3845,6 +3845,18 @@ html.theme-fading .settingsSheet {
   transition: width 0.3s ease;
 }
 
+.xpGlobalToast--pr {
+  border-color: #FFD700;
+  color: #FFD700;
+  animation: xpPRPulse 1.5s ease-in-out 2;
+  box-shadow: 0 0 12px rgba(255, 215, 0, 0.3);
+}
+
+@keyframes xpPRPulse {
+  0%, 100% { box-shadow: 0 0 12px rgba(255, 215, 0, 0.3); }
+  50% { box-shadow: 0 0 24px rgba(255, 215, 0, 0.6); }
+}
+
 .xpGlobalFade-enter-active { transition: opacity 0.2s, transform 0.2s; }
 .xpGlobalFade-leave-active { transition: opacity 0.5s, transform 0.5s; }
 .xpGlobalFade-enter-from { opacity: 0; transform: translateX(-50%) translateY(-8px); }
@@ -3904,6 +3916,44 @@ html.theme-fading .settingsSheet {
   justify-content: center;
   z-index: 10001;
   padding: 24px;
+  overflow: hidden;
+}
+
+/* ─── Confetti particles ────────────────────────────────────────── */
+
+.confettiContainer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  pointer-events: none;
+}
+
+.confettiPiece {
+  position: absolute;
+  opacity: 0;
+  animation: confettiBurst 1.2s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+  animation-delay: var(--confetti-delay, 0s);
+}
+
+@keyframes confettiBurst {
+  0% {
+    transform: translate(0, 0) rotate(0deg) scale(0);
+    opacity: 1;
+  }
+  20% {
+    opacity: 1;
+    transform: translate(
+      calc(var(--confetti-x) * 0.3),
+      calc(var(--confetti-y) * 0.3)
+    ) rotate(calc(var(--confetti-rotate) * 0.5)) scale(1.2);
+  }
+  100% {
+    transform: translate(
+      var(--confetti-x),
+      calc(var(--confetti-y) + 80px)
+    ) rotate(var(--confetti-rotate)) scale(0.6);
+    opacity: 0;
+  }
 }
 
 .unlockModal {

--- a/src/stores/__tests__/progression.test.ts
+++ b/src/stores/__tests__/progression.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { getLocalStorageMock } from '../../__tests__/helpers'
 
@@ -8,7 +8,7 @@ vi.mock('../../lib/syncQueue', () => ({
   syncQueue: { enqueue: vi.fn() }
 }))
 
-import { useProgressionStore, getTrainingDaysInWeek, getUnlockedThemeIds, computeWeekXP } from '../progression'
+import { useProgressionStore, getTrainingDaysInWeek, getUnlockedThemeIds, computeWeekXP, xpToast, showXPToast, unlockCelebration, showUnlockCelebration, queueUnlockCelebrations, dismissUnlockCelebration } from '../progression'
 import type { SetXPEntry } from '../progression'
 import { XP_CONFIG } from '../../lib/xp'
 
@@ -673,6 +673,86 @@ describe('progression store', () => {
       // History records the raw combined (1.0 × 1.1 = 1.1)
       // The applyStreakMultiplier in xp.ts gates on streakCount < 1 and returns baseXP
       expect(lastEntry.combinedMultiplier).toBe(1.1)
+    })
+  })
+
+  // ── XP Toast isPR flag ──────────────────────────────────────────
+
+  describe('XP toast isPR flag', () => {
+    it('defaults isPR to false', () => {
+      showXPToast('test', 50, 1000, 5000)
+      expect(xpToast.isPR).toBe(false)
+      expect(xpToast.visible).toBe(true)
+    })
+
+    it('sets isPR to true when passed', () => {
+      showXPToast('PR! · 150 XP', 50, 1000, 5000, true)
+      expect(xpToast.isPR).toBe(true)
+    })
+
+    it('resets isPR on subsequent non-PR toast', () => {
+      showXPToast('PR!', 50, 1000, 5000, true)
+      expect(xpToast.isPR).toBe(true)
+      showXPToast('Working', 50, 1000, 5000)
+      expect(xpToast.isPR).toBe(false)
+    })
+  })
+
+  // ── Unlock celebration queue ────────────────────────────────────
+
+  describe('unlock celebration queue', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      unlockCelebration.visible = false
+      unlockCelebration.themeId = null
+      unlockCelebration.themeName = ''
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('shows single unlock immediately', () => {
+      queueUnlockCelebrations([{ themeId: 'fire', themeName: 'Fire' }])
+      expect(unlockCelebration.visible).toBe(true)
+      expect(unlockCelebration.themeId).toBe('fire')
+      expect(unlockCelebration.themeName).toBe('Fire')
+    })
+
+    it('queues multiple unlocks and shows them sequentially on dismiss', () => {
+      queueUnlockCelebrations([
+        { themeId: 'fire', themeName: 'Fire' },
+        { themeId: 'water', themeName: 'Water' },
+        { themeId: 'luck', themeName: 'Luck' },
+      ])
+
+      // First unlock shown immediately
+      expect(unlockCelebration.themeId).toBe('fire')
+
+      // Dismiss first → second appears after delay
+      dismissUnlockCelebration()
+      expect(unlockCelebration.visible).toBe(false)
+      vi.advanceTimersByTime(400)
+      expect(unlockCelebration.visible).toBe(true)
+      expect(unlockCelebration.themeId).toBe('water')
+
+      // Dismiss second → third appears after delay
+      dismissUnlockCelebration()
+      vi.advanceTimersByTime(400)
+      expect(unlockCelebration.themeId).toBe('luck')
+
+      // Dismiss third → no more
+      dismissUnlockCelebration()
+      vi.advanceTimersByTime(400)
+      expect(unlockCelebration.visible).toBe(false)
+    })
+
+    it('does not show next unlock if queue is empty', () => {
+      showUnlockCelebration('air', 'Air')
+      expect(unlockCelebration.visible).toBe(true)
+      dismissUnlockCelebration()
+      vi.advanceTimersByTime(500)
+      expect(unlockCelebration.visible).toBe(false)
     })
   })
 })

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -24,14 +24,16 @@ export const xpToast = reactive({
   progressPercent: 0,
   totalXP: 0,
   nextThresholdXP: null as number | null,
+  isPR: false,
   _timer: null as ReturnType<typeof setTimeout> | null,
 })
 
-export function showXPToast(text: string, progressPercent: number, totalXP: number, nextThresholdXP: number | null) {
+export function showXPToast(text: string, progressPercent: number, totalXP: number, nextThresholdXP: number | null, isPR = false) {
   xpToast.text = text
   xpToast.progressPercent = progressPercent
   xpToast.totalXP = totalXP
   xpToast.nextThresholdXP = nextThresholdXP
+  xpToast.isPR = isPR
   xpToast.visible = true
   if (xpToast._timer) clearTimeout(xpToast._timer)
   xpToast._timer = setTimeout(() => { xpToast.visible = false }, 4000)
@@ -44,14 +46,35 @@ export const unlockCelebration = reactive({
   themeName: '',
 })
 
+// Queue for showing multiple unlock celebrations sequentially
+const unlockQueue: Array<{ themeId: ThemeId; themeName: string }> = []
+
 export function showUnlockCelebration(themeId: ThemeId, themeName: string) {
   unlockCelebration.themeId = themeId
   unlockCelebration.themeName = themeName
   unlockCelebration.visible = true
 }
 
+export function queueUnlockCelebrations(unlocks: Array<{ themeId: ThemeId; themeName: string }>) {
+  unlockQueue.push(...unlocks)
+  if (!unlockCelebration.visible && unlockQueue.length > 0) {
+    showNextUnlock()
+  }
+}
+
+function showNextUnlock() {
+  const next = unlockQueue.shift()
+  if (next) {
+    showUnlockCelebration(next.themeId, next.themeName)
+  }
+}
+
 export function dismissUnlockCelebration() {
   unlockCelebration.visible = false
+  // Show next queued unlock after a short delay
+  if (unlockQueue.length > 0) {
+    setTimeout(showNextUnlock, 400)
+  }
 }
 
 export interface ThemeUnlock {

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -48,6 +48,7 @@ export const unlockCelebration = reactive({
 
 // Queue for showing multiple unlock celebrations sequentially
 const unlockQueue: Array<{ themeId: ThemeId; themeName: string }> = []
+let unlockTransitionTimer: ReturnType<typeof setTimeout> | null = null
 
 export function showUnlockCelebration(themeId: ThemeId, themeName: string) {
   unlockCelebration.themeId = themeId
@@ -57,12 +58,14 @@ export function showUnlockCelebration(themeId: ThemeId, themeName: string) {
 
 export function queueUnlockCelebrations(unlocks: Array<{ themeId: ThemeId; themeName: string }>) {
   unlockQueue.push(...unlocks)
-  if (!unlockCelebration.visible && unlockQueue.length > 0) {
+  // Only start showing if not already visible and no transition pending
+  if (!unlockCelebration.visible && !unlockTransitionTimer && unlockQueue.length > 0) {
     showNextUnlock()
   }
 }
 
 function showNextUnlock() {
+  unlockTransitionTimer = null
   const next = unlockQueue.shift()
   if (next) {
     showUnlockCelebration(next.themeId, next.themeName)
@@ -71,9 +74,14 @@ function showNextUnlock() {
 
 export function dismissUnlockCelebration() {
   unlockCelebration.visible = false
+  // Cancel any pending transition to prevent double-pop
+  if (unlockTransitionTimer) {
+    clearTimeout(unlockTransitionTimer)
+    unlockTransitionTimer = null
+  }
   // Show next queued unlock after a short delay
   if (unlockQueue.length > 0) {
-    setTimeout(showNextUnlock, 400)
+    unlockTransitionTimer = setTimeout(showNextUnlock, 400)
   }
 }
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-143](https://github.com/aschung212/Lift/issues/143)

Picked LIFT-143 — Enhanced celebrations for theme unlocks and PRs. This is a high-polish feature that makes the app's reward moments more satisfying, directly supporting the portfolio narrative of product taste.

## Changes
- Added CSS confetti particle burst animation (24 deterministic particles) to theme unlock celebration modal
- Added gold pulsing glow effect on XP toast when a PR is achieved (`isPR` flag)
- Built unlock celebration queue system — dismissing one unlock now reveals the next (previously only the first unlock was shown when multiple triggered simultaneously)
- Fixed race condition in queue (Gemini review catch) — rapid dismiss or overlapping queues can't double-pop
- Updated WorkoutTracker, BodyweightTracker, and App.vue to use the queue system
- Added 6 regression tests covering isPR toast flag and queue behavior

## Verification

### Steps to test
1. Navigate to Settings tab → enable Progression if not already enabled
2. Go to Workout tab, select an exercise, and log a set that beats your previous best (PR)
3. Observe the XP toast at the top of the screen
4. To test unlock celebration: if you're near an unlock threshold, log enough sets to cross it. Alternatively, use dev tools to set `totalXP` just below a threshold in localStorage's `user-progression` key, then log a set
5. When the unlock modal appears, tap "Nice!" to dismiss
6. If multiple themes unlock at once (e.g., after a bulk XP migration), each should appear sequentially after dismissing the previous one

### Expected behavior
- PR toast: gold border with pulsing glow animation (2 cycles), gold text instead of theme accent
- Regular toast: unchanged appearance (theme accent border/text, no glow)
- Unlock modal: confetti particles burst outward from center when modal appears, fade out after ~1.2s
- Multi-unlock: each dismiss reveals the next unlock after a 400ms fade transition
- Confetti uses varied colors, shapes (circles and rectangles), and trajectories

### What to watch for
- PR glow should be visible in all 9 themes, especially light mode variants where gold on light backgrounds may need contrast
- Confetti particles should not cause layout shift or overflow scrollbars
- Rapid tapping "Nice!" should not skip celebrations or show a flash of wrong theme
- The unlock queue should drain correctly — no stuck modals, no missing celebrations
- Toast auto-hides after 4s regardless of PR status

### Risk assessment
- **Scope:** Narrow — XP toast styling, unlock modal overlay, progression store queue logic
- **Confidence:** High — all existing 1181 tests pass plus 6 new tests, build clean, Gemini review clean after race condition fix
- **Rollback:** Simple revert of 2 commits, no data model changes

## Commits
- [`d433bfa`](https://github.com/aschung212/Lift/commit/d433bfa) fix(LIFT-143): prevent unlock queue race condition on rapid dismiss
- [`2e27bc8`](https://github.com/aschung212/Lift/commit/2e27bc8) feat(LIFT-143): enhanced celebrations — confetti, PR toast glow, multi-unlock queue
- [`cd64461`](https://github.com/aschung212/Lift/commit/cd64461) fix(LIFT-257): upgrade Vite 5.4→6.4.2 to fix path traversal vulnerability (#259)

## Test Results
- Before: 1181 passing
- After: 1187 passing (6 delta)

---
_Automated by overnight pipeline — Tue Apr  7 23:32:47 PDT 2026_

## Preview
Test on your phone: https://lift-nr40w6wvq-aschung212-1101s-projects.vercel.app