### PR TITLE
a11y(LIFT-272): add role="status" and aria-label to SkeletonLoader

### DIFF
--- a/src/components/SkeletonLoader.vue
+++ b/src/components/SkeletonLoader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="skeletonCard">
+  <div class="skeletonCard" role="status" aria-label="Loading content" aria-busy="true">
     <div class="skeletonHeader">
       <div class="skeletonBlock skeletonTitle"></div>
       <div class="skeletonBlock skeletonBtn"></div>

--- a/src/components/__tests__/SkeletonLoader.test.ts
+++ b/src/components/__tests__/SkeletonLoader.test.ts
@@ -42,4 +42,22 @@ describe('SkeletonLoader', () => {
     const wrapper = mount(SkeletonLoader, { props: { rows: 1 } })
     expect(wrapper.findAll('.skeletonRow')).toHaveLength(1)
   })
+
+  it('has role="status" for screen reader announcement', () => {
+    const wrapper = mount(SkeletonLoader)
+    const card = wrapper.find('.skeletonCard')
+    expect(card.attributes('role')).toBe('status')
+  })
+
+  it('has aria-label describing the loading state', () => {
+    const wrapper = mount(SkeletonLoader)
+    const card = wrapper.find('.skeletonCard')
+    expect(card.attributes('aria-label')).toBe('Loading content')
+  })
+
+  it('has aria-busy="true" to indicate loading', () => {
+    const wrapper = mount(SkeletonLoader)
+    const card = wrapper.find('.skeletonCard')
+    expect(card.attributes('aria-busy')).toBe('true')
+  })
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-272](https://github.com/aschung212/Lift/issues/272)

Picked LIFT-272 — SkeletonLoader was missing accessibility attributes, making it invisible to screen readers. Added `role="status"`, `aria-label="Loading content"`, and `aria-busy="true"` to the root element.

## Changes
- Added `role="status"`, `aria-label="Loading content"`, and `aria-busy="true"` to the `.skeletonCard` root div in `SkeletonLoader.vue`
- Added 3 regression tests pinning each accessibility attribute

## Verification

### Steps to test
1. Navigate to any screen that shows skeleton loaders during data loading (e.g., force a slow network in DevTools, or check initial app load)
2. Enable VoiceOver on iPhone (Settings → Accessibility → VoiceOver)
3. When skeleton loaders appear, swipe to them with VoiceOver active

### Expected behavior
- VoiceOver announces "Loading content" when the skeleton loader is focused
- The skeleton card is identified as a status region

### What to watch for
- Verify the announcement doesn't repeat excessively if multiple skeleton cards render simultaneously
- Check that the aria-label text is natural and not overly verbose
- Ensure no visual changes — this is purely an accessibility fix

### Risk assessment
- **Scope:** Narrow — only affects SkeletonLoader component (used as a placeholder during loading)
- **Confidence:** High — standard ARIA pattern, no behavioral changes, 3 tests pinning the attributes
- **Rollback:** Simple revert of one commit

## Commits
- [`2ab3cef`](https://github.com/aschung212/Lift/commit/2ab3cef) a11y(LIFT-272): add role="status" and aria-label to SkeletonLoader

## Test Results
- Before: 1181 passing
- After: 1184 passing (3 delta)

---
_Automated by overnight pipeline — Wed Apr  8 00:20:21 PDT 2026_

## Preview
Test on your phone: https://lift-a73674xte-aschung212-1101s-projects.vercel.app