### PR TITLE
fix: move timeline PR badges after e1RM

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -117,9 +117,9 @@
               <div class="wtTimelineRowMain">
                 <span class="wtTimelineExName">{{ entry.exerciseName }}</span>
                 <span class="wtTimelineSetDetail">{{ displayWeight(entry.set.weight) }} {{ weightUnit }} × {{ entry.set.reps }}</span>
+                <span class="wtTimelineE1RM">~{{ displayWeight(entry.set.estimated1RM) }}</span>
                 <span v-if="timelinePRMap[entry.set.id] === 'pr'" class="wtTimelineBadge" aria-label="Personal record">🏆</span>
                 <span v-else-if="timelinePRMap[entry.set.id] === 'repPR'" class="wtTimelineBadge" aria-label="Rep personal record">🔥</span>
-                <span class="wtTimelineE1RM">~{{ displayWeight(entry.set.estimated1RM) }}</span>
               </div>
               <div v-if="activeSetId === entry.set.id" class="wtSetActions">
                 <button class="wtSetBtn" @click.stop="openEditModal(store.exercises.find(e => e.id === entry.exerciseId)!, entry.set)" aria-label="Edit set">Edit</button>


### PR DESCRIPTION
## Summary
- Move 🏆 and 🔥 badges to render after the e1RM value so they align vertically on the right edge of each timeline row

## Test plan
- [x] Verified in iPhone 16 Pro simulator — badges align on the right after e1RM values
- [ ] Verify on real device after preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)