### PR TITLE
fix: make plate calc starting weight tappable for numpad

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -459,7 +459,20 @@
                     <span class="iosSettingsRowLabel">Starting weight</span>
                     <div class="iosStepper">
                       <button class="iosStepperBtn" @click="newExerciseBarWeight = Math.max(0, newExerciseBarWeight - 5)" aria-label="Decrease weight">−</button>
-                      <span class="iosStepperValue">{{ newExerciseBarWeight }} {{ weightUnit }}</span>
+                      <input
+                        v-if="newBarWeightEditing"
+                        ref="newBarWeightInputEl"
+                        :value="newExerciseBarWeight"
+                        type="text"
+                        inputmode="numeric"
+                        autocomplete="off"
+                        class="iosStepperInput"
+                        aria-label="Starting weight"
+                        @focus="($event.target as HTMLInputElement)?.select()"
+                        @blur="newBarWeightEditing = false"
+                        @change="newExerciseBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); newBarWeightEditing = false"
+                      />
+                      <button v-else class="iosStepperValue iosStepperValueTappable" @click="newBarWeightEditing = true; nextTick(() => newBarWeightInputEl?.focus())">{{ newExerciseBarWeight }} {{ weightUnit }}</button>
                       <button class="iosStepperBtn" @click="newExerciseBarWeight = Math.min(MAX_WEIGHT, newExerciseBarWeight + 5)" aria-label="Increase weight">+</button>
                     </div>
                   </div>
@@ -714,7 +727,20 @@
                 <span class="iosSettingsRowLabel">Starting weight</span>
                 <div class="iosStepper">
                   <button class="iosStepperBtn" @click="editBarWeight = Math.max(0, editBarWeight - 5)" aria-label="Decrease weight">−</button>
-                  <span class="iosStepperValue">{{ editBarWeight }} {{ weightUnit }}</span>
+                  <input
+                    v-if="editBarWeightEditing"
+                    ref="editBarWeightInputEl"
+                    :value="editBarWeight"
+                    type="text"
+                    inputmode="numeric"
+                    autocomplete="off"
+                    class="iosStepperInput"
+                    aria-label="Starting weight"
+                    @focus="($event.target as HTMLInputElement)?.select()"
+                    @blur="editBarWeightEditing = false"
+                    @change="editBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); editBarWeightEditing = false"
+                  />
+                  <button v-else class="iosStepperValue iosStepperValueTappable" @click="editBarWeightEditing = true; nextTick(() => editBarWeightInputEl?.focus())">{{ editBarWeight }} {{ weightUnit }}</button>
                   <button class="iosStepperBtn" @click="editBarWeight = Math.min(MAX_WEIGHT, editBarWeight + 5)" aria-label="Increase weight">+</button>
                 </div>
               </div>
@@ -1448,6 +1474,8 @@ const newExerciseTagInput = ref('')
 const newExercisePlateMode = ref(false)
 const newExercisePlateCountMode = ref<PlateCountMode>('per-side')
 const newExerciseBarWeight = ref(45)
+const newBarWeightEditing = ref(false)
+const newBarWeightInputEl = ref<HTMLInputElement | null>(null)
 // String-based raw inputs to avoid iOS keyboard dismissal on type="number"
 // Vue writing back the parsed number to el.value causes iOS Safari to dismiss
 // the keyboard after each keystroke. Using type="text" + inputmode avoids this.
@@ -2279,6 +2307,8 @@ const newTagInput = ref('')
 const editPlateMode = ref(false)
 const editPlateCountMode = ref<'per-side' | 'total'>('per-side')
 const editBarWeight = ref<number>(45)
