### PR TITLE
feat: configurable PR baseline for training blocks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -260,6 +260,42 @@
               </div>
             </div>
 
+            <div class="settingsGroup">
+              <div class="settingsHeader">Personal Records</div>
+              <div class="settingsRow">
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel">Evaluate PRs since</span>
+                  <span class="settingsHint">{{ formatBaselineLabel(prBaselineDate) }}</span>
+                </div>
+                <div class="settingsInputWrap">
+                  <input
+                    type="date"
+                    class="settingsInput"
+                    :value="prBaselineDate ?? ''"
+                    :max="new Date().toISOString().slice(0,10)"
+                    @change="onBaselineDateInput(($event.target as HTMLInputElement).value)"
+                    aria-label="PR baseline date"
+                  />
+                  <button
+                    v-if="prBaselineDate"
+                    class="settingsInputClear"
+                    @click="clearPRBaseline()"
+                    aria-label="Clear PR baseline (use all time)"
+                  >×</button>
+                </div>
+              </div>
+              <div class="settingsRow">
+                <button class="settingsRevealBtn" @click="confirmStartNewTrainingBlock">
+                  Start new training block
+                </button>
+              </div>
+              <div class="settingsRow">
+                <span class="settingsHint">
+                  PRs are evaluated against sets on or after this date. Your XP history and past workouts are never modified.
+                </span>
+              </div>
+            </div>
+
             <!-- Dev tools — only on localhost/LAN -->
             <div v-if="isDev" class="settingsGroup">
               <div class="settingsHeader">Dev Tools</div>
@@ -730,6 +766,7 @@ const BodyweightTracker = defineAsyncComponent({
   delay: 100,
 })
 import { useTheme, connectProgressionStore, type ThemeId } from './composables/useTheme'
+import { usePRBaseline } from './composables/usePRBaseline'
 import { useProgressionStore, UNLOCK_TIERS, xpToast, unlockCelebration, dismissUnlockCelebration, showUnlockCelebration, showXPToast } from './stores/progression'
 import { computeThemeStats, type ThemeStats } from './lib/themeStats'
 import { isMigrated, markMigrated, clearMigrationFlag, computeRetroactiveXP } from './lib/xpMigration'
@@ -750,6 +787,27 @@ import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
 import { registerSW } from 'virtual:pwa-register'
 
 const { currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode, glassEnabled, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, selectTheme: themeSelectFn, previewTheme, revertPreview, isThemeUnlocked } = useTheme()
