### PR TITLE
a11y(LIFT-80): add up/down reorder buttons for WCAG 2.5.7 compliance

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -70,12 +70,30 @@
         :data-index="index"
       >
         <div class="wtExerciseHeader">
-          <span
-            :class="['wtDragHandle', { wtDragHandleDisabled: activeTagFilters.length > 0 }]"
-            @touchstart.prevent="activeTagFilters.length === 0 && onDragStart(index, $event)"
-            @mousedown="activeTagFilters.length === 0 && onDragStart(index, $event)"
-            aria-label="Drag to reorder"
-          >⠿</span>
+          <div :class="['wtReorderControls', { wtReorderDisabled: activeTagFilters.length > 0 }]">
+            <button
+              v-if="activeTagFilters.length === 0 && index > 0"
+              class="wtReorderBtn"
+              :aria-label="`Move ${exercise.name} up`"
+              @click="moveExercise(index, index - 1)"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"/></svg>
+            </button>
+            <span
+              :class="['wtDragHandle', { wtDragHandleDisabled: activeTagFilters.length > 0 }]"
+              @touchstart.prevent="activeTagFilters.length === 0 && onDragStart(index, $event)"
+              @mousedown="activeTagFilters.length === 0 && onDragStart(index, $event)"
+              aria-hidden="true"
+            >⠿</span>
+            <button
+              v-if="activeTagFilters.length === 0 && index < filteredExercises.length - 1"
+              class="wtReorderBtn"
+              :aria-label="`Move ${exercise.name} down`"
+              @click="moveExercise(index, index + 1)"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+          </div>
           <button
             class="wtExerciseRow"
             @click="openDetailModal(exercise.id)"
@@ -1209,6 +1227,12 @@ function onDragStart(index: number, _event: MouseEvent | TouchEvent) {
   document.addEventListener('touchend', onEnd, { once: true })
   document.addEventListener('mousemove', onMove)
   document.addEventListener('mouseup', onEnd, { once: true })
+}
+
+// ── Single-pointer reorder (WCAG 2.5.7) ─────────────────────────
+function moveExercise(fromIndex: number, toIndex: number) {
+  store.reorderExercise(fromIndex, toIndex)
+  logEvent('exercise_reorder')
 }
 
 // ── Set actions (tap-to-reveal) ──────────────────────────────────

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -223,6 +223,63 @@ describe('WorkoutTracker', () => {
       const handles = wrapper.findAll('.wtDragHandle')
       expect(handles.length).toBe(3)
     })
