### PR TITLE
chore: automate Supabase migrations in CI on merge to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,35 @@ jobs:
 
       - run: npx vitest run --coverage
 
+  # Push unapplied Supabase migrations on merge to master.
+  # Runs before Vercel deploys so the DB schema is ready for the new code.
+  migrate-db:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link Supabase project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+
+      - name: Push migrations
+        run: supabase db push --linked
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
   # Notify Slack on post-merge success (push to master only)
   notify-deploy:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, migrate-db]
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Notify Slack
@@ -57,7 +82,7 @@ jobs:
   # Notify Slack on post-merge failure (push to master only)
   notify-failure:
     runs-on: ubuntu-latest
-    needs: build-and-test
+    needs: [build-and-test, migrate-db]
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Notify Slack


### PR DESCRIPTION
## Summary
Part of #262 — automates migration deployment so schema changes can't be forgotten.

- New `migrate-db` CI job runs `supabase db push --linked` on merge to master
- Runs after build-and-test passes, before Slack notification
- Notify jobs depend on migrate-db so Slack reports migration failures

## Setup required
```bash
gh secret set SUPABASE_ACCESS_TOKEN --repo aschung212/Lift
gh secret set SUPABASE_DB_PASSWORD --repo aschung212/Lift
# SUPABASE_PROJECT_REF already set
```

## Test plan
- [x] YAML syntax valid
- [ ] Set secrets, merge, verify migrate-db job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)