+const { prBaselineDate, setPRBaseline, startNewTrainingBlock, clearPRBaseline } = usePRBaseline()
+
+function formatBaselineLabel(iso: string | null): string {
+  if (!iso) return 'All time'
+  const d = new Date(iso + 'T12:00:00')
+  if (isNaN(d.getTime())) return 'All time'
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+function onBaselineDateInput(value: string) {
+  if (!value) clearPRBaseline()
+  else setPRBaseline(value)
+}
+
+function confirmStartNewTrainingBlock() {
+  const nextLabel = new Date().toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  showConfirm(
+    `Start a new training block from ${nextLabel}? PRs will be evaluated only against sets from today onward. Your XP history stays intact.`,
+    () => { startNewTrainingBlock() }
+  )
+}
 const progressionStore = useProgressionStore()
 connectProgressionStore(() => progressionStore)
 

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -288,6 +288,7 @@ import { ref, computed, watch, nextTick } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
 import { useAnalytics } from '../composables/useAnalytics'
 import { useTheme } from '../composables/useTheme'
+import { usePRBaseline } from '../composables/usePRBaseline'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { useTagVolume } from '../composables/useTagVolume'
 import { useTagRecovery } from '../composables/useTagRecovery'
@@ -296,6 +297,7 @@ import MuscleGroupRecovery from './MuscleGroupRecovery.vue'
 
 const store = useWorkoutStore()
 const { weightUnit, displayWeight, toLbs } = useTheme()
+const { prBaselineDate } = usePRBaseline()
 const { logEvent } = useAnalytics()
 
 // ── Tag filtering ────────────────────────────────────────────────
@@ -358,18 +360,21 @@ const trainingMap = computed(() => {
   return map
 })
 
-// Map YYYY-MM-DD → Set of exercise names that achieved an all-time PR on that date
-// Only the first set to reach the PR value counts — ties on later dates are not new records
+// Map YYYY-MM-DD → Set of exercise names that achieved a PR on that date.
+// Only the first set to reach the PR value counts — ties on later dates are not new records.
+// Respects the PR baseline: when set, only sets on/after the baseline count.
 const prMap = computed(() => {
   const map: Record<string, Set<string>> = {}
+  const baseline = prBaselineDate.value
   for (const exercise of filteredExercises.value) {
-    const pr = store.getExercisePR(exercise.id)
+    const pr = store.getExercisePR(exercise.id, baseline)
     if (!pr) continue
-    // Find the earliest date any set hit the PR value
+    // Find the earliest date (within baseline window) any set hit the PR value
     let earliestDate = ''
     for (const set of exercise.sets) {
+      const day = set.date.slice(0, 10)
+      if (baseline && day < baseline) continue
       if (set.estimated1RM === pr) {
-        const day = set.date.slice(0, 10)
         if (!earliestDate || day < earliestDate) earliestDate = day
       }
     }
@@ -406,7 +411,7 @@ const daySummary = computed(() => {
     for (const s of daySets) {
       totalVolume += s.weight * s.reps
     }
-    const pr = store.getExercisePR(exercise.id)
+    const pr = store.getExercisePR(exercise.id, prBaselineDate.value)
     if (pr && daySets.some(s => s.estimated1RM === pr)) {
       prCount++
     }
@@ -440,7 +445,7 @@ function toggleDetail(dateStr: string, exName: string) {
 function getSetsForDay(dateStr: string, exName: string) {
   const exercise = store.exercises.find(e => e.name === exName)
   if (!exercise) return []
-  const pr = store.getExercisePR(exercise.id)
+  const pr = store.getExercisePR(exercise.id, prBaselineDate.value)
   const dayStr = dateStr.slice(0, 10)
   // Only mark as PR if this is the earliest date the PR was achieved
   const isPRDay = prMap.value[dayStr]?.has(exName) ?? false

--- a/src/components/ExerciseGraph.vue
+++ b/src/components/ExerciseGraph.vue
@@ -81,9 +81,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useTheme } from '../composables/useTheme'
+import { usePRBaseline } from '../composables/usePRBaseline'
 import type { Exercise } from '../stores/workout'
 
 const { weightUnit, displayWeight } = useTheme()
+const { prBaselineDate } = usePRBaseline()
 
 const props = defineProps<{
   exercise: Exercise
@@ -102,11 +104,15 @@ const PAD_B = 26
 const chartW = W - PAD_L - PAD_R
 const chartH = H - PAD_T - PAD_B
 
-// Best estimated1RM per calendar date, sorted chronologically
+// Best estimated1RM per calendar date, sorted chronologically.
+// Filters to sets on/after the PR baseline when set — keeps the graph aligned
+// with the user's current training block view.
 const dailyBest = computed((): [string, number][] => {
   const byDate: Record<string, number> = {}
+  const baseline = prBaselineDate.value
   for (const s of props.exercise.sets) {
     const day = s.date.slice(0, 10) // YYYY-MM-DD
+    if (baseline && day < baseline) continue
     if (!byDate[day] || s.estimated1RM > byDate[day]) {
       byDate[day] = s.estimated1RM
     }

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -86,9 +86,9 @@
           >
             <div class="wtExerciseNameBlock">
               <span class="wtExerciseName">{{ exercise.name }}</span>
-              <span v-if="store.getExercisePRSet(exercise.id)" class="wtExerciseMeta">
-                Est. 1RM: {{ displayWeight(store.getExercisePRSet(exercise.id)!.estimated1RM) }} {{ weightUnit }}
-                ({{ displayWeight(store.getExercisePRSet(exercise.id)!.weight) }} × {{ store.getExercisePRSet(exercise.id)!.reps }})
+              <span v-if="store.getExercisePRSet(exercise.id, prBaselineDate)" class="wtExerciseMeta">
+                Est. 1RM: {{ displayWeight(store.getExercisePRSet(exercise.id, prBaselineDate)!.estimated1RM) }} {{ weightUnit }}
+                ({{ displayWeight(store.getExercisePRSet(exercise.id, prBaselineDate)!.weight) }} × {{ store.getExercisePRSet(exercise.id, prBaselineDate)!.reps }})
               </span>
             </div>
             <span class="wtChevron">›</span>
@@ -179,7 +179,7 @@
                     :key="set.id"
                     class="wtSetRow"
                     :class="{
-                      wtSetRowPR: set.estimated1RM === store.getExercisePR(detailExercise.id) && set.date.slice(0,10) === detailPRDate,
+                      wtSetRowPR: set.estimated1RM === store.getExercisePR(detailExercise.id, prBaselineDate) && set.date.slice(0,10) === detailPRDate,
                       'wtSetRowActive': activeSetId === set.id,
                     }"
                     @click="toggleSetActions(set.id)"
@@ -187,7 +187,7 @@
                     <span class="wtSetDetail">{{ displayWeight(set.weight) }} {{ weightUnit }} × {{ set.reps }}</span>
                     <span class="wtSet1RM">
                       ~{{ displayWeight(set.estimated1RM) }} {{ weightUnit }}
-                      <span v-if="set.estimated1RM === store.getExercisePR(detailExercise.id) && set.date.slice(0,10) === detailPRDate" class="wtSetPR">🏆</span>
+                      <span v-if="set.estimated1RM === store.getExercisePR(detailExercise.id, prBaselineDate) && set.date.slice(0,10) === detailPRDate" class="wtSetPR">🏆</span>
                     </span>
                     <div v-if="activeSetId === set.id" class="wtSetActions">
                       <button
@@ -557,7 +557,7 @@
           <div v-if="!isEditMode && isLogForExercise && prTargetsTable" class="wtPrTargets">
             <button class="wtPrTargetsHeader" @click="prTableExpanded = !prTableExpanded" :aria-expanded="prTableExpanded">
               <span class="wtPrTargetsTitle">PR Targets</span>
-              <span class="wtPrTargetsSub">Beat {{ displayWeight(store.getExercisePR(selectedExerciseId)) }} {{ weightUnit }} e1RM</span>
+              <span class="wtPrTargetsSub">Beat {{ displayWeight(store.getExercisePR(selectedExerciseId, prBaselineDate)) }} {{ weightUnit }} e1RM</span>
               <svg :class="['wtPrTargetsChevron', { wtPrTargetsChevronOpen: prTableExpanded }]" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
             </button>
             <div v-if="prTableExpanded" class="wtPrTargetsList">
@@ -919,6 +919,7 @@ import { useUndoToast } from '../composables/useUndoToast'
 import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
+import { usePRBaseline } from '../composables/usePRBaseline'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
@@ -932,6 +933,15 @@ const { logEvent } = useAnalytics()
 const { show: showUndo } = useUndoToast()
 const { currentTheme, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, setRestTimerEnabled } = useTheme()
 const { impactLight, notifySuccess } = useHaptics()
+const { prBaselineDate } = usePRBaseline()
+
+// Filter sets to those on/after the user-set PR baseline.
+// When no baseline is set, returns sets unchanged (legacy all-time behavior).
+function filterSetsSinceBaseline<T extends { date: string }>(sets: T[]): T[] {
+  const baseline = prBaselineDate.value
+  if (!baseline) return sets
+  return sets.filter(s => s.date.slice(0, 10) >= baseline)
+}
 
 function computeAndLogXP(exerciseId: string, setId: string, estimated1RM: number, weight: number, reps: number) {
   const exercise = store.exercises.find(e => e.id === exerciseId)
@@ -939,15 +949,18 @@ function computeAndLogXP(exerciseId: string, setId: string, estimated1RM: number
 
   // Best 1RM from existing sets (before this set was added, it's already in the array)
   const otherSets = exercise.sets.filter(s => s.id !== setId)
-  const rawBest1RM = calculateBest1RM(otherSets)
+  // Apply user-set PR baseline (falls back to rolling window when unset).
+  const rawBest1RM = calculateBest1RM(otherSets, { sinceDate: prBaselineDate.value })
 
   // Suppress PR detection for immature exercises (all sets from same day)
   const isEstablished = isExerciseEstablished(otherSets, date.value || todayISO())
   const best1RM = isEstablished ? rawBest1RM : null
 
-  // Rep PR only awards bonus when NOT already in PR/Tied PR zone
+  // Rep PR only awards bonus when NOT already in PR/Tied PR zone.
+  // When a baseline is set, rep PRs are also evaluated against sets since that date.
+  const repPRPriorSets = filterSetsSinceBaseline(otherSets)
   const isPRZone = best1RM !== null && estimated1RM >= best1RM
-  const isRepPR = isEstablished && !isPRZone && checkRepPR(weight, reps, otherSets)
+  const isRepPR = isEstablished && !isPRZone && checkRepPR(weight, reps, repPRPriorSets)
 
   const setIndex = exercise.sets.length - 1
   const baseXP = calculateSetXP({
@@ -1068,27 +1081,30 @@ const timelineSets = computed((): TimelineEntry[] => {
   return entries.sort((a, b) => b.set.date.slice(0, 10).localeCompare(a.set.date.slice(0, 10)))
 })
 
-// PR badge map: for each set, determine if it's the all-time best e1RM (weight PR)
-// or the best reps at its weight (rep PR) for that exercise
+// PR badge map: for each set, determine if it's the best e1RM (weight PR)
+// or the best reps at its weight (rep PR) for that exercise.
+// Respects the user-set PR baseline: when set, only sets on/after baseline
+// are eligible for badges AND serve as the comparison pool.
 const timelinePRMap = computed((): Record<string, 'pr' | 'repPR'> => {
   const map: Record<string, 'pr' | 'repPR'> = {}
   for (const ex of store.exercises) {
     if (ex.sets.length === 0) continue
-    const best1RM = Math.max(...ex.sets.map(s => s.estimated1RM))
-    // Weight PR: the set(s) that achieved the all-time best e1RM
-    for (const s of ex.sets) {
+    const eligible = filterSetsSinceBaseline(ex.sets)
+    if (eligible.length === 0) continue
+    const best1RM = Math.max(...eligible.map(s => s.estimated1RM))
+    // Weight PR: set(s) achieving the best e1RM within the baseline window
+    for (const s of eligible) {
       if (s.estimated1RM === best1RM) {
         map[s.id] = 'pr'
       }
     }
-    // Rep PR: best reps at each weight (computed across ALL sets to get true baseline)
+    // Rep PR: best reps at each weight within the baseline window
     const bestRepsAtWeight: Record<number, number> = {}
-    for (const s of ex.sets) {
+    for (const s of eligible) {
       bestRepsAtWeight[s.weight] = Math.max(bestRepsAtWeight[s.weight] ?? 0, s.reps)
     }
-    // Only assign repPR badge to non-weight-PR sets
-    for (const s of ex.sets) {
-      if (!map[s.id] && s.reps === bestRepsAtWeight[s.weight] && ex.sets.filter(o => o.weight === s.weight).length > 1) {
+    for (const s of eligible) {
+      if (!map[s.id] && s.reps === bestRepsAtWeight[s.weight] && eligible.filter(o => o.weight === s.weight).length > 1) {
         map[s.id] = 'repPR'
       }
     }
@@ -1156,14 +1172,15 @@ const detailExercise = computed((): Exercise | null =>
 )
 const detailExerciseId = ref<string | null>(null)
 
-// Earliest date the detail exercise hit its PR — only that date gets trophies
+// Earliest date the detail exercise hit its PR — only that date gets trophies.
+// Respects baseline: searches only sets on/after the baseline when set.
 const detailPRDate = computed(() => {
   const ex = detailExercise.value
   if (!ex) return ''
-  const pr = store.getExercisePR(ex.id)
+  const pr = store.getExercisePR(ex.id, prBaselineDate.value)
   if (!pr) return ''
   let earliest = ''
-  for (const set of ex.sets) {
+  for (const set of filterSetsSinceBaseline(ex.sets)) {
     if (set.estimated1RM === pr) {
       const day = set.date.slice(0, 10)
       if (!earliest || day < earliest) earliest = day
@@ -2198,7 +2215,7 @@ const isNewPR = computed(() => {
   const exercise = store.exercises.find(e => e.id === id)
   if (!exercise) return false
   if (!isExerciseEstablished(exercise.sets, date.value || todayISO())) return false
-  const pr = store.getExercisePR(id)
+  const pr = store.getExercisePR(id, prBaselineDate.value)
   return pr > 0 && liveEstimateLbs.value > pr
 })
 
@@ -2210,7 +2227,7 @@ const prTargetWeight = computed<number | null>(() => {
   if (weight.value && weight.value > 0) return null
   const id = selectedExerciseId.value
   if (!id || id === '__new__') return null
-  const pr = store.getExercisePR(id)
+  const pr = store.getExercisePR(id, prBaselineDate.value)
   if (pr <= 0) return null
   // Account for Epley rounding: round(w * (1 + r/30)) > pr triggers at pr + 0.5
   const target = pr + 0.5
@@ -2236,7 +2253,7 @@ const liveXPPreview = computed(() => {
   const exercise = store.exercises.find(e => e.id === id)
   if (!exercise) return null
 
-  const rawBest1RM = calculateBest1RM(exercise.sets)
+  const rawBest1RM = calculateBest1RM(exercise.sets, { sinceDate: prBaselineDate.value })
   const estimated1RM = liveEstimateLbs.value
   const w = toLbs(weight.value!)
   const r = reps.value!
@@ -2244,9 +2261,10 @@ const liveXPPreview = computed(() => {
   const isEstablished = isExerciseEstablished(exercise.sets, date.value || todayISO())
   const best1RM = isEstablished ? rawBest1RM : null
 
+  const repPRPriorSets = filterSetsSinceBaseline(exercise.sets)
   const isPRZone = best1RM !== null && estimated1RM >= best1RM
-  const hasSetAtWeight = exercise.sets.some(s => s.weight === w)
-  const isRepPR = isEstablished && !isPRZone && checkRepPR(w, r, exercise.sets)
+  const hasSetAtWeight = repPRPriorSets.some(s => s.weight === w)
+  const isRepPR = isEstablished && !isPRZone && checkRepPR(w, r, repPRPriorSets)
   const isNewWeight = !isPRZone && !isRepPR && !hasSetAtWeight && best1RM !== null
 
   const setIndex = exercise.sets.length
@@ -2283,7 +2301,7 @@ const prTargetReps = computed<number | null>(() => {
   if (reps.value && reps.value >= 1) return null // both filled
   const id = selectedExerciseId.value
   if (!id || id === '__new__') return null
-  const pr = store.getExercisePR(id)
+  const pr = store.getExercisePR(id, prBaselineDate.value)
   if (pr <= 0) return null
   const wLbs = toLbs(weight.value)
   // Account for Epley rounding: round(w * (1 + r/30)) > pr triggers at pr + 0.5
@@ -2310,7 +2328,7 @@ const prTargetsTable = computed<PRTargetRow[] | null>(() => {
   const exercise = store.exercises.find(e => e.id === id)
   if (!exercise) return null
   if (!isExerciseEstablished(exercise.sets, date.value || todayISO())) return null
-  const pr = store.getExercisePR(id)
+  const pr = store.getExercisePR(id, prBaselineDate.value)
   if (pr <= 0) return null
 
   const target = pr + 0.5
@@ -2454,7 +2472,7 @@ function saveSet() {
       const set = ex?.sets.find(s => s.id === editSetId)
       if (ex && set) {
         const otherSets = ex.sets.filter(s => s.id !== editSetId)
-        const rawBest = calculateBest1RM(otherSets)
+        const rawBest = calculateBest1RM(otherSets, { sinceDate: prBaselineDate.value })
         const editEstablished = isExerciseEstablished(otherSets, set.date)
         const best = editEstablished ? rawBest : null
         const newXP = calculateSetXP({
@@ -2466,7 +2484,8 @@ function saveSet() {
         const editIsPR = best !== null && set.estimated1RM > best
         const editIsTie = best !== null && set.estimated1RM === best
         const editIsPRZone = editIsPR || editIsTie
-        const editIsRepPR = editEstablished && !editIsPRZone && checkRepPR(set.weight, set.reps, otherSets)
+        const editRepPRPriorSets = filterSetsSinceBaseline(otherSets)
+        const editIsRepPR = editEstablished && !editIsPRZone && checkRepPR(set.weight, set.reps, editRepPRPriorSets)
         let editZone: string
         if (best === null) editZone = 'new_exercise'
         else if (editIsPR) editZone = 'pr'

--- a/src/composables/__tests__/usePRBaseline.test.ts
+++ b/src/composables/__tests__/usePRBaseline.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { nextTick } from 'vue'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+// Import after mocks are set up (module runs side effects at import)
+const { usePRBaseline } = await import('../usePRBaseline')
+
+describe('usePRBaseline', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    localStorageMock.setItem.mockClear()
+    localStorageMock.getItem.mockClear()
+  })
+
+  it('defaults to null (legacy all-time behavior)', () => {
+    const { prBaselineDate } = usePRBaseline()
+    expect(prBaselineDate.value).toBeNull()
+  })
+
+  it('setPRBaseline persists a valid ISO date to localStorage', async () => {
+    const { setPRBaseline, prBaselineDate } = usePRBaseline()
+    setPRBaseline('2026-01-01')
+    await nextTick()
+    expect(prBaselineDate.value).toBe('2026-01-01')
+    expect(localStorageMock.setItem).toHaveBeenCalledWith('pr-baseline-date', '2026-01-01')
+  })
+
+  it('rejects malformed dates without touching state', async () => {
+    const { setPRBaseline, prBaselineDate } = usePRBaseline()
+    setPRBaseline('2026-01-01')
+    await nextTick()
+    setPRBaseline('not-a-date')
+    await nextTick()
+    expect(prBaselineDate.value).toBe('2026-01-01')
+  })
+
+  it('clearPRBaseline removes persistence and reverts to null', async () => {
+    const { setPRBaseline, clearPRBaseline, prBaselineDate } = usePRBaseline()
+    setPRBaseline('2026-01-01')
+    await nextTick()
+    clearPRBaseline()
+    await nextTick()
+    expect(prBaselineDate.value).toBeNull()
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith('pr-baseline-date')
+  })
+
+  it('startNewTrainingBlock sets today', async () => {
+    const { startNewTrainingBlock, prBaselineDate } = usePRBaseline()
+    startNewTrainingBlock()
+    await nextTick()
+    const today = new Date()
+    const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+    expect(prBaselineDate.value).toBe(expected)
+  })
+})

--- a/src/composables/usePRBaseline.ts
+++ b/src/composables/usePRBaseline.ts
@@ -1,0 +1,82 @@
+/**
+ * PR baseline date — the anchor date against which PRs are evaluated.
+ *
+ * Semantics:
+ * - `null` (default) → preserve legacy behavior: display PRs use all-time max,
+ *   XP system uses the rolling XP_CONFIG.best1RMWindowMonths window.
+ * - ISO date (YYYY-MM-DD) → PRs are evaluated only against sets on or after
+ *   that date. Applies to both display badges and future XP evaluation.
+ *
+ * Ledger invariant: historical `isPR`/`isRepPR` flags stored in the
+ * progression store are NEVER rewritten when the baseline changes. XP already
+ * awarded stays awarded. The baseline only affects:
+ *   1. Future set evaluations (XP + zone detection at log time).
+ *   2. Display badges computed on-the-fly (timeline, calendar, graph).
+ */
+
+import { ref, watch, type Ref } from 'vue'
+
+const STORAGE_KEY = 'pr-baseline-date'
+
+function loadStored(): string | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    // Validate shape (YYYY-MM-DD). Reject anything else to avoid propagating bad state.
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null
+    return raw
+  } catch {
+    return null
+  }
+}
+
+const prBaselineDate: Ref<string | null> = ref(loadStored())
+
+watch(prBaselineDate, (v) => {
+  try {
+    if (v === null) localStorage.removeItem(STORAGE_KEY)
+    else localStorage.setItem(STORAGE_KEY, v)
+  } catch {
+    /* quota / private mode — silent */
+  }
+})
+
+function todayISO(): string {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/**
+ * Set the PR baseline. Pass null to revert to legacy (all-time) behavior.
+ * Pass a YYYY-MM-DD string to anchor PR evaluation.
+ */
+function setPRBaseline(date: string | null): void {
+  if (date === null) {
+    prBaselineDate.value = null
+    return
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return
+  prBaselineDate.value = date
+}
+
+/** Anchor the PR baseline to today — typical "starting a new training block" action. */
+function startNewTrainingBlock(): void {
+  prBaselineDate.value = todayISO()
+}
+
+/** Revert to all-time PR evaluation. */
+function clearPRBaseline(): void {
+  prBaselineDate.value = null
+}
+
+export function usePRBaseline() {
+  return {
+    prBaselineDate,
+    setPRBaseline,
+    startNewTrainingBlock,
+    clearPRBaseline,
+  }
+}

--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -280,6 +280,58 @@ describe('calculateBest1RM', () => {
     ]
     expect(calculateBest1RM(sets, { windowMonths: 1 })).toBe(100)
   })
+
+  describe('sinceDate (PR baseline)', () => {
+    it('excludes sets before the baseline date', () => {
+      const sets = [
+        makeSet({ estimated1RM: 300, date: '2025-06-01T10:00:00Z' }),
+        makeSet({ estimated1RM: 150, date: '2026-01-15T10:00:00Z' }),
+        makeSet({ estimated1RM: 200, date: '2026-03-01T10:00:00Z' }),
+      ]
+      // Baseline of 2026-01-01 should exclude the 300 set from 2025
+      expect(calculateBest1RM(sets, { sinceDate: '2026-01-01' })).toBe(200)
+    })
+
+    it('includes sets on the baseline date itself', () => {
+      const sets = [
+        makeSet({ estimated1RM: 100, date: '2026-01-01T08:00:00Z' }),
+        makeSet({ estimated1RM: 120, date: '2026-02-01T10:00:00Z' }),
+      ]
+      expect(calculateBest1RM(sets, { sinceDate: '2026-01-01' })).toBe(120)
+    })
+
+    it('returns null when no sets fall on/after baseline', () => {
+      const sets = [
+        makeSet({ estimated1RM: 300, date: '2025-01-01T10:00:00Z' }),
+      ]
+      expect(calculateBest1RM(sets, { sinceDate: '2026-01-01' })).toBeNull()
+    })
+
+    it('sinceDate takes precedence over windowMonths', () => {
+      // Within 6-month rolling window but before baseline — must be excluded
+      const sets = [
+        makeSet({ estimated1RM: 300, date: '2025-12-01T10:00:00Z' }),
+        makeSet({ estimated1RM: 150, date: '2026-02-01T10:00:00Z' }),
+      ]
+      expect(calculateBest1RM(sets, { sinceDate: '2026-01-01', windowMonths: 12 })).toBe(150)
+    })
+
+    it('null sinceDate falls back to windowMonths behavior', () => {
+      const sets = [
+        makeSet({ estimated1RM: 300, date: '2025-01-01T10:00:00Z' }),
+        makeSet({ estimated1RM: 100, date: '2026-03-01T10:00:00Z' }),
+      ]
+      // null → rolling window; 2025 set is outside default 6mo window
+      expect(calculateBest1RM(sets, { sinceDate: null })).toBe(100)
+    })
+
+    it('malformed sinceDate falls back to windowMonths', () => {
+      const sets = [
+        makeSet({ estimated1RM: 100, date: '2026-03-01T10:00:00Z' }),
+      ]
+      expect(calculateBest1RM(sets, { sinceDate: 'not-a-date' })).toBe(100)
+    })
+  })
 })
 
 // --- applyStreakMultiplier ---

--- a/src/lib/xp.ts
+++ b/src/lib/xp.ts
@@ -164,19 +164,35 @@ export function isExerciseEstablished(sets: WorkoutSet[], currentDate: string): 
 }
 
 /**
- * Calculate the best estimated 1RM for an exercise within a rolling window.
- * Defaults to XP_CONFIG.best1RMWindowMonths.
+ * Calculate the best estimated 1RM for an exercise within a time window.
+ *
+ * - If `sinceDate` is provided (YYYY-MM-DD or ISO), only sets on or after that
+ *   date are considered. Takes precedence over `windowMonths`.
+ * - Otherwise falls back to the rolling `windowMonths` window
+ *   (default: XP_CONFIG.best1RMWindowMonths).
+ *
+ * Returns null when no sets fall inside the window.
  */
 export function calculateBest1RM(
   sets: WorkoutSet[],
-  options: { windowMonths?: number } = {}
+  options: { windowMonths?: number; sinceDate?: string | null } = {}
 ): number | null {
   if (sets.length === 0) return null
 
-  const months = options.windowMonths ?? XP_CONFIG.best1RMWindowMonths
-  const windowMs = months * 30 * 24 * 60 * 60 * 1000
-  const now = Date.now()
-  const cutoff = now - windowMs
+  let cutoff: number
+  if (options.sinceDate) {
+    // Normalize to start-of-day for YYYY-MM-DD inputs so the anchor day itself is included.
+    const anchor = options.sinceDate.length === 10
+      ? options.sinceDate + 'T00:00:00'
+      : options.sinceDate
+    const parsed = new Date(anchor).getTime()
+    if (isNaN(parsed)) return calculateBest1RM(sets, { windowMonths: options.windowMonths })
+    cutoff = parsed
+  } else {
+    const months = options.windowMonths ?? XP_CONFIG.best1RMWindowMonths
+    const windowMs = months * 30 * 24 * 60 * 60 * 1000
+    cutoff = Date.now() - windowMs
+  }
 
   let best: number | null = null
 

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -423,6 +423,41 @@ describe('workout store', () => {
       const store = useWorkoutStore()
       expect(store.getExercisePR('fake')).toBe(0)
     })
+
+    describe('sinceDate (PR baseline)', () => {
+      it('excludes sets before sinceDate', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 225, 5, '2025-06-01T10:00:00Z') // 1RM ≈ 262
+        store.logSet(id, 185, 5, '2026-02-01T10:00:00Z') // 1RM ≈ 216
+        store.logSet(id, 135, 5, '2026-03-01T10:00:00Z') // 1RM ≈ 158
+        expect(store.getExercisePR(id, '2026-01-01')).toBe(216)
+      })
+
+      it('includes sets exactly on sinceDate', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 135, 5, '2026-01-01T00:00:00Z')
+        expect(store.getExercisePR(id, '2026-01-01')).toBeGreaterThan(0)
+      })
+
+      it('returns 0 when all sets are before sinceDate', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 225, 5, '2024-01-01T10:00:00Z')
+        expect(store.getExercisePR(id, '2026-01-01')).toBe(0)
+      })
+
+      it('undefined sinceDate preserves all-time behavior', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 225, 5, '2020-01-01T10:00:00Z')
+        store.logSet(id, 135, 5, '2026-03-01T10:00:00Z')
+        // Older set has higher 1RM; without baseline it should win
+        const allTime = store.getExercisePR(id)
+        expect(allTime).toBeGreaterThan(store.getExercisePR(id, '2026-01-01'))
+      })
+    })
   })
 
   describe('getRecentSets', () => {

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -823,16 +823,34 @@ export const useWorkoutStore = defineStore('workout', {
       return [...dates].sort()
     },
 
-    getExercisePR: (state) => (exerciseId: string): number => {
+    /**
+     * Max estimated1RM across all sets for an exercise.
+     * When `sinceDate` (YYYY-MM-DD) is provided, only sets on or after that
+     * date are considered. Default (undefined/null) preserves legacy
+     * all-time behavior.
+     */
+    getExercisePR: (state) => (exerciseId: string, sinceDate?: string | null): number => {
       const exercise = state.exercises.find((e: Exercise) => e.id === exerciseId)
       if (!exercise || exercise.sets.length === 0) return 0
-      return Math.max(...exercise.sets.map((s: WorkoutSet) => s.estimated1RM))
+      const filtered = sinceDate
+        ? exercise.sets.filter((s: WorkoutSet) => s.date.slice(0, 10) >= sinceDate)
+        : exercise.sets
+      if (filtered.length === 0) return 0
+      return Math.max(...filtered.map((s: WorkoutSet) => s.estimated1RM))
     },
 
-    getExercisePRSet: (state) => (exerciseId: string): WorkoutSet | null => {
+    /**
+     * The single set that achieved the max estimated1RM.
+     * Respects `sinceDate` like getExercisePR.
+     */
+    getExercisePRSet: (state) => (exerciseId: string, sinceDate?: string | null): WorkoutSet | null => {
       const exercise = state.exercises.find((e: Exercise) => e.id === exerciseId)
       if (!exercise || exercise.sets.length === 0) return null
-      return exercise.sets.reduce((best: WorkoutSet, s: WorkoutSet) =>
+      const filtered = sinceDate
+        ? exercise.sets.filter((s: WorkoutSet) => s.date.slice(0, 10) >= sinceDate)
+        : exercise.sets
+      if (filtered.length === 0) return null
+      return filtered.reduce((best: WorkoutSet, s: WorkoutSet) =>
         s.estimated1RM > best.estimated1RM ? s : best
       )
     },


### PR DESCRIPTION
## Summary
- Adds a user-configurable PR baseline date in **Settings → Personal Records**: pick a date or tap **Start new training block** to anchor to today. PRs are then evaluated only against sets on or after the baseline.
- Backward compatible: when the baseline is null (default), display PRs stay all-time and XP evaluation keeps its 6-month rolling window — exactly today's behavior.
- **Ledger invariant**: historical `isPR` / `isRepPR` flags in the progression store are never rewritten when the baseline changes. XP already awarded stays awarded. The baseline only affects future set evaluations and on-the-fly display badges.

## Why this shape

Three design options were on the table:

1. **Global rolling-window selector** (3mo / 6mo / 1yr / all-time). Simple, but widening the window retroactively demotes past PRs and inflates/deflates the XP economy.
2. **Training block anchor date** (this PR). Matches how lifters actually think — "I'm starting a new block." Pairs with the existing `epoch`/prestige mental model.
3. **Per-exercise overrides.** Real fidelity for mixed programming but doubles the settings surface. Deferred — the `sinceDate` param is already per-call, so this becomes a non-breaking UI addition later.

Picked (2) with the ledger-freeze guardrail from (1). Protects XP integrity while matching user intent.

## Implementation
- `src/lib/xp.ts` — `calculateBest1RM()` accepts `sinceDate` taking precedence over `windowMonths`
- `src/stores/workout.ts` — `getExercisePR` / `getExercisePRSet` accept optional `sinceDate` (default = all-time, unchanged)
- `src/composables/usePRBaseline.ts` — new composable, localStorage-persisted at key `pr-baseline-date`
- `WorkoutTracker.vue`, `CalendarView.vue`, `ExerciseGraph.vue` — threaded baseline into every PR computation and display site

## Test plan
- [x] `npm test` — 1218 tests passing; added coverage for sinceDate precedence, baseline boundaries, composable persistence
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [x] iPhone 16 Pro simulator: default **All time** → **Start new training block** opens confirm dialog → anchored to today → × clears back to **All time**
- [x] Verify on real device that the date picker opens the native iOS date wheel
- [ ] Log a set with baseline set to confirm PR zone toast still fires correctly
- [ ] Confirm timeline/calendar/graph badges update immediately when baseline changes

## Follow-ups (not in this PR)
- Supabase sync for the baseline — currently localStorage-only, won't follow to a new device
- Per-exercise overrides when a user actually asks

🤖 Generated with [Claude Code](https://claude.com/claude-code)