### PR TITLE
chore: add Supabase generated types and typed client (#262)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:new": "npx supabase migration new",
     "db:status": "npx supabase migration list",
     "db:diff": "npx supabase db diff",
+    "db:types": "npx supabase gen types --linked --lang typescript 2>/dev/null > src/lib/database.types.ts",
     "cap:sync": "npx cap sync",
     "cap:open:ios": "npx cap open ios",
     "cap:run:ios": "npx cap run ios",

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -1,0 +1,451 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.4"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      bodyweight_entries: {
+        Row: {
+          created_at: string
+          date: string
+          id: string
+          user_id: string
+          weight: number
+        }
+        Insert: {
+          created_at?: string
+          date: string
+          id?: string
+          user_id: string
+          weight: number
+        }
+        Update: {
+          created_at?: string
+          date?: string
+          id?: string
+          user_id?: string
+          weight?: number
+        }
+        Relationships: []
+      }
+      exercises: {
+        Row: {
+          bar_weight: number
+          created_at: string
+          id: string
+          input_mode: string | null
+          name: string
+          tags: string[]
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          bar_weight?: number
+          created_at?: string
+          id?: string
+          input_mode?: string | null
+          name: string
+          tags?: string[]
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          bar_weight?: number
+          created_at?: string
+          id?: string
+          input_mode?: string | null
+          name?: string
+          tags?: string[]
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
+      progression_snapshots: {
+        Row: {
+          created_at: string
+          id: string
+          streak_weeks: number
+          themes_unlocked: number
+          total_xp: number
+          training_days: number
+          user_id: string
+          week_start: string
+          week_xp: number
+          weekly_target: number
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          streak_weeks?: number
+          themes_unlocked?: number
+          total_xp: number
+          training_days?: number
+          user_id: string
+          week_start: string
+          week_xp?: number
+          weekly_target?: number
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          streak_weeks?: number
+          themes_unlocked?: number
+          total_xp?: number
+          training_days?: number
+          user_id?: string
+          week_start?: string
+          week_xp?: number
+          weekly_target?: number
+        }
+        Relationships: []
+      }
+      sets: {
+        Row: {
+          created_at: string
+          date: string
+          estimated_1rm: number
+          exercise_id: string
+          id: string
+          reps: number
+          session_id: string | null
+          user_id: string
+          weight: number
+        }
+        Insert: {
+          created_at?: string
+          date: string
+          estimated_1rm: number
+          exercise_id: string
+          id?: string
+          reps: number
+          session_id?: string | null
+          user_id: string
+          weight: number
+        }
+        Update: {
+          created_at?: string
+          date?: string
+          estimated_1rm?: number
+          exercise_id?: string
+          id?: string
+          reps?: number
+          session_id?: string | null
+          user_id?: string
+          weight?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "sets_exercise_id_fkey"
+            columns: ["exercise_id"]
+            isOneToOne: false
+            referencedRelation: "exercises"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_preferences: {
+        Row: {
+          id: string
+          preferences: Json
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          id?: string
+          preferences?: Json
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          id?: string
+          preferences?: Json
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_progression: {
+        Row: {
+          bodyweight_xp_dates: Json
+          epoch: number
+          pending_target_change: number | null
+          progression_enabled: boolean
+          show_progression: boolean
+          starter_confirmed: boolean
+          starter_theme: string | null
+          streak_history: Json
+          streak_weeks: number
+          total_xp: number
+          unlocked_themes: Json
+          updated_at: string
+          user_id: string
+          weekly_target: number
+          xp_per_set: Json
+        }
+        Insert: {
+          bodyweight_xp_dates?: Json
+          epoch?: number
+          pending_target_change?: number | null
+          progression_enabled?: boolean
+          show_progression?: boolean
+          starter_confirmed?: boolean
+          starter_theme?: string | null
+          streak_history?: Json
+          streak_weeks?: number
+          total_xp?: number
+          unlocked_themes?: Json
+          updated_at?: string
+          user_id: string
+          weekly_target?: number
+          xp_per_set?: Json
+        }
+        Update: {
+          bodyweight_xp_dates?: Json
+          epoch?: number
+          pending_target_change?: number | null
+          progression_enabled?: boolean
+          show_progression?: boolean
+          starter_confirmed?: boolean
+          starter_theme?: string | null
+          streak_history?: Json
+          streak_weeks?: number
+          total_xp?: number
+          unlocked_themes?: Json
+          updated_at?: string
+          user_id?: string
+          weekly_target?: number
+          xp_per_set?: Json
+        }
+        Relationships: []
+      }
+      xp_events: {
+        Row: {
+          active_theme: string | null
+          base_xp: number
+          epoch: number
+          exercise_id: string | null
+          final_xp: number
+          id: string
+          is_pr: boolean
+          is_rep_pr: boolean
+          is_tie: boolean
+          logged_at: string
+          set_date: string | null
+          set_id: string
+          streak_multiplier: number
+          user_id: string
+          zone: string
+        }
+        Insert: {
+          active_theme?: string | null
+          base_xp: number
+          epoch?: number
+          exercise_id?: string | null
+          final_xp: number
+          id?: string
+          is_pr?: boolean
+          is_rep_pr?: boolean
+          is_tie?: boolean
+          logged_at?: string
+          set_date?: string | null
+          set_id: string
+          streak_multiplier?: number
+          user_id: string
+          zone: string
+        }
+        Update: {
+          active_theme?: string | null
+          base_xp?: number
+          epoch?: number
+          exercise_id?: string | null
+          final_xp?: number
+          id?: string
+          is_pr?: boolean
+          is_rep_pr?: boolean
+          is_tie?: boolean
+          logged_at?: string
+          set_date?: string | null
+          set_id?: string
+          streak_multiplier?: number
+          user_id?: string
+          zone?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,5 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { ref } from 'vue'
+import type { Database } from './database.types'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
@@ -16,6 +17,6 @@ export const isPreviewDeploy: boolean =
 /** Reactive flag — true when writes should be blocked. Starts true on preview deploys, can be toggled. */
 export const isPreviewMode = ref(isPreviewDeploy)
 
-export const supabase: SupabaseClient | null = !import.meta.env.DEV && supabaseUrl && supabaseAnonKey
-  ? createClient(supabaseUrl, supabaseAnonKey)
+export const supabase: SupabaseClient<Database> | null = !import.meta.env.DEV && supabaseUrl && supabaseAnonKey
+  ? createClient<Database>(supabaseUrl, supabaseAnonKey)
   : null

--- a/src/lib/xpInstrumentation.ts
+++ b/src/lib/xpInstrumentation.ts
@@ -44,7 +44,7 @@ export function logXPEvent(data: XPEventData): void {
   syncQueue.enqueue(`xp-event:${data.setId}`, () =>
     supabase!.from('xp_events').upsert({
       set_id: data.setId,
-      user_id: data.userId,
+      user_id: data.userId!,
       exercise_id: data.exerciseId,
       set_date: data.setDate,
       base_xp: data.baseXP,
@@ -88,7 +88,7 @@ export function logWeeklySnapshot(data: WeeklySnapshotData): void {
 
   syncQueue.enqueue(`progression-snapshot:${data.weekStart}`, () =>
     supabase!.from('progression_snapshots').upsert({
-      user_id: data.userId,
+      user_id: data.userId!,
       week_start: data.weekStart,
       total_xp: data.totalXP,
       week_xp: data.weekXP,

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -104,10 +104,11 @@ export const usePreferencesStore = defineStore('preferences', {
             .select('preferences')
             .eq('user_id', userId)
             .single()
-          if (data?.preferences?.features) {
-            this.features = { ...DEFAULTS, ...data.preferences.features }
-            if (data.preferences.weightGoal) {
-              this.weightGoal = _migrateWeightGoal(data.preferences.weightGoal)
+          const prefs = data?.preferences as Record<string, unknown> | null
+          if (prefs?.features) {
+            this.features = { ...DEFAULTS, ...prefs.features as Record<string, boolean> }
+            if (prefs.weightGoal) {
+              this.weightGoal = _migrateWeightGoal(prefs.weightGoal as { target?: number; unit?: string })
             }
             localStorage.setItem(STORAGE_KEY, JSON.stringify({ features: this.features, weightGoal: this.weightGoal }))
           }

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -8,6 +8,7 @@ import type { ThemeId } from '../composables/useTheme'
 import type { StreakHistoryEntry } from '../lib/xp'
 import { XP_CONFIG } from '../lib/xp'
 import { logError, logWarn } from '../lib/logger'
+import type { Json } from '../lib/database.types'
 
 const STORAGE_KEY = 'user-progression'
 
@@ -280,7 +281,7 @@ export const useProgressionStore = defineStore('progression', {
       this.starterTheme = (data.starter_theme as ThemeId | null) ?? this.starterTheme
       this.starterConfirmed = (data.starter_confirmed as boolean) ?? this.starterConfirmed
       this.epoch = (data.epoch as number) ?? this.epoch
-      this.streakHistory = (data.streak_history as StreakWeekEntry[]) ?? this.streakHistory
+      this.streakHistory = (data.streak_history as unknown as StreakWeekEntry[]) ?? this.streakHistory
 
       // Merge collection fields — union strategy, no data loss
       const remoteThemes = migrateUnlockedThemes((data.unlocked_themes as unknown) ?? [])
@@ -317,13 +318,13 @@ export const useProgressionStore = defineStore('progression', {
         pending_target_change: this.pendingTargetChange,
         show_progression: this.showProgression,
         progression_enabled: this.progressionEnabled,
-        unlocked_themes: this.unlockedThemes,
+        unlocked_themes: this.unlockedThemes as unknown as Json,
         starter_theme: this.starterTheme,
         starter_confirmed: this.starterConfirmed,
         epoch: this.epoch,
-        streak_history: this.streakHistory,
-        xp_per_set: this.xpPerSet,
-        bodyweight_xp_dates: this.bodyweightXPDates,
+        streak_history: this.streakHistory as unknown as Json,
+        xp_per_set: this.xpPerSet as unknown as Json,
+        bodyweight_xp_dates: this.bodyweightXPDates as unknown as Json,
       }
       syncQueue.enqueue('progression-sync', () =>
         supabase!.from('user_progression').upsert(payload)


### PR DESCRIPTION
## Summary
Closes #262

- Generate `database.types.ts` from the linked Supabase project schema
- Pass `Database` generic to `createClient<Database>()` so all queries are typed
- Fix 8 type errors surfaced by the typed client
- Add `npm run db:types` script for easy regeneration after schema changes

## Impact
The compiler now catches column mismatches at build time, preventing the class of bugs from #261 where code wrote to columns that didn't exist.

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] All 1195 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)