### PR TITLE
chore(LIFT-261): remove plate_loaded migration

### DIFF
--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -220,7 +220,6 @@ export const useWorkoutStore = defineStore('workout', {
           sets: [] as WorkoutSet[],
         }
         if (ex.input_mode) exercise.inputMode = ex.input_mode as ExerciseInputMode
-        if (ex.plate_loaded) exercise.inputMode = 'plates' // migrate old field
         if (ex.bar_weight != null) exercise.barWeight = ex.bar_weight as number
         return exercise
       })


### PR DESCRIPTION
## Summary
- Removes the `plate_loaded` → `inputMode: 'plates'` migration line
- Column was dropped from Supabase in favor of `input_mode` (text)

Closes #261

## Test plan
- [x] 1181 tests pass
- [x] `plate_loaded` column already dropped from production

🤖 Generated with [Claude Code](https://claude.com/claude-code)