### PR TITLE
fix: add +/− prefixes to plate calculator buttons

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -611,11 +611,11 @@
             </div>
             <div class="wtPlateGrid">
               <div v-for="denom in activeDenominations" :key="denom" class="wtPlateCol">
-                <button class="wtPlateBtn wtPlateBtnAdd" @click="addPlate(denom)" :aria-label="`Add ${denom}`">{{ denom }}</button>
+                <button class="wtPlateBtn wtPlateBtnAdd" @click="addPlate(denom)" :aria-label="`Add ${denom}`">+{{ denom }}</button>
                 <div class="wtPlateCountBox" :class="{ wtPlateCountActive: plateCounts.get(denom) }">
                   <span class="wtPlateCountNum">{{ plateCounts.get(denom) || 0 }}</span>
                 </div>
-                <button class="wtPlateBtn wtPlateBtnRemove" @click="removePlate(denom)" :disabled="!currentPlates.includes(denom)" :aria-label="`Remove ${denom}`">{{ denom }}</button>
+                <button class="wtPlateBtn wtPlateBtnRemove" @click="removePlate(denom)" :disabled="!currentPlates.includes(denom)" :aria-label="`Remove ${denom}`">−{{ denom }}</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Plate calculator buttons now show `+45`, `−45` etc. instead of just `45`
- Color (green/red) is kept as secondary reinforcement, but the +/− prefix makes the action unambiguous

## Test plan
- [ ] Open plate calculator for any exercise in plates mode
- [ ] Verify top row buttons show `+` prefix, bottom row shows `−` prefix
- [ ] Verify disabled state still works on remove buttons when count is 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)