### PR TITLE
fix: enable skipWaiting and defer Supabase SDK load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -715,7 +715,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, onMounted, onUnmounted, defineAsyncComponent, type ComponentPublicInstance } from 'vue'
-import { isPreviewDeploy, isPreviewMode } from './lib/supabase'
+import { isPreviewDeploy, isPreviewMode, initSupabase } from './lib/supabase'
 import ErrorBoundary from './components/ErrorBoundary.vue'
 import AuthScreen from './components/AuthScreen.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
@@ -829,7 +829,7 @@ const sortedThemes = computed(() => {
   return [...unlocked, ...locked]
 })
 
-const { user, loading, signOut, deleteAccount } = useAuth()
+const { user, loading, init: initAuth, signOut, deleteAccount } = useAuth()
 const { logEvent, tabSwitch, flushEngagement } = useAnalytics()
 const prefs = usePreferencesStore()
 const { toast: undoToast, performUndo } = useUndoToast()
@@ -1639,6 +1639,9 @@ function onBeforeUnload() {
 onMounted(async () => {
   window.addEventListener('beforeunload', onBeforeUnload)
   logEvent('session_start')
+
+  // Load Supabase SDK off the critical render path, then start auth
+  initSupabase().then(() => initAuth())
 
   // Request persistent storage to prevent browser eviction
   requestPersistentStorage()

--- a/src/App.vue
+++ b/src/App.vue
@@ -1640,8 +1640,19 @@ onMounted(async () => {
   window.addEventListener('beforeunload', onBeforeUnload)
   logEvent('session_start')
 
-  // Load Supabase SDK off the critical render path, then start auth
-  initSupabase().then(() => initAuth())
+  // Load Supabase SDK off the critical render path, then start auth.
+  // If the SDK fails to load (offline first visit, network error), fall
+  // back to local-only mode so the app still renders from localStorage.
+  initSupabase()
+    .then(() => initAuth())
+    .catch(() => initAuth())
+
+  // When skipWaiting activates a new SW, reload to pick up fresh chunk hashes.
+  // Without this, lazy-loaded tabs would request old hashed filenames that the
+  // new SW's precache no longer contains, causing ChunkLoadErrors.
+  navigator.serviceWorker?.addEventListener('controllerchange', () => {
+    window.location.reload()
+  })
 
   // Request persistent storage to prevent browser eviction
   requestPersistentStorage()

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -63,8 +63,6 @@ function init(): void {
   })
 }
 
-init()
-
 async function signInWithProvider(provider: Provider): Promise<{ error: AuthError | null }> {
   if (!supabase) return { error: { message: 'Supabase not configured' } }
   const { error } = await supabase.auth.signInWithOAuth({
@@ -161,5 +159,5 @@ async function deleteAccount(): Promise<void> {
 }
 
 export function useAuth() {
-  return { user, loading, signInWithProvider, signInWithEmail, signUp, signOut, devSignIn, deleteAccount }
+  return { user, loading, init, signInWithProvider, signInWithEmail, signUp, signOut, devSignIn, deleteAccount }
 }

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -36,13 +36,13 @@ function init(): void {
   if (_initialized) return
   _initialized = true
 
-  // Dev mode: show auth screen, allow instant sign-in via devSignIn()
-  if (import.meta.env.DEV) {
+  // Dev mode or Supabase unavailable: fall back to local-only mode
+  if (import.meta.env.DEV || !supabase) {
     loading.value = false
     return
   }
 
-  supabase!.auth.getSession().then(({ data: { session } }) => {
+  supabase.auth.getSession().then(({ data: { session } }) => {
     user.value = session?.user ?? null
     if (session?.user) {
       initStores(session.user.id).then(() => { loading.value = false })
@@ -54,7 +54,7 @@ function init(): void {
     loading.value = false
   })
 
-  supabase!.auth.onAuthStateChange((_event, session) => {
+  supabase.auth.onAuthStateChange((_event, session) => {
     const prev = user.value
     user.value = session?.user ?? null
     if (session?.user && !prev) {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 import { ref } from 'vue'
 import type { Database } from './database.types'
 
@@ -17,6 +17,12 @@ export const isPreviewDeploy: boolean =
 /** Reactive flag — true when writes should be blocked. Starts true on preview deploys, can be toggled. */
 export const isPreviewMode = ref(isPreviewDeploy)
 
-export const supabase: SupabaseClient<Database> | null = !import.meta.env.DEV && supabaseUrl && supabaseAnonKey
-  ? createClient<Database>(supabaseUrl, supabaseAnonKey)
-  : null
+/** Supabase client — null until initSupabase() resolves. */
+export let supabase: SupabaseClient<Database> | null = null
+
+/** Lazily load the Supabase SDK and create the client. */
+export async function initSupabase(): Promise<void> {
+  if (import.meta.env.DEV || !supabaseUrl || !supabaseAnonKey) return
+  const { createClient } = await import('@supabase/supabase-js')
+  supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -90,6 +90,7 @@ export default defineConfig({
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
         clientsClaim: true,
+        skipWaiting: true,
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,


### PR DESCRIPTION
## Summary
- **skipWaiting** prevents stale service workers from serving deleted asset paths after redeployment, which caused `TypeError: text/html is not a valid JavaScript MIME type` crashes
- **Deferred Supabase SDK** removes ~51 KB gzipped from the critical render path via dynamic import — app renders from localStorage immediately, Supabase loads after mount
- **Edge case hardening**: `.catch()` fallback for offline first visits, null guard for missing env vars, `controllerchange` reload to prevent ChunkLoadErrors with lazy-loaded tabs

## Test plan
- [ ] Verify app loads and renders workout data on iOS simulator
- [ ] Verify auth flow still works (sign in, sign out)
- [ ] Verify Supabase sync works after deferred load
- [ ] Verify offline/local-only mode works when Supabase unavailable
- [ ] Verify tab switching works (lazy-loaded chunks load correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)