### PR TITLE
fix: remove client-initiated DELETEs from sync READ path (SEV1)

### DIFF
--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
 import { getLocalStorageMock } from '../../__tests__/helpers'
 
 const localStorageMock = getLocalStorageMock()
@@ -792,6 +796,88 @@ describe('workout store', () => {
       expect(result[0].id).toBe('x1')
       expect(removed).toHaveLength(1)
       expect(removed[0].id).toBe('x2')
+    })
+
+    it('SEV1 regression 2026-04-12 — dedup must never push server DELETEs (READ path is read-only)', () => {
+      // Incident: client-side dedup in _fetchFromSupabase broadcast DELETE ops
+      // to Supabase every sync. For users with backdated straight-set programs
+      // (5x5 with T12:00:00 noon-local or T23:59:59 fixed timestamps), identical
+      // (date|weight|reps) tuples collapsed to one survivor and the rest were
+      // permanently deleted server-side. ~11 sets/session lost. No PITR on free
+      // tier = unrecoverable.
+      //
+      // Root cause: client treated its dedup heuristic as authoritative over
+      // server data. Fix: dedup is purely local; server is source of truth.
+      //
+      // This structural test prevents the exact anti-patterns from returning.
+      // Functional behavior is covered by the deduplicateSets / deduplicateByName
+      // unit tests above — those verify the local pruning still works.
+      const __filename = fileURLToPath(import.meta.url)
+      const __dirname = dirname(__filename)
+      const src = readFileSync(resolve(__dirname, '../workout.ts'), 'utf-8')
+
+      // Extract the _fetchFromSupabase function body. Uses brace counting
+      // to handle nested braces correctly.
+      const fnStart = src.indexOf('async _fetchFromSupabase(')
+      expect(fnStart).toBeGreaterThan(-1)
+      const openBrace = src.indexOf('{', fnStart)
+      let depth = 1
+      let i = openBrace + 1
+      while (i < src.length && depth > 0) {
+        if (src[i] === '{') depth++
+        else if (src[i] === '}') depth--
+        i++
+      }
+      const body = src.slice(openBrace + 1, i - 1)
+
+      // Every .delete(...) call in this function MUST be part of tombstone
+      // processing (syncing pending USER-initiated deletes). Non-tombstone
+      // deletes in the read path are the bug we shipped a SEV1 for.
+      //
+      // Heuristic: for each .delete( match, the prior 10 lines must mention
+      // "tombstone" (either the import or the branch condition isTombstoned).
+      const deletePattern = /\.delete\s*\(/g
+      let match: RegExpExecArray | null
+      while ((match = deletePattern.exec(body)) !== null) {
+        const before = body.slice(Math.max(0, match.index - 400), match.index)
+        expect(before).toMatch(/tombstone/i)
+      }
+
+      // Guard against the specific variable names and comment fragments that
+      // existed before the fix. If these reappear, the bug is back.
+      expect(body).not.toMatch(/dupSetIds/)
+      expect(body).not.toMatch(/Set was content-deduped out/)
+      expect(body).not.toMatch(/Delete the duplicate exercise from Supabase/)
+    })
+
+    it('SEV1 regression 2026-04-12 — bodyweight read path is also read-only', () => {
+      // Bodyweight store had the same anti-pattern as workout: date-level dedup
+      // broadcast deletes to Supabase. Same fix applied.
+      const __filename = fileURLToPath(import.meta.url)
+      const __dirname = dirname(__filename)
+      const src = readFileSync(resolve(__dirname, '../bodyweight.ts'), 'utf-8')
+
+      const fnStart = src.indexOf('async _fetchFromSupabase(')
+      expect(fnStart).toBeGreaterThan(-1)
+      const openBrace = src.indexOf('{', fnStart)
+      let depth = 1
+      let i = openBrace + 1
+      while (i < src.length && depth > 0) {
+        if (src[i] === '{') depth++
+        else if (src[i] === '}') depth--
+        i++
+      }
+      const body = src.slice(openBrace + 1, i - 1)
+
+      const deletePattern = /\.delete\s*\(/g
+      let match: RegExpExecArray | null
+      while ((match = deletePattern.exec(body)) !== null) {
+        const before = body.slice(Math.max(0, match.index - 400), match.index)
+        expect(before).toMatch(/tombstone/i)
+      }
+
+      expect(body).not.toMatch(/dupIds/)
+      expect(body).not.toMatch(/Clean up duplicate entries from Supabase/)
     })
 
     it('sorts merged sets chronologically (regression: out-of-order after dedup)', () => {

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -88,9 +88,12 @@ export const useBodyweightStore = defineStore('bodyweight', {
       }))
       const { merged, localOnly, localWins } = mergeEntities<BWWithTimestamp>(localWithTimestamps, remoteEntries as BWWithTimestamp[])
 
-      // Deduplicate by date — keep only the latest entry per date (by updated_at)
+      // Deduplicate by date for LOCAL display only — keep the entry with the
+      // later updated_at per date. We intentionally do NOT push deletes to
+      // Supabase for the losers; the client has no authority to mutate server
+      // data based on dedup heuristics. Server-side cleanup should be a
+      // controlled one-time SQL migration. See incident 2026-04-12 (SEV1).
       const byDate = new Map<string, (typeof merged)[0]>()
-      const dupIds: string[] = []
       for (const entry of merged) {
         const dateKey = entry.date.slice(0, 10)
         const existing = byDate.get(dateKey)
@@ -99,25 +102,13 @@ export const useBodyweightStore = defineStore('bodyweight', {
         } else {
           // Keep the one with the later updated_at
           if (entry.updated_at > existing.updated_at) {
-            dupIds.push(existing.id)
             // If a sample entry replaces a real remote entry, adopt it so it gets synced back
             if (entry.sample && !existing.sample) delete entry.sample
             byDate.set(dateKey, entry)
           } else {
-            dupIds.push(entry.id)
             // If existing sample entry beats a real remote entry, adopt it
             if (existing.sample && !entry.sample) delete existing.sample
           }
-        }
-      }
-
-      // Clean up duplicate entries from Supabase
-      if (dupIds.length > 0) {
-        const userId = this._userId
-        for (const id of dupIds) {
-          syncQueue.enqueue(`bodyweight:${id}`, () =>
-            supabase!.from('bodyweight_entries').delete().eq('id', id).eq('user_id', userId),
-          )
         }
       }
 

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -297,73 +297,26 @@ export const useWorkoutStore = defineStore('workout', {
         }
       }
 
-      // Deduplicate exercises by name (case-insensitive).
-      // Supabase can end up with multiple exercises of the same name from
-      // different sessions/devices with different UUIDs. Merge their sets
-      // into the primary (the one with the most sets) and delete the dupes.
+      // Deduplicate exercises by name (case-insensitive) for LOCAL display only.
+      // Two devices can create exercises with the same name but different UUIDs;
+      // this merges them into a single row in the local state so the UI doesn't
+      // show duplicates. We intentionally do NOT push deletes or reassignments
+      // to Supabase here — the client has no authority to mutate server data
+      // based on dedup heuristics. Server-side cleanup should be done via a
+      // controlled one-time SQL migration, not ambient client behavior.
+      // See incident 2026-04-12 (SEV1): pushing client-dedup deletes to the
+      // server destroyed user data when (date|weight|reps) collided across
+      // same-named exercises. The fix is to keep dedup strictly local.
       const deduped = deduplicateByName(merged as Exercise[])
 
-      // Clean up duplicate exercises from Supabase
-      // (#4 fix: only reassign sets that survived content dedup; delete the rest)
-      if (supabase && this._userId && deduped.removed.length > 0) {
-        const userId = this._userId
-        for (const dupe of deduped.removed) {
-          const primary = deduped.exercises.find(e =>
-            e.name.toLowerCase() === dupe.name.toLowerCase()
-          )
-          if (primary && !primary.sample) {
-            // Only sync dedup operations for non-sample exercises
-            const primarySetIds = new Set(primary.sets.map(s => s.id))
-            for (const set of dupe.sets) {
-              if (primarySetIds.has(set.id)) {
-                // Set was merged into primary — upsert under the primary exercise ID.
-                syncQueue.enqueue(`set:${set.id}`, () =>
-                  supabase!.from('sets').upsert({
-                    id: set.id, user_id: userId, exercise_id: primary.id,
-                    date: set.date, weight: set.weight, reps: set.reps,
-                    estimated_1rm: set.estimated1RM
-                  })
-                )
-              } else {
-                // Set was content-deduped out — delete it from Supabase
-                syncQueue.enqueue(`set:${set.id}`, () =>
-                  supabase!.from('sets').delete().eq('id', set.id).eq('user_id', userId)
-                )
-              }
-            }
-            // Delete the duplicate exercise from Supabase
-            syncQueue.enqueue(`exercise:${dupe.id}`, () =>
-              supabase!.from('exercises').delete().eq('id', dupe.id).eq('user_id', userId)
-            )
-            // Push the primary's merged state (tags may have been combined from dupes)
-            syncQueue.enqueue(`exercise:${primary.id}`, () =>
-              supabase!.from('exercises').upsert({
-                id: primary.id, user_id: userId, name: primary.name, tags: primary.tags,
-                ...(primary.inputMode ? { input_mode: primary.inputMode } : {}), ...(primary.barWeight != null ? { bar_weight: primary.barWeight } : {})
-              })
-            )
-          }
-        }
-      }
-
-      // Deduplicate sets within each exercise by exact content match
-      // (full timestamp + weight + reps). Catches identical entries safely
-      // without affecting programs like 5x5 that log the same weight/reps
-      // multiple times (those get unique jitter timestamps).
-      const dupSetIds: string[] = []
+      // Deduplicate sets within each exercise for LOCAL display only.
+      // Legacy pre-jitter timestamps (T12:00:00 noon-local, T23:59:59 fixed)
+      // cause identical (date|weight|reps) tuples for straight-set programs
+      // like 5x5. We collapse those for local rendering but do NOT push
+      // deletes — the server is the source of truth. See incident 2026-04-12.
       for (const ex of deduped.exercises) {
-        const { unique, removedIds } = deduplicateSets(ex.sets)
+        const { unique } = deduplicateSets(ex.sets)
         ex.sets = unique
-        dupSetIds.push(...removedIds)
-      }
-
-      if (supabase && this._userId && dupSetIds.length > 0) {
-        const userId = this._userId
-        for (const setId of dupSetIds) {
-          syncQueue.enqueue(`set:${setId}`, () =>
-            supabase!.from('sets').delete().eq('id', setId).eq('user_id', userId)
-          )
-        }
       }
 
       this.exercises = deduped.exercises


### PR DESCRIPTION
## Summary

Client-side dedup logic inside `workoutStore._fetchFromSupabase` and `bodyweightStore._fetchFromSupabase` was broadcasting `.delete()` operations to Supabase on every sync. This silently destroyed user data for weeks. One reported user (crgulland15@gmail.com) lost an estimated ~40–60% of his historical set data and it is unrecoverable (free-tier Supabase, no PITR).

- Dedup is now strictly **local** (for UI cleanliness only)
- The sync **READ path issues zero writes** based on dedup heuristics
- User-initiated deletes still hard-delete as before — Phase 2 converts those to soft-deletes

## Root cause

The client treated its dedup heuristic as authoritative over the server. When legacy pre-jitter timestamps collided on `(date|weight|reps)` — e.g. a 5×5 workout backdated with `T12:00:00` noon-local (pre-`2373cda`) or `T23:59:59` fixed (pre-`3ed1600`) — four of the five sets were permanently deleted server-side on every sync.

This pattern is a residual from LIFT-255 "triplicate cleanup." The server-side SQL migration (`3e3531f`) should have ended the story, but the client-side DELETE broadcasting stayed as permanent runtime behavior and kept firing forever.

## Why usage pattern matters

- Users who primarily log sets **in real time** have unique millisecond timestamps from `new Date().toISOString()` → no collisions → no data loss observed
- Users who **backdate sets** via date picker and log **straight-set programs** (5×5, 3×10) get identical `(date|weight|reps)` → catastrophic loss
- This is why Aaron + girlfriend were unaffected but crgulland15 was

## Why existing tests missed it

The `deduplicateSets` / `deduplicateByName` unit tests only asserted the return values (`unique` array, `removedIds` count). They never checked the downstream `syncQueue` side effects in the caller. The pure functions are correct — the caller was weaponizing them against the server.

## What the fix does

`src/stores/workout.ts`
- `deduplicateByName` cleanup block (38 lines, lines 306–347) → **removed**; local merge preserved
- `deduplicateSets` delete block (8 lines, lines 360–367) → **removed**; local prune preserved

`src/stores/bodyweight.ts`
- Date-dedup delete block (8 lines, lines 114–122) → **removed**; local date-dedup preserved

`src/stores/__tests__/workout.test.ts`
- Two new structural regression tests that:
  - Assert any `.delete(` inside `_fetchFromSupabase` is within a tombstone (user-initiated delete) block
  - Guard specific variable names and comment fragments from the buggy code against reintroduction

## Test plan

- [x] `npx vitest run src/stores/__tests__/workout.test.ts` → 80 tests pass (incl. 2 new regression tests)
- [x] `npx vitest run src/stores/__tests__/bodyweight.test.ts` → 26 tests pass
- [x] Full `npx vitest run` → **1220 / 1220 tests pass**
- [x] `npm run lint` → 0 errors, 9 pre-existing warnings (none from this PR)
- [x] `npm run build` → clean
- [ ] Manual: open app on Aaron's phone, log a set, verify sync still works end-to-end
- [ ] Manual: verify local dedup still merges same-name exercises in UI

## Recovery note for crgulland15

Free-tier Supabase has no PITR. The data Supabase lost can't be restored from backup. We have two remaining options:
1. Accept the loss, ship the fix, stop further bleeding (this PR)
2. Ask him to check if any older device still has un-synced localStorage/IDB data we can extract via CSV export

## Follow-ups

Phase 2 tracked as separate issue — covers soft-deletes everywhere, server-authoritative `updated_at`, rolling IDB snapshots, deletion circuit breaker in SyncQueue, E2E sync fuzz in CI.

Gemini's post-commit review also flagged three issues in code this PR does **not** touch (`WorkoutTracker.vue`, `xp.ts`, `useAuth.ts`). Those are pre-existing and should be triaged separately — not blockers for this SEV1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)