### PR TITLE
feat: add PR badges to timeline view

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1077,12 +1077,12 @@ const timelinePRMap = computed((): Record<string, 'pr' | 'repPR'> => {
         map[s.id] = 'pr'
       }
     }
-    // Rep PR: best reps at each weight (only for sets that aren't already a weight PR)
+    // Rep PR: best reps at each weight (computed across ALL sets to get true baseline)
     const bestRepsAtWeight: Record<number, number> = {}
     for (const s of ex.sets) {
-      if (map[s.id]) continue
       bestRepsAtWeight[s.weight] = Math.max(bestRepsAtWeight[s.weight] ?? 0, s.reps)
     }
+    // Only assign repPR badge to non-weight-PR sets
     for (const s of ex.sets) {
       if (!map[s.id] && s.reps === bestRepsAtWeight[s.weight] && ex.sets.filter(o => o.weight === s.weight).length > 1) {
         map[s.id] = 'repPR'

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -117,6 +117,8 @@
               <div class="wtTimelineRowMain">
                 <span class="wtTimelineExName">{{ entry.exerciseName }}</span>
                 <span class="wtTimelineSetDetail">{{ displayWeight(entry.set.weight) }} {{ weightUnit }} × {{ entry.set.reps }}</span>
+                <span v-if="timelinePRMap[entry.set.id] === 'pr'" class="wtTimelineBadge" aria-label="Personal record">🏆</span>
+                <span v-else-if="timelinePRMap[entry.set.id] === 'repPR'" class="wtTimelineBadge" aria-label="Rep personal record">🔥</span>
                 <span class="wtTimelineE1RM">~{{ displayWeight(entry.set.estimated1RM) }}</span>
               </div>
               <div v-if="activeSetId === entry.set.id" class="wtSetActions">
@@ -1060,6 +1062,34 @@ const timelineSets = computed((): TimelineEntry[] => {
     }
   }
   return entries.sort((a, b) => b.set.date.slice(0, 10).localeCompare(a.set.date.slice(0, 10)))
+})
+
+// PR badge map: for each set, determine if it's the all-time best e1RM (weight PR)
+// or the best reps at its weight (rep PR) for that exercise
+const timelinePRMap = computed((): Record<string, 'pr' | 'repPR'> => {
+  const map: Record<string, 'pr' | 'repPR'> = {}
+  for (const ex of store.exercises) {
+    if (ex.sets.length === 0) continue
+    const best1RM = Math.max(...ex.sets.map(s => s.estimated1RM))
+    // Weight PR: the set(s) that achieved the all-time best e1RM
+    for (const s of ex.sets) {
+      if (s.estimated1RM === best1RM) {
+        map[s.id] = 'pr'
+      }
+    }
+    // Rep PR: best reps at each weight (only for sets that aren't already a weight PR)
+    const bestRepsAtWeight: Record<number, number> = {}
+    for (const s of ex.sets) {
+      if (map[s.id]) continue
+      bestRepsAtWeight[s.weight] = Math.max(bestRepsAtWeight[s.weight] ?? 0, s.reps)
+    }
+    for (const s of ex.sets) {
+      if (!map[s.id] && s.reps === bestRepsAtWeight[s.weight] && ex.sets.filter(o => o.weight === s.weight).length > 1) {
+        map[s.id] = 'repPR'
+      }
+    }
+  }
+  return map
 })
 
 const visibleTimelineGroups = computed(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -2005,6 +2005,12 @@ html.theme-fading .settingsSheet {
   white-space: nowrap;
 }
 
+.wtTimelineBadge {
+  margin-left: 4px;
+  font-size: var(--font-footnote);
+  line-height: 1;
+}
+
 .wtTimelineE1RM {
   font-size: var(--font-caption1);
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Show 🏆 for weight PRs (all-time best e1RM) and 🔥 for rep PRs (best reps at a given weight) in the timeline view
- Badges are computed from exercise set data, not the progression store, so they work with sample/onboarding data too
- Added `.wtTimelineBadge` CSS class for emoji sizing

## Test plan
- [x] TypeScript strict mode passes
- [x] All 1197 tests pass
- [x] Verified in iPhone 16 Pro simulator with sample data — trophies and fire emojis display correctly
- [ ] Verify on real device after preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)