### PR TITLE
fix: consolidate duplicate SW controllerchange listeners

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -439,15 +439,6 @@
       </Transition>
     </Teleport>
 
-    <!-- SW updated toast (informational, auto-dismisses) -->
-    <Teleport to="body">
-      <Transition name="undoToast">
-        <div v-if="swUpdated" class="undoToastBar swUpdateBar" role="status" aria-live="polite">
-          <span class="undoToastMsg">App updated ✓</span>
-        </div>
-      </Transition>
-    </Teleport>
-
     <!-- Keyboard shortcuts help -->
     <Teleport to="body">
       <Transition name="undoToast">
@@ -900,7 +891,6 @@ function onSettingsSheetMounted(el: Element | ComponentPublicInstance | null) {
 }
 
 // ── Service worker auto-update ──────────────────────────────────
-const swUpdated = ref(false)
 let swRegistration: ServiceWorkerRegistration | undefined
 registerSW({
   onRegisteredSW(_url, registration) {
@@ -919,13 +909,14 @@ document.addEventListener('visibilitychange', () => {
 // Expose a function components can call after meaningful user actions
 function checkForSWUpdate() { swRegistration?.update() }
 
-// Listen for the controlling SW changing — means auto-update activated
+// Listen for the controlling SW changing — means auto-update activated.
+// On first visit currentController is null; skip reload to avoid a surprise refresh.
+// On subsequent changes a new SW took over — reload to pick up fresh chunk hashes
+// (without this, lazy-loaded tabs request old hashed filenames that no longer exist).
 let currentController = navigator.serviceWorker?.controller
 navigator.serviceWorker?.addEventListener('controllerchange', () => {
   if (currentController) {
-    // A new SW took over — show informational toast, then auto-dismiss
-    swUpdated.value = true
-    setTimeout(() => { swUpdated.value = false }, 4000)
+    window.location.reload()
   }
   currentController = navigator.serviceWorker?.controller ?? null
 })
@@ -1646,13 +1637,6 @@ onMounted(async () => {
   initSupabase()
     .then(() => initAuth())
     .catch(() => initAuth())
-
-  // When skipWaiting activates a new SW, reload to pick up fresh chunk hashes.
-  // Without this, lazy-loaded tabs would request old hashed filenames that the
-  // new SW's precache no longer contains, causing ChunkLoadErrors.
-  navigator.serviceWorker?.addEventListener('controllerchange', () => {
-    window.location.reload()
-  })
 
   // Request persistent storage to prevent browser eviction
   requestPersistentStorage()

--- a/src/index.css
+++ b/src/index.css
@@ -5688,10 +5688,6 @@ html.theme-fading .settingsSheet {
   background: var(--accent-subtle);
 }
 
-.swUpdateBar {
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 124px);
-}
-
 .undoToast-enter-active {
   animation: undoToastIn 0.25s ease-out;
 }


### PR DESCRIPTION
## Summary
- Merged two competing `controllerchange` listeners into one: guards against first-visit reload, reloads on actual SW updates to prevent stale chunk errors
- Removed dead toast code (`swUpdated` ref, `swUpdateBar` CSS) that was never visible due to the reload

## Context
Sentry reported `TypeError: Importing a module script failed` in production on iPhone/Safari. Root cause: users with cached old HTML tried to load JS chunks whose hashed filenames changed in the new deploy. The existing reload listener was supposed to prevent this but had two issues:
1. Duplicate listener in `onMounted` reloaded unconditionally (even on first visit)
2. Race condition where lazy imports could fail before the reload fired

## Test plan
- [x] TypeScript strict mode passes
- [x] All 1197 tests pass
- [ ] Verify no surprise reload on first visit in production
- [ ] Monitor Sentry for recurrence of chunk import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)