### PR TITLE
fix(LIFT-270): move _resetCache above cleanupTombstones JSDoc

### DIFF
--- a/src/lib/__tests__/tombstones.test.ts
+++ b/src/lib/__tests__/tombstones.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  addTombstone,
+  removeTombstone,
+  isTombstoned,
+  cleanupTombstones,
+  _resetCache,
+} from '../tombstones'
+
+const STORAGE_KEY = 'lift-sync-tombstones'
+
+describe('tombstones', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    _resetCache()
+  })
+
+  // ── addTombstone / isTombstoned ─────────────────────────────────
+
+  describe('addTombstone + isTombstoned', () => {
+    it('marks an entity as tombstoned', () => {
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+    })
+
+    it('returns false for non-tombstoned entities', () => {
+      expect(isTombstoned('exercises', 'ex-999')).toBe(false)
+    })
+
+    it('persists tombstones to localStorage', () => {
+      addTombstone('sets', 's-1')
+      const raw = localStorage.getItem(STORAGE_KEY)
+      expect(raw).toBeTruthy()
+      const data = JSON.parse(raw!)
+      expect(data.sets).toContain('s-1')
+    })
+
+    it('handles multiple tombstones in the same store', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      addTombstone('exercises', 'ex-3')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+      expect(isTombstoned('exercises', 'ex-3')).toBe(true)
+    })
+
+    it('does not duplicate when adding the same id twice', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-1')
+      const raw = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      // Set ensures uniqueness — array should have exactly 1 entry
+      expect(raw.exercises.filter((id: string) => id === 'ex-1')).toHaveLength(1)
+    })
+  })
+
+  // ── Store isolation ─────────────────────────────────────────────
+
+  describe('store isolation', () => {
+    it('tombstones in one store do not affect another', () => {
+      addTombstone('exercises', 'shared-id')
+      expect(isTombstoned('exercises', 'shared-id')).toBe(true)
+      expect(isTombstoned('sets', 'shared-id')).toBe(false)
+    })
+
+    it('removing from one store does not affect another', () => {
+      addTombstone('exercises', 'shared-id')
+      addTombstone('sets', 'shared-id')
+      removeTombstone('exercises', 'shared-id')
+      expect(isTombstoned('exercises', 'shared-id')).toBe(false)
+      expect(isTombstoned('sets', 'shared-id')).toBe(true)
+    })
+  })
+
+  // ── removeTombstone ─────────────────────────────────────────────
+
+  describe('removeTombstone', () => {
+    it('removes a previously added tombstone', () => {
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+      removeTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+    })
+
+    it('is a no-op for non-existent tombstones', () => {
+      // Should not throw
+      removeTombstone('exercises', 'non-existent')
+      expect(isTombstoned('exercises', 'non-existent')).toBe(false)
+    })
+
+    it('removes only the specified tombstone, not others', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      removeTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+    })
+
+    it('cleans up store key from localStorage when last tombstone is removed', () => {
+      addTombstone('exercises', 'ex-1')
+      removeTombstone('exercises', 'ex-1')
+      const raw = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      // Store key should be deleted (not left as empty array)
+      expect(raw.exercises).toBeUndefined()
+    })
+  })
+
+  // ── cleanupTombstones ───────────────────────────────────────────
+
+  describe('cleanupTombstones', () => {
+    it('removes tombstones for ids no longer in remote', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      addTombstone('exercises', 'ex-3')
+
+      // ex-2 still exists remotely, ex-1 and ex-3 do not
+      const remoteIds = new Set(['ex-2'])
+      cleanupTombstones('exercises', remoteIds)
+
+      // ex-1 and ex-3 should be cleaned up (remote no longer has them)
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+      expect(isTombstoned('exercises', 'ex-3')).toBe(false)
+      // ex-2 should remain (still in remote, so tombstone is needed)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+    })
+
+    it('is a no-op when there are no tombstones', () => {
+      cleanupTombstones('exercises', new Set(['ex-1']))
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+    })
+
+    it('does not affect tombstones in other stores', () => {
+      addTombstone('exercises', 'shared-id')
+      addTombstone('sets', 'shared-id')
+
+      // Cleanup exercises only — remote has no ids, so all should be cleaned
+      cleanupTombstones('exercises', new Set())
+
+      expect(isTombstoned('exercises', 'shared-id')).toBe(false)
+      expect(isTombstoned('sets', 'shared-id')).toBe(true)
+    })
+
+    it('keeps all tombstones when all ids exist in remote', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+
+      cleanupTombstones('exercises', new Set(['ex-1', 'ex-2', 'ex-3']))
+
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+    })
+  })
+
+  // ── Edge cases ──────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles empty string store name', () => {
+      addTombstone('', 'id-1')
+      expect(isTombstoned('', 'id-1')).toBe(true)
+      removeTombstone('', 'id-1')
+      expect(isTombstoned('', 'id-1')).toBe(false)
+    })
+
+    it('handles empty string entity id', () => {
+      addTombstone('exercises', '')
+      expect(isTombstoned('exercises', '')).toBe(true)
+    })
+
+    it('recovers gracefully from corrupt localStorage data', () => {
+      localStorage.setItem(STORAGE_KEY, 'not-valid-json!!!')
+      _resetCache()
+      // Should not throw — falls back to empty state
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+      // Should still work after recovery
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+    })
+
+    it('works when localStorage key is missing entirely', () => {
+      localStorage.clear()
+      _resetCache()
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+    })
+  })
+})