+
+    it('renders up/down reorder buttons (WCAG 2.5.7)', () => {
+      const wrapper = mountTracker()
+      const reorderBtns = wrapper.findAll('.wtReorderBtn')
+      // 3 exercises: first has only down, middle has up+down, last has only up = 4 buttons
+      expect(reorderBtns.length).toBe(4)
+    })
+
+    it('first exercise has no move-up button', () => {
+      const wrapper = mountTracker()
+      const items = wrapper.findAll('.wtExerciseItem')
+      const firstItem = items[0]
+      const upBtn = firstItem.findAll('.wtReorderBtn').filter(b =>
+        b.attributes('aria-label')?.includes('up')
+      )
+      expect(upBtn.length).toBe(0)
+    })
+
+    it('last exercise has no move-down button', () => {
+      const wrapper = mountTracker()
+      const items = wrapper.findAll('.wtExerciseItem')
+      const lastItem = items[items.length - 1]
+      const downBtn = lastItem.findAll('.wtReorderBtn').filter(b =>
+        b.attributes('aria-label')?.includes('down')
+      )
+      expect(downBtn.length).toBe(0)
+    })
+
+    it('move-down button calls reorderExercise', async () => {
+      const wrapper = mountTracker()
+      const items = wrapper.findAll('.wtExerciseItem')
+      const firstItem = items[0]
+      const downBtn = firstItem.findAll('.wtReorderBtn').find(b =>
+        b.attributes('aria-label')?.includes('down')
+      )!
+      await downBtn.trigger('click')
+      expect(mockReorderExercise).toHaveBeenCalledWith(0, 1)
+    })
+
+    it('move-up button calls reorderExercise', async () => {
+      const wrapper = mountTracker()
+      const items = wrapper.findAll('.wtExerciseItem')
+      const lastItem = items[items.length - 1]
+      const upBtn = lastItem.findAll('.wtReorderBtn').find(b =>
+        b.attributes('aria-label')?.includes('up')
+      )!
+      await upBtn.trigger('click')
+      expect(mockReorderExercise).toHaveBeenCalledWith(2, 1)
+    })
+
+    it('hides reorder buttons when tag filter is active', async () => {
+      const wrapper = mountTracker()
+      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
+      await chips[0].trigger('click')
+
+      expect(wrapper.findAll('.wtReorderBtn').length).toBe(0)
+    })
   })
 
   describe('tag filtering', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -2149,7 +2149,42 @@ html.theme-fading .settingsSheet {
 .wtExerciseLogBtn:hover  { background: var(--accent-subtle); }
 .wtExerciseLogBtn:active { opacity: 0.75; }
 
-/* ─── Drag handle ──────────────────────────────────────────────────────── */
+/* ─── Reorder controls (drag handle + WCAG 2.5.7 buttons) ─────────────── */
+
+.wtReorderControls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+}
+
+.wtReorderDisabled {
+  opacity: 0.25;
+  pointer-events: none;
+}
+
+.wtReorderBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  min-height: 22px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: color 0.15s, background-color 0.15s;
+}
+
+.wtReorderBtn:active {
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
 
 .wtDragHandle {
   display: flex;
@@ -2161,7 +2196,6 @@ html.theme-fading .settingsSheet {
   color: var(--text-muted);
   background: none;
   border: none;
-  border-right: 1px solid var(--border);
   cursor: grab;
   user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-80](https://github.com/aschung212/Lift/issues/80)

Picked LIFT-80 — WCAG 2.5.7 requires a single-pointer alternative to drag-to-reorder. This is a legally required accessibility compliance issue (ADA, European Accessibility Act) with a clear standard solution: up/down arrow buttons.

## Changes
- Added up/down chevron reorder buttons flanking the drag handle in the exercise list
- Buttons are conditionally rendered: first item has no "up", last item has no "down"
- Buttons are hidden when tag filters are active (matching existing drag handle behavior)
- Added `moveExercise()` function using the existing `store.reorderExercise()` + analytics
- Changed drag handle `aria-label` to `aria-hidden="true"` (buttons now provide the accessible action)
- Added CSS for `.wtReorderControls` and `.wtReorderBtn` using theme variables
- Added 6 regression tests: button count, boundary visibility, click behavior, filter hiding

## Verification

### Steps to test
1. Navigate to the Exercise Tracker tab (default view)
2. Ensure you have at least 3 exercises added
3. Look at the left edge of each exercise row — you should see small up/down chevron arrows flanking the ⠿ drag handle
4. Tap the down arrow on the first exercise — it should move to position 2
5. Tap the up arrow on the last exercise — it should move up one position
6. Verify the first exercise has NO up arrow, and the last exercise has NO down arrow
7. Activate a tag filter by tapping a tag chip
8. Verify the reorder arrows disappear when a filter is active
9. Clear the filter — verify arrows reappear

### Expected behavior
- Each exercise row shows a vertical stack: [up arrow] [⠿] [down arrow] on the left edge
- First exercise: only [⠿] [down arrow]
- Last exercise: only [up arrow] [⠿]
- Tapping arrows instantly reorders — no animation needed, list re-renders in new order
- With tag filter active, only the ⠿ shows (dimmed, non-interactive)

### What to watch for
- Touch targets too small on iPhone — each button should be comfortably tappable (44px wide, ~22px tall)
- Arrow color should match text-muted and adapt to all 9 themes
- Active state should flash accent color on tap
- Verify buttons don't cause layout shift when exercises reorder
- Test with only 1 exercise — should show no reorder buttons at all
- Test with exactly 2 exercises — first has only down, second has only up

### Risk assessment
- **Scope:** Narrow — only affects exercise list in WorkoutTracker exercises view
- **Confidence:** High — uses existing `reorderExercise` store method, same logic as drag, covered by 6 tests
- **Rollback:** Simple revert of one commit

## Commits
- [`d5593f1`](https://github.com/aschung212/Lift/commit/d5593f1) a11y(LIFT-80): add up/down reorder buttons for WCAG 2.5.7 compliance

## Test Results
- Before: 1181 passing
- After: 1187 passing (6 delta)

---
_Automated by overnight pipeline — Tue Apr  7 23:46:40 PDT 2026_

## Preview
Test on your phone: https://lift-j03huta9s-aschung212-1101s-projects.vercel.app