### PR TITLE
a11y(LIFT-280): add role="button" and tabindex to drag handle

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -74,6 +74,9 @@
             :class="['wtDragHandle', { wtDragHandleDisabled: activeTagFilters.length > 0 }]"
             @touchstart.prevent="activeTagFilters.length === 0 && onDragStart(index, $event)"
             @mousedown="activeTagFilters.length === 0 && onDragStart(index, $event)"
+            role="button"
+            tabindex="0"
+            :aria-disabled="activeTagFilters.length > 0"
             aria-label="Drag to reorder"
           >⠿</span>
           <button

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -223,6 +223,26 @@ describe('WorkoutTracker', () => {
       const handles = wrapper.findAll('.wtDragHandle')
       expect(handles.length).toBe(3)
     })
+
+    it('drag handles have role="button", tabindex="0", and aria-label', () => {
+      const wrapper = mountTracker()
+      const handles = wrapper.findAll('.wtDragHandle')
+      for (const handle of handles) {
+        expect(handle.attributes('role')).toBe('button')
+        expect(handle.attributes('tabindex')).toBe('0')
+        expect(handle.attributes('aria-label')).toBe('Drag to reorder')
+      }
+    })
+
+    it('drag handles have aria-disabled when tag filter is active', async () => {
+      const wrapper = mountTracker()
+      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
+      const legsChip = chips.find(c => c.text() === 'Legs')!
+      await legsChip.trigger('click')
+      const handles = wrapper.findAll('.wtDragHandle')
+      const disabledHandles = handles.filter(h => h.attributes('aria-disabled') === 'true')
+      expect(disabledHandles.length).toBeGreaterThan(0)
+    })
   })
 
   describe('tag filtering', () => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-280](https://github.com/aschung212/Lift/issues/280)

Picked LIFT-280 — drag handle missing `role="button"` and `tabindex="0"`, making it invisible to assistive technology. Small, clean a11y fix with regression tests.

## Changes
- Added `role="button"` and `tabindex="0"` to the drag handle `<span>` in WorkoutTracker.vue
- Added `:aria-disabled` binding that reflects when tag filters disable reordering
- Added 2 regression tests: one verifying role/tabindex/aria-label, one verifying aria-disabled when filters are active

## Verification

### Steps to test
1. Navigate to the main workout tracker screen (first tab)
2. Ensure you have at least one exercise with logged sets
3. Inspect the drag handle (⠿ icon) to the left of each exercise name — it should be focusable via keyboard/VoiceOver
4. Activate a tag filter chip, then check that the drag handles announce as disabled

### Expected behavior
- VoiceOver should announce drag handles as "Drag to reorder, button"
- When a tag filter is active, VoiceOver should announce "Drag to reorder, dimmed, button"
- Visual appearance is unchanged

### What to watch for
- Drag-to-reorder still works by touch (the touch handler is unchanged)
- Tab order doesn't create unexpected focus traps
- No visual change to the drag handle icon

### Risk assessment
- **Scope:** Narrow — only the drag handle element in WorkoutTracker
- **Confidence:** High — attributes are additive, no behavior change
- **Rollback:** Revert single commit

## Commits
- [`b03abe3`](https://github.com/aschung212/Lift/commit/b03abe3) a11y(LIFT-280): add role="button" and tabindex to drag handle

## Test Results
- Before: 1181 passing
- After: 1183 passing (2 delta)

---
_Automated by overnight pipeline — Wed Apr  8 01:26:05 PDT 2026_

## Preview
Test on your phone: https://lift-ddcaadw63-aschung212-1101s-projects.vercel.app