--- a/src/lib/tombstones.ts
+++ b/src/lib/tombstones.ts
@@ -68,6 +68,11 @@ export function isTombstoned(store: string, id: string): boolean {
  * Remove tombstones for IDs that no longer exist in remote data.
  * Only operates on the specified store's tombstones — other stores are untouched.
  */
+/** Reset in-memory cache (for testing only). */
+export function _resetCache(): void {
+  _data = null
+}
+
 export function cleanupTombstones(store: string, remoteIds: Set<string>) {
   const ids = getStoreSet(store)
   if (ids.size === 0) return

--- a/src/lib/tombstones.ts
+++ b/src/lib/tombstones.ts
@@ -64,15 +64,15 @@ export function isTombstoned(store: string, id: string): boolean {
   return getStoreSet(store).has(id)
 }
 
-/**
- * Remove tombstones for IDs that no longer exist in remote data.
- * Only operates on the specified store's tombstones — other stores are untouched.
- */
 /** Reset in-memory cache (for testing only). */
 export function _resetCache(): void {
   _data = null
 }
 
+/**
+ * Remove tombstones for IDs that no longer exist in remote data.
+ * Only operates on the specified store's tombstones — other stores are untouched.
+ */
 export function cleanupTombstones(store: string, remoteIds: Set<string>) {
   const ids = getStoreSet(store)
   if (ids.size === 0) return


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-270](https://github.com/aschung212/Lift/issues/270)

Picked LIFT-270 — add unit tests for the tombstones module (offline delete tracking). This module prevents deleted entities from resurrecting during sync and had zero direct tests, unlike the other sync infrastructure (conflictResolver, syncQueue) which already had comprehensive coverage.

## Changes
- Added 19 unit tests for `tombstones.ts` covering:
  - Add/remove/check lifecycle
  - Store isolation (cross-store independence)
  - Cleanup after successful sync
  - Corrupt localStorage recovery
  - Edge cases (empty strings, duplicate adds, remove non-existent)
- Added `_resetCache()` test helper export following the established `_resetRateLimit()` pattern in syncQueue.ts
- Fixed JSDoc placement issue caught by Gemini review

## Verification

### Steps to test
1. This is a test-only change — no UI changes to verify visually
2. Run `npm test` to confirm all 1200 tests pass (including 19 new tombstone tests)
3. Run `npm run build` to confirm production build succeeds

### Expected behavior
- All 51 test files pass, 1200 total tests
- Build completes without errors
- No runtime behavior changes

### What to watch for
- The `_resetCache()` export is test-only — verify it's not imported anywhere in production code
- No functional changes to tombstone behavior, only added test coverage and a test helper

### Risk assessment
- **Scope:** Narrow — only adds a test file and one test-only export to tombstones.ts
- **Confidence:** High — all tests pass, no production logic changed
- **Rollback:** Trivial — revert the two commits

## Commits
- [`fe9405e`](https://github.com/aschung212/Lift/commit/fe9405e) fix(LIFT-270): move _resetCache above cleanupTombstones JSDoc
- [`0b66ffa`](https://github.com/aschung212/Lift/commit/0b66ffa) test(LIFT-270): add unit tests for tombstones module (offline delete tracking)
- [`d270a4f`](https://github.com/aschung212/Lift/commit/d270a4f) feat(LIFT-268): plate calculator clear empties weight field (#271)

## Test Results
- Before: 1181 passing
- After: 1200 passing (19 delta)

---
_Automated by overnight pipeline — Wed Apr  8 00:13:55 PDT 2026_

## Preview
Test on your phone: https://lift-4ja666l61-aschung212-1101s-projects.vercel.app