### PR TITLE
fix: round PR target weight to achievable plate increments

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2077,7 +2077,10 @@ const prTargetWeight = computed<number | null>(() => {
   if (pr <= 0) return null
   // Account for Epley rounding: round(w * (1 + r/30)) > pr triggers at pr + 0.5
   const target = pr + 0.5
-  const targetLbs = reps.value === 1 ? Math.ceil(target) : Math.ceil(target / (1 + reps.value / 30))
+  const rawLbs = reps.value === 1 ? Math.ceil(target) : Math.ceil(target / (1 + reps.value / 30))
+  // Round up to nearest achievable weight increment (5 lbs or 2.5 kg)
+  const increment = weightUnit.value === 'kg' ? Math.round(2.5 / 0.453592) : 5
+  const targetLbs = Math.ceil(rawLbs / increment) * increment
   return displayWeight(targetLbs)
 })
 


### PR DESCRIPTION
## Summary
- PR target suggestion card was showing arbitrary weights (e.g. 316 lbs) that can't be loaded on a bar
- Now rounds up to the nearest 5 lb increment (2.5 kg in kg mode)
- Matches the behavior of the PR targets table

## Test plan
- [ ] Open log modal, enter reps only → PR target shows a weight divisible by 5
- [ ] Verify in kg mode → weight divisible by 2.5
- [ ] In plate mode, tap to load plates → plates load correctly for the rounded weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)