### PR TITLE
feat(LIFT-268): plate calculator clear empties weight field

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -591,7 +591,7 @@
           <div v-if="plateMode && !isEditMode" class="wtPlateCalc">
             <div class="wtPlateDisplayRow">
               <span class="wtPlateDisplaySpacer"></span>
-              <button v-if="!plateNumpadOverride" class="wtPlateWeightBtn" @click="onWeightInputFocus(); nextTick(() => { weightInputEl?.focus(); weightInputEl?.select() })">{{ weight || 0 }}</button>
+              <button v-if="!plateNumpadOverride" class="wtPlateWeightBtn" @click="onWeightInputFocus(); nextTick(() => { weightInputEl?.focus(); weightInputEl?.select() })">{{ weight != null ? weight : '—' }}</button>
               <input
                 v-else
                 ref="weightInputEl"
@@ -606,7 +606,7 @@
               />
               <span class="wtPlateDisplayAfter">
                 <span class="wtPlateWeightUnit">{{ weightUnit }}</span>
-                <button v-if="currentPlates.length > 0" class="wtPlateClearBtn" @click="currentPlates = []; syncPlateWeight()" aria-label="Clear plates">×</button>
+                <button v-if="currentPlates.length > 0 || weight" class="wtPlateClearBtn" @click="currentPlates = []; weight = null; weightStr = ''" aria-label="Clear weight">×</button>
               </span>
             </div>
             <div class="wtPlateGrid">
@@ -1993,8 +1993,6 @@ function playGoBeep() {
 
 const liveEstimate = computed(() => {
   if (!weight.value || weight.value <= 0 || !reps.value || reps.value < 1) return null
-  // In plate mode, bar-only (no plates) should show PR suggestion instead of live estimate
-  if (plateMode.value && currentPlates.value.length === 0) return null
   const w = toLbs(weight.value)
   const est = reps.value === 1 ? w : w * (1 + reps.value / 30)
   return displayWeight(Math.round(est))
@@ -2002,7 +2000,6 @@ const liveEstimate = computed(() => {
 
 const liveEstimateLbs = computed(() => {
   if (!weight.value || weight.value <= 0 || !reps.value || reps.value < 1) return null
-  if (plateMode.value && currentPlates.value.length === 0) return null
   const w = toLbs(weight.value)
   return reps.value === 1 ? Math.round(w) : Math.round(w * (1 + reps.value / 30))
 })
@@ -2022,9 +2019,8 @@ const isNewPR = computed(() => {
 // When only one field is filled, show what's needed in the other to beat the PR
 const prTargetWeight = computed<number | null>(() => {
   if (isEditMode.value || !reps.value || reps.value < 1) return null
-  // In plate mode, treat bar-only (no plates) as "no weight entered" for suggestions
-  const isBarOnly = plateMode.value && currentPlates.value.length === 0
-  if (!isBarOnly && weight.value && weight.value > 0) return null // both filled → show live estimate instead
+  // Show PR suggestion when weight is empty; show live estimate when weight is filled
+  if (weight.value && weight.value > 0) return null
   const id = selectedExerciseId.value
   if (!id || id === '__new__') return null
   const pr = store.getExercisePR(id)


### PR DESCRIPTION
## Summary
- Clear button (×) now sets weight to null instead of resetting to bar weight
- Empty weight displays as — (dash) in the plate calculator
- Removes `isBarOnly` special case — null weight is the explicit signal for PR suggestions

**Before:** Clear → bar weight shown → confusing why PR card appears instead of 1RM
**After:** Clear → dash shown → obvious weight is empty → PR card makes sense

Closes #268

## Test plan
- [x] 1181 tests pass, build succeeds
- [x] Enable plate calculator, add plates, press ×: weight shows —, PR suggestion appears
- [x] Enter reps with empty weight: PR suggestion card shows
- [x] Enter bar-only weight (no plates) + reps: estimated 1RM shows (not PR suggestion)
- [x] Save button disabled when weight is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)