### PR TITLE
fix: filter bot-probe noise in Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,15 +25,14 @@ if (sentryDsn && import.meta.env.PROD) {
       environment: import.meta.env.MODE,
       tracesSampleRate: 0.1,
       enabled: true,
+      denyUrls: [
+        // Bot probes for CMS/REST endpoints that don't exist in this SPA
+        /\/js\/rest\//,
+        /\/wp-(admin|content|includes)\//,
+        /\/xmlrpc\.php/,
+      ],
       beforeSend(event) {
         if (event.request?.cookies) delete event.request.cookies
-        // Drop SecurityErrors from bot-probed paths (e.g. /js/rest/field)
-        if (
-          event.exception?.values?.some((e) => e.type === 'SecurityError') &&
-          window.location.pathname !== '/'
-        ) {
-          return null
-        }
         return event
       },
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,13 @@ if (sentryDsn && import.meta.env.PROD) {
       enabled: true,
       beforeSend(event) {
         if (event.request?.cookies) delete event.request.cookies
+        // Drop SecurityErrors from bot-probed paths (e.g. /js/rest/field)
+        if (
+          event.exception?.values?.some((e) => e.type === 'SecurityError') &&
+          window.location.pathname !== '/'
+        ) {
+          return null
+        }
         return event
       },
     })


### PR DESCRIPTION
## Summary
- Adds Sentry `denyUrls` config to drop errors from known bot-probe paths (`/js/rest/`, `/wp-admin/`, `/xmlrpc.php`)
- Fixes noisy `SecurityError` alerts caused by bots scanning for CMS/REST endpoints that don't exist in this SPA
- Uses Sentry's built-in filtering instead of a broad `beforeSend` heuristic, so real app errors are never suppressed

## Context
Sentry reported a `SecurityError` at `/js/rest/field` from Mobile Safari — a bot probing for Jira/Confluence REST APIs. Initial fix filtered all `SecurityError`s on non-root paths, but Codex review flagged that as too broad (would suppress real errors on deep links). Tightened to target-specific bot-probe URL patterns only.

## Test plan
- [ ] Verify Sentry stops reporting `/js/rest/field` SecurityErrors
- [ ] Confirm real app errors still appear in Sentry dashboard
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)