### PR TITLE
a11y(LIFT-280): add role="button" and keyboard support to drag handles

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -74,7 +74,12 @@
             :class="['wtDragHandle', { wtDragHandleDisabled: activeTagFilters.length > 0 }]"
             @touchstart.prevent="activeTagFilters.length === 0 && onDragStart(index, $event)"
             @mousedown="activeTagFilters.length === 0 && onDragStart(index, $event)"
+            role="button"
+            tabindex="0"
+            :aria-disabled="activeTagFilters.length > 0"
             aria-label="Drag to reorder"
+            @keydown.space.prevent="activeTagFilters.length === 0 && onDragStart(index, $event)"
+            @keydown.enter.prevent="activeTagFilters.length === 0 && onDragStart(index, $event)"
           >⠿</span>
           <button
             class="wtExerciseRow"
@@ -745,8 +750,8 @@
   <!-- Exercise Picker (timeline + Log Set) -->
   <Teleport to="body">
     <div v-if="timelineLogPicking" class="repMaxOverlay" @click.self="timelineLogPicking = false" @keydown.escape="timelineLogPicking = false">
-      <div class="repMaxModal" role="dialog" aria-modal="true">
-        <h2>Choose Exercise</h2>
+      <div class="repMaxModal" role="dialog" aria-modal="true" aria-labelledby="exercisePickerTitle">
+        <h2 id="exercisePickerTitle">Choose Exercise</h2>
         <div class="wtExPickerList">
           <button
             v-for="ex in store.exercises"

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -223,6 +223,27 @@ describe('WorkoutTracker', () => {
       const handles = wrapper.findAll('.wtDragHandle')
       expect(handles.length).toBe(3)
     })
+
+    it('drag handles have role="button" and tabindex for assistive technology', () => {
+      const wrapper = mountTracker()
+      const handles = wrapper.findAll('.wtDragHandle')
+      handles.forEach(handle => {
+        expect(handle.attributes('role')).toBe('button')
+        expect(handle.attributes('tabindex')).toBe('0')
+        expect(handle.attributes('aria-label')).toBe('Drag to reorder')
+      })
+    })
+
+    it('drag handles have aria-disabled when tag filter is active', async () => {
+      const wrapper = mountTracker()
+      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
+      await chips[0].trigger('click')
+
+      const handles = wrapper.findAll('.wtDragHandle')
+      handles.forEach(handle => {
+        expect(handle.attributes('aria-disabled')).toBe('true')
+      })
+    })
   })
 
   describe('tag filtering', () => {


### PR DESCRIPTION
## Summary



## Changes




## Commits
- [`6bc45db`](https://github.com/aschung212/Lift/commit/6bc45db) a11y(LIFT-280): add role="button" and keyboard support to drag handles

## Test Results
- Before: 1181 passing
- After: 1183 passing (2 delta)

---
_Automated by overnight pipeline — Wed Apr  8 01:19:22 PDT 2026_

## Preview
Test on your phone: https://lift-7wcj44eup-aschung212-1101s-projects.vercel.app