+const editBarWeightEditing = ref(false)
+const editBarWeightInputEl = ref<HTMLInputElement | null>(null)
 
 
 function openEditExerciseModal(exercise: Exercise) {

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -469,8 +469,7 @@
                         class="iosStepperInput"
                         aria-label="Starting weight"
                         @focus="($event.target as HTMLInputElement)?.select()"
-                        @blur="newBarWeightEditing = false"
-                        @change="newExerciseBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); newBarWeightEditing = false"
+                        @blur="newExerciseBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); newBarWeightEditing = false"
                       />
                       <button v-else class="iosStepperValue iosStepperValueTappable" @click="newBarWeightEditing = true; nextTick(() => newBarWeightInputEl?.focus())">{{ newExerciseBarWeight }} {{ weightUnit }}</button>
                       <button class="iosStepperBtn" @click="newExerciseBarWeight = Math.min(MAX_WEIGHT, newExerciseBarWeight + 5)" aria-label="Increase weight">+</button>
@@ -737,8 +736,7 @@
                     class="iosStepperInput"
                     aria-label="Starting weight"
                     @focus="($event.target as HTMLInputElement)?.select()"
-                    @blur="editBarWeightEditing = false"
-                    @change="editBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); editBarWeightEditing = false"
+                    @blur="editBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); editBarWeightEditing = false"
                   />
                   <button v-else class="iosStepperValue iosStepperValueTappable" @click="editBarWeightEditing = true; nextTick(() => editBarWeightInputEl?.focus())">{{ editBarWeight }} {{ weightUnit }}</button>
                   <button class="iosStepperBtn" @click="editBarWeight = Math.min(MAX_WEIGHT, editBarWeight + 5)" aria-label="Increase weight">+</button>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -468,10 +468,10 @@
                         autocomplete="off"
                         class="iosStepperInput"
                         aria-label="Starting weight"
-                        @focus="($event.target as HTMLInputElement)?.select()"
+                        @focus="($event.target as HTMLInputElement)?.select(); scrollInputAboveKeyboard($event.target as HTMLElement)"
                         @blur="newExerciseBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); newBarWeightEditing = false"
                       />
-                      <button v-else class="iosStepperValue iosStepperValueTappable" @click="newBarWeightEditing = true; nextTick(() => { newBarWeightInputEl?.focus(); newBarWeightInputEl?.scrollIntoView({ block: 'center', behavior: 'smooth' }) })">{{ newExerciseBarWeight }} {{ weightUnit }}</button>
+                      <button v-else class="iosStepperValue iosStepperValueTappable" @click="newBarWeightEditing = true; nextTick(() => newBarWeightInputEl?.focus())">{{ newExerciseBarWeight }} {{ weightUnit }}</button>
                       <button class="iosStepperBtn" @click="newExerciseBarWeight = Math.min(MAX_WEIGHT, newExerciseBarWeight + 5)" aria-label="Increase weight">+</button>
                     </div>
                   </div>
@@ -735,10 +735,10 @@
                     autocomplete="off"
                     class="iosStepperInput"
                     aria-label="Starting weight"
-                    @focus="($event.target as HTMLInputElement)?.select()"
+                    @focus="($event.target as HTMLInputElement)?.select(); scrollInputAboveKeyboard($event.target as HTMLElement)"
                     @blur="editBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); editBarWeightEditing = false"
                   />
-                  <button v-else class="iosStepperValue iosStepperValueTappable" @click="editBarWeightEditing = true; nextTick(() => { editBarWeightInputEl?.focus(); editBarWeightInputEl?.scrollIntoView({ block: 'center', behavior: 'smooth' }) })">{{ editBarWeight }} {{ weightUnit }}</button>
+                  <button v-else class="iosStepperValue iosStepperValueTappable" @click="editBarWeightEditing = true; nextTick(() => editBarWeightInputEl?.focus())">{{ editBarWeight }} {{ weightUnit }}</button>
                   <button class="iosStepperBtn" @click="editBarWeight = Math.min(MAX_WEIGHT, editBarWeight + 5)" aria-label="Increase weight">+</button>
                 </div>
               </div>
@@ -2157,6 +2157,22 @@ const bestWeightAtReps = computed<number | null>(() => {
 })
 
 const MAX_WEIGHT = 2000
+
+/** Scroll an input above the iOS keyboard after the keyboard finishes animating */
+function scrollInputAboveKeyboard(el: HTMLElement) {
+  setTimeout(() => {
+    const modal = el.closest('.repMaxModal')
+    if (!modal) return
+    const vv = window.visualViewport
+    if (vv) {
+      const inputRect = el.getBoundingClientRect()
+      const visibleBottom = vv.offsetTop + vv.height
+      if (inputRect.bottom > visibleBottom - 16) {
+        modal.scrollTop += inputRect.bottom - visibleBottom + 60
+      }
+    }
+  }, 400)
+}
 const MAX_REPS = 200
 const hasSetData = computed(() => weight.value !== null && weight.value > 0 && weight.value <= MAX_WEIGHT && reps.value !== null && reps.value >= 1 && reps.value <= MAX_REPS)
 

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2158,19 +2158,30 @@ const bestWeightAtReps = computed<number | null>(() => {
 
 const MAX_WEIGHT = 2000
 
-/** Scroll an input above the iOS keyboard after the keyboard finishes animating */
+/** Shrink modal to fit above iOS keyboard, then scroll input into view */
 function scrollInputAboveKeyboard(el: HTMLElement) {
   setTimeout(() => {
-    const modal = el.closest('.repMaxModal')
+    const modal = el.closest('.repMaxModal') as HTMLElement | null
     if (!modal) return
     const vv = window.visualViewport
-    if (vv) {
+    if (!vv) return
+    // Shrink modal so it fits within the visible viewport above the keyboard
+    const availableHeight = vv.height - 96
+    modal.style.maxHeight = `${availableHeight}px`
+    // Scroll the input into view within the now-scrollable modal
+    nextTick(() => {
       const inputRect = el.getBoundingClientRect()
       const visibleBottom = vv.offsetTop + vv.height
       if (inputRect.bottom > visibleBottom - 16) {
         modal.scrollTop += inputRect.bottom - visibleBottom + 60
       }
+    })
+    // Restore max-height when keyboard dismisses
+    const restore = () => {
+      modal.style.maxHeight = ''
+      vv.removeEventListener('resize', restore)
     }
+    vv.addEventListener('resize', restore)
   }, 400)
 }
 const MAX_REPS = 200

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -471,7 +471,7 @@
                         @focus="($event.target as HTMLInputElement)?.select()"
                         @blur="newExerciseBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); newBarWeightEditing = false"
                       />
-                      <button v-else class="iosStepperValue iosStepperValueTappable" @click="newBarWeightEditing = true; nextTick(() => newBarWeightInputEl?.focus())">{{ newExerciseBarWeight }} {{ weightUnit }}</button>
+                      <button v-else class="iosStepperValue iosStepperValueTappable" @click="newBarWeightEditing = true; nextTick(() => { newBarWeightInputEl?.focus(); newBarWeightInputEl?.scrollIntoView({ block: 'center', behavior: 'smooth' }) })">{{ newExerciseBarWeight }} {{ weightUnit }}</button>
                       <button class="iosStepperBtn" @click="newExerciseBarWeight = Math.min(MAX_WEIGHT, newExerciseBarWeight + 5)" aria-label="Increase weight">+</button>
                     </div>
                   </div>
@@ -738,7 +738,7 @@
                     @focus="($event.target as HTMLInputElement)?.select()"
                     @blur="editBarWeight = Math.max(0, Math.min(MAX_WEIGHT, Math.round(Number(($event.target as HTMLInputElement).value) || 0))); editBarWeightEditing = false"
                   />
-                  <button v-else class="iosStepperValue iosStepperValueTappable" @click="editBarWeightEditing = true; nextTick(() => editBarWeightInputEl?.focus())">{{ editBarWeight }} {{ weightUnit }}</button>
+                  <button v-else class="iosStepperValue iosStepperValueTappable" @click="editBarWeightEditing = true; nextTick(() => { editBarWeightInputEl?.focus(); editBarWeightInputEl?.scrollIntoView({ block: 'center', behavior: 'smooth' }) })">{{ editBarWeight }} {{ weightUnit }}</button>
                   <button class="iosStepperBtn" @click="editBarWeight = Math.min(MAX_WEIGHT, editBarWeight + 5)" aria-label="Increase weight">+</button>
                 </div>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3688,6 +3688,30 @@ html.theme-fading .settingsSheet {
   line-height: 36px;
 }
 
+.iosStepperValueTappable {
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.iosStepperInput {
+  min-width: 56px;
+  width: 56px;
+  text-align: center;
+  font-size: var(--font-callout);
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--bg-base);
+  border: none;
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  padding: 0 8px;
+  line-height: 36px;
+  height: 36px;
+  font-family: inherit;
+  outline: none;
+}
+
 .iosSettingsFooter {
   display: block;
   font-size: var(--font-caption2);


### PR DESCRIPTION
## Summary
- Starting weight value in plate calculator settings is now tappable to bring up an inline numpad input
- Eliminates the need to tap +/− 9 times to go from 0 → 45
- Applied to both new exercise and edit exercise modals
- Stepper buttons still work for ±5 fine-tuning

## Test plan
- [ ] New exercise → enable plate calculator → tap the weight value → numpad appears, enter a number, blur to confirm
- [ ] Edit exercise → same flow
- [ ] Verify +/− stepper buttons still work alongside tappable input
- [ ] Verify input clamps to 0–2000 range
- [ ] Test on iOS Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)