### PR TITLE
feat: add deleted_at columns for soft-delete (Phase 2 Gate 4)

### DIFF
--- a/scripts/phase2/02-dryrun-deleted-at.sql
+++ b/scripts/phase2/02-dryrun-deleted-at.sql
@@ -1,0 +1,61 @@
+-- Phase 2, Gate 4 DRY RUN: additive soft-delete columns
+-- This file is run inside BEGIN/ROLLBACK so nothing is persisted.
+-- If this run is clean, the migration itself (same DDL, different file)
+-- lands in supabase/migrations/ and auto-applies on master push.
+
+\echo '=== DRY RUN: wrapping everything in a transaction that rolls back ==='
+BEGIN;
+
+-- Columns: nullable timestamptz. Null = not deleted. Purely additive.
+ALTER TABLE exercises          ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+ALTER TABLE sets               ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+ALTER TABLE bodyweight_entries ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+-- Partial indexes for the common "active rows" lookup pattern.
+-- Existing full indexes on user_id stay in place for admin / cleanup queries
+-- that need to see deleted rows too.
+CREATE INDEX IF NOT EXISTS idx_exercises_user_active
+  ON exercises (user_id) WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_sets_user_exercise_active
+  ON sets (user_id, exercise_id) WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_bodyweight_user_active
+  ON bodyweight_entries (user_id) WHERE deleted_at IS NULL;
+
+\echo ''
+\echo '=== Verify columns added ==='
+SELECT table_name, column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND column_name = 'deleted_at'
+ORDER BY table_name;
+
+\echo ''
+\echo '=== Verify indexes created ==='
+SELECT schemaname, tablename, indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public' AND indexname LIKE '%active%'
+ORDER BY tablename, indexname;
+
+\echo ''
+\echo '=== Verify zero data mutation: row counts unchanged ==='
+SELECT 'exercises'          AS t, count(*) FROM exercises
+UNION ALL SELECT 'sets',                count(*) FROM sets
+UNION ALL SELECT 'bodyweight_entries',  count(*) FROM bodyweight_entries;
+
+\echo ''
+\echo '=== Sample: confirm existing rows have deleted_at = NULL (not deleted) ==='
+SELECT count(*) FILTER (WHERE deleted_at IS NULL)     AS not_deleted,
+       count(*) FILTER (WHERE deleted_at IS NOT NULL) AS deleted
+FROM exercises;
+
+\echo ''
+\echo '=== ROLLBACK — nothing persisted ==='
+ROLLBACK;
+
+\echo ''
+\echo '=== Post-rollback: columns should NOT exist ==='
+SELECT count(*) AS should_be_zero
+FROM information_schema.columns
+WHERE table_schema = 'public' AND column_name = 'deleted_at';

--- a/supabase/migrations/20260417000000_add_deleted_at_columns.sql
+++ b/supabase/migrations/20260417000000_add_deleted_at_columns.sql
@@ -1,0 +1,28 @@
+-- Phase 2 Gate 4: additive soft-delete columns (follow-up to #338 / #339)
+--
+-- Adds a nullable deleted_at timestamptz to the three mutable data tables.
+-- NULL = active row, non-NULL = soft-deleted-at-that-time.
+--
+-- This migration is purely additive:
+--   - No existing queries filter on deleted_at, so they keep seeing all rows.
+--   - No data is mutated; all existing rows start with deleted_at = NULL.
+--   - No triggers, no RLS changes, no client-facing behavior change.
+--
+-- Client UPDATE-instead-of-DELETE rollout lands in a separate PR (Gate 5)
+-- so rollback here is trivial: drop three columns, drop three indexes.
+
+alter table exercises          add column if not exists deleted_at timestamptz;
+alter table sets               add column if not exists deleted_at timestamptz;
+alter table bodyweight_entries add column if not exists deleted_at timestamptz;
+
+-- Partial indexes for the common "give me active rows for this user" lookup.
+-- Existing idx_*_user_id indexes remain in place for admin / cleanup queries
+-- that need to see soft-deleted rows too.
+create index if not exists idx_exercises_user_active
+  on exercises (user_id) where deleted_at is null;
+
+create index if not exists idx_sets_user_exercise_active
+  on sets (user_id, exercise_id) where deleted_at is null;
+
+create index if not exists idx_bodyweight_user_active
+  on bodyweight_entries (user_id) where deleted_at is null;


### PR DESCRIPTION
## Summary

Additive schema migration for Phase 2 (#339). Adds a nullable `deleted_at timestamptz` to the three mutable data tables plus partial indexes for the "active rows" lookup pattern.

- `exercises.deleted_at`
- `sets.deleted_at`
- `bodyweight_entries.deleted_at`
- 3 partial indexes: `(user_id) WHERE deleted_at IS NULL` (the `sets` one also keys on `exercise_id`)

## Blast radius: effectively zero

- **No queries filter on `deleted_at` yet.** Client code continues to see every row, same as before.
- **No data mutations.** All existing rows start with `deleted_at = NULL`.
- **No triggers, no RLS changes, no client behavior change.** Client UPDATE-instead-of-DELETE lands in a separate PR (Gate 5) so rollback here is a simple 3-column / 3-index drop.
- **Existing `idx_*_user_id` indexes stay.** They serve admin / cleanup queries that need to see soft-deleted rows.

## Dry-run evidence

Before writing the migration, I ran the exact DDL against prod inside a `BEGIN; ... ROLLBACK;` transaction (`scripts/phase2/02-dryrun-deleted-at.sql`). Results:

- 3 `ALTER TABLE` + 3 `CREATE INDEX` all succeed
- Row counts on all three tables **unchanged** (59 exercises, 416 sets, 16 bodyweight entries — matches Gate 1 investigation)
- All 59 existing exercises verified as `deleted_at IS NULL` (0 deleted, 59 not deleted)
- Post-rollback: `deleted_at` column does not exist — clean

## Rollback plan

If we need to revert after merge:

```sql
drop index if exists idx_exercises_user_active;
drop index if exists idx_sets_user_exercise_active;
drop index if exists idx_bodyweight_user_active;
alter table exercises          drop column if exists deleted_at;
alter table sets               drop column if exists deleted_at;
alter table bodyweight_entries drop column if exists deleted_at;
```

`DROP COLUMN` is immediate — partial indexes get dropped with the column.

## Test plan

- [x] Dry-run against prod in a rolled-back transaction — all assertions pass
- [x] `npm test` → 1238/1238 pass (no test changes; schema doesn't affect tests since `supabase` is mocked to null)
- [x] `npm run lint` → 0 errors
- [x] `npm run typecheck` → clean
- [ ] CI `migrate-db` job succeeds on master push (must verify before celebrating)

## What happens on merge

CI runs `supabase db push --linked` against prod. The migration applies (3 ALTERs + 3 CREATE INDEXes) and becomes part of the declared schema. **I'll monitor the `migrate-db` job personally after merge.**

## Out of scope

- **Cascade trigger** (exercise soft-delete → auto-soft-delete its sets) — defer to Gate 5 where client changes land together
- **Client UPDATE-instead-of-DELETE** — Gate 5
- **SyncQueue circuit breaker** — Gate 3
- **Scheduled hard-delete cron** — Gate 6

Contributes to #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)