### PR TITLE
feat: soft-delete via deleted_at (Phase 2 Gate 5)

### DIFF
--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -480,4 +480,34 @@ describe('SyncQueue — delete routing discipline (structural)', () => {
       }
     }
   })
+
+  // Gate 5 invariant: stores do not issue hard DELETEs at all.
+  // Every removal must go through UPDATE { deleted_at: ... } so data is
+  // recoverable within the grace window before the hard-delete cron runs.
+  it('stores never call .delete() on a Supabase query — all removals are soft', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { resolve } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const { dirname } = await import('node:path')
+
+    const __filename = fileURLToPath(import.meta.url)
+    const __dirname = dirname(__filename)
+    const storeDir = resolve(__dirname, '../../stores')
+
+    const files = ['workout.ts', 'bodyweight.ts', 'preferences.ts', 'progression.ts']
+    for (const file of files) {
+      const src = readFileSync(resolve(storeDir, file), 'utf-8')
+      // Match any supabase query builder .delete(), allowing whitespace / newlines
+      // between .from(...) and .delete(). Non-supabase .delete() (Map/Set) is not
+      // matched because the anchor requires .from(...) upstream within 200 chars.
+      const re = /\.from\(\s*['"][^'"]+['"]\s*\)[\s\S]{0,200}?\.delete\s*\(/g
+      const match = re.exec(src)
+      if (match) {
+        const offset = match.index
+        throw new Error(
+          `${file} contains a hard .delete() on a Supabase query at offset ${offset}. Gate 5 requires UPDATE { deleted_at: new Date().toISOString() } for all removals. Context:\n${src.slice(offset, offset + 200)}`,
+        )
+      }
+    }
+  })
 })

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -43,6 +43,7 @@ export type Database = {
         Row: {
           created_at: string
           date: string
+          deleted_at: string | null
           id: string
           user_id: string
           weight: number
@@ -50,6 +51,7 @@ export type Database = {
         Insert: {
           created_at?: string
           date: string
+          deleted_at?: string | null
           id?: string
           user_id: string
           weight: number
@@ -57,6 +59,7 @@ export type Database = {
         Update: {
           created_at?: string
           date?: string
+          deleted_at?: string | null
           id?: string
           user_id?: string
           weight?: number
@@ -67,6 +70,7 @@ export type Database = {
         Row: {
           bar_weight: number
           created_at: string
+          deleted_at: string | null
           id: string
           input_mode: string | null
           name: string
@@ -77,6 +81,7 @@ export type Database = {
         Insert: {
           bar_weight?: number
           created_at?: string
+          deleted_at?: string | null
           id?: string
           input_mode?: string | null
           name: string
@@ -87,6 +92,7 @@ export type Database = {
         Update: {
           bar_weight?: number
           created_at?: string
+          deleted_at?: string | null
           id?: string
           input_mode?: string | null
           name?: string
@@ -139,6 +145,7 @@ export type Database = {
         Row: {
           created_at: string
           date: string
+          deleted_at: string | null
           estimated_1rm: number
           exercise_id: string
           id: string
@@ -150,6 +157,7 @@ export type Database = {
         Insert: {
           created_at?: string
           date: string
+          deleted_at?: string | null
           estimated_1rm: number
           exercise_id: string
           id?: string
@@ -161,6 +169,7 @@ export type Database = {
         Update: {
           created_at?: string
           date?: string
+          deleted_at?: string | null
           estimated_1rm?: number
           exercise_id?: string
           id?: string

--- a/src/lib/tombstones.ts
+++ b/src/lib/tombstones.ts
@@ -80,3 +80,8 @@ export function cleanupTombstones(store: string, remoteIds: Set<string>) {
     setStoreSet(store, ids)
   }
 }
+
+/** Reset in-memory tombstone cache (for testing only — prod doesn't need this). */
+export function _resetTombstones() {
+  _data = null
+}

--- a/src/stores/__tests__/syncFuzz.test.ts
+++ b/src/stores/__tests__/syncFuzz.test.ts
@@ -60,6 +60,10 @@ const { fakeSupabase } = vi.hoisted(() => {
       return this.calls.filter(c => c.op === 'upsert' && c.table === table)
     }
 
+    updatesFor(table: string) {
+      return this.calls.filter(c => c.op === 'update' && c.table === table)
+    }
+
     _exec(
       op: FakeSupabase['calls'][number]['op'],
       table: string,
@@ -69,7 +73,15 @@ const { fakeSupabase } = vi.hoisted(() => {
       this.calls.push({ op, table, filters: { ...filters }, data })
       const rows = this.tables[table] || (this.tables[table] = [])
       const matches = rows.filter(r =>
-        Object.entries(filters).every(([k, v]) => r[k] === v),
+        Object.entries(filters).every(([k, v]) => {
+          // .is(col, null) sentinel: match NULL or missing
+          if (v !== null && typeof v === 'object' && v !== undefined && '__is' in v) {
+            const target = (v as { __is: unknown }).__is
+            if (target === null) return r[k] == null
+            return r[k] === target
+          }
+          return r[k] === v
+        }),
       )
 
       if (op === 'select') return matches
@@ -107,6 +119,7 @@ const { fakeSupabase } = vi.hoisted(() => {
     upsert(data: unknown) { this._op = 'upsert'; this._data = data; return this }
     update(data: unknown) { this._op = 'update'; this._data = data; return this }
     eq(col: string, val: unknown) { this._filters[col] = val; return this }
+    is(col: string, val: null | boolean) { this._filters[col] = { __is: val }; return this }
     order(_col: string) { return this }
 
     then<TResult1 = { data: Row[]; error: null }, TResult2 = never>(
@@ -156,6 +169,7 @@ vi.mock('../../lib/logger', () => ({
 import { useWorkoutStore } from '../workout'
 import { useBodyweightStore } from '../bodyweight'
 import { getLocalStorageMock } from '../../__tests__/helpers'
+import { _resetTombstones } from '../../lib/tombstones'
 
 // Helper: flush a microtask tick so any op() chained via syncQueue settles
 const tick = () => new Promise(resolve => setTimeout(resolve, 0))
@@ -165,6 +179,8 @@ describe('sync fuzz: SEV1 2026-04-12 regression', () => {
     setActivePinia(createPinia())
     fakeSupabase.reset()
     getLocalStorageMock().clear()
+    // Tombstones cache in-memory — must be reset or they leak between tests
+    _resetTombstones()
   })
 
   describe('workoutStore._fetchFromSupabase — READ path is read-only', () => {
@@ -310,8 +326,8 @@ describe('sync fuzz: SEV1 2026-04-12 regression', () => {
     })
   })
 
-  describe('user-initiated deletes still reach the server (positive control)', () => {
-    it('deleteSet issues exactly one DELETE on the sets table', async () => {
+  describe('user-initiated deletes soft-delete on the server (Gate 5)', () => {
+    it('deleteSet issues UPDATE { deleted_at } (never a hard DELETE)', async () => {
       const userId = 'test-user'
       fakeSupabase.seed('exercises', [
         { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
@@ -325,19 +341,23 @@ describe('sync fuzz: SEV1 2026-04-12 regression', () => {
       const store = useWorkoutStore()
       await store.init(userId)
       await tick()
-      // Baseline: no deletes from init
-      expect(fakeSupabase.deletesFor('sets')).toEqual([])
 
       store.deleteSet('ex-1', 's-1')
       await tick()
 
-      const deletes = fakeSupabase.deletesFor('sets')
-      expect(deletes).toHaveLength(1)
-      expect(deletes[0].filters).toMatchObject({ id: 's-1', user_id: userId })
-      expect(fakeSupabase.tables.sets).toHaveLength(0)
+      // NO hard delete
+      expect(fakeSupabase.deletesFor('sets')).toEqual([])
+      // Exactly one UPDATE with deleted_at set, scoped to id + user_id
+      const updates = fakeSupabase.updatesFor('sets')
+      expect(updates).toHaveLength(1)
+      expect(updates[0].filters).toMatchObject({ id: 's-1', user_id: userId })
+      expect((updates[0].data as Record<string, unknown>).deleted_at).toBeTypeOf('string')
+      // Server row still exists but with deleted_at populated
+      expect(fakeSupabase.tables.sets).toHaveLength(1)
+      expect(fakeSupabase.tables.sets[0].deleted_at).toBeTypeOf('string')
     })
 
-    it('bodyweight deleteEntry issues exactly one DELETE on bodyweight_entries', async () => {
+    it('bodyweight deleteEntry issues UPDATE { deleted_at } (never a hard DELETE)', async () => {
       const userId = 'test-user'
       fakeSupabase.seed('bodyweight_entries', [
         { id: 'bw-1', user_id: userId, date: '2026-01-01T12:00:00Z',
@@ -347,15 +367,159 @@ describe('sync fuzz: SEV1 2026-04-12 regression', () => {
       const store = useBodyweightStore()
       await store.init(userId)
       await tick()
-      expect(fakeSupabase.deletesFor('bodyweight_entries')).toEqual([])
 
       store.deleteEntry('bw-1')
       await tick()
 
-      const deletes = fakeSupabase.deletesFor('bodyweight_entries')
-      expect(deletes).toHaveLength(1)
-      expect(deletes[0].filters).toMatchObject({ id: 'bw-1', user_id: userId })
-      expect(fakeSupabase.tables.bodyweight_entries).toHaveLength(0)
+      expect(fakeSupabase.deletesFor('bodyweight_entries')).toEqual([])
+      const updates = fakeSupabase.updatesFor('bodyweight_entries')
+      expect(updates).toHaveLength(1)
+      expect(updates[0].filters).toMatchObject({ id: 'bw-1', user_id: userId })
+      expect((updates[0].data as Record<string, unknown>).deleted_at).toBeTypeOf('string')
+      expect(fakeSupabase.tables.bodyweight_entries).toHaveLength(1)
+      expect(fakeSupabase.tables.bodyweight_entries[0].deleted_at).toBeTypeOf('string')
+    })
+
+    it('deleteExercise soft-deletes the exercise AND its sets (cascade)', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ])
+      fakeSupabase.seed('sets', [
+        { id: 's-1', user_id: userId, exercise_id: 'ex-1',
+          date: '2026-01-01T12:00:00Z', weight: 225, reps: 5, estimated_1rm: 253 },
+        { id: 's-2', user_id: userId, exercise_id: 'ex-1',
+          date: '2026-01-02T12:00:00Z', weight: 235, reps: 5, estimated_1rm: 264 },
+      ])
+
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      store.deleteExercise('ex-1')
+      await tick()
+
+      expect(fakeSupabase.deletesFor('sets')).toEqual([])
+      expect(fakeSupabase.deletesFor('exercises')).toEqual([])
+      // Exactly one UPDATE on each table
+      const exerciseUpdates = fakeSupabase.updatesFor('exercises')
+      const setsUpdates = fakeSupabase.updatesFor('sets')
+      expect(exerciseUpdates).toHaveLength(1)
+      expect(setsUpdates).toHaveLength(1)
+      // Sets cascade targets exercise_id, not individual set ids
+      expect(setsUpdates[0].filters).toMatchObject({ exercise_id: 'ex-1', user_id: userId })
+      // Rows still present with deleted_at populated
+      expect(fakeSupabase.tables.exercises[0].deleted_at).toBeTypeOf('string')
+      expect(fakeSupabase.tables.sets.every(s => s.deleted_at != null)).toBe(true)
+    })
+
+    it('restoreSet issues UPDATE { deleted_at: null } (undo delete)', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ])
+      fakeSupabase.seed('sets', [
+        { id: 's-1', user_id: userId, exercise_id: 'ex-1',
+          date: '2026-01-01T12:00:00Z', weight: 225, reps: 5, estimated_1rm: 253 },
+      ])
+
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      const setToDelete = { ...store.exercises[0].sets[0] }
+      store.deleteSet('ex-1', 's-1')
+      await tick()
+      store.restoreSet('ex-1', setToDelete)
+      await tick()
+
+      const updates = fakeSupabase.updatesFor('sets')
+      // First update: deleted_at=<time>; second: deleted_at=null
+      expect(updates).toHaveLength(2)
+      expect((updates[0].data as Record<string, unknown>).deleted_at).toBeTypeOf('string')
+      expect((updates[1].data as Record<string, unknown>).deleted_at).toBeNull()
+      // Final server state: restored
+      expect(fakeSupabase.tables.sets[0].deleted_at).toBeNull()
+    })
+
+    it('restoreExercise issues UPDATE { deleted_at: null } on both exercise and sets', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ])
+      fakeSupabase.seed('sets', [
+        { id: 's-1', user_id: userId, exercise_id: 'ex-1',
+          date: '2026-01-01T12:00:00Z', weight: 225, reps: 5, estimated_1rm: 253 },
+      ])
+
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+      const exerciseCopy = { ...store.exercises[0] }
+
+      store.deleteExercise('ex-1')
+      await tick()
+      store.restoreExercise(exerciseCopy)
+      await tick()
+
+      const exUpdates = fakeSupabase.updatesFor('exercises')
+      const setUpdates = fakeSupabase.updatesFor('sets')
+      // Two updates each: soft-delete then restore
+      expect(exUpdates).toHaveLength(2)
+      expect(setUpdates).toHaveLength(2)
+      expect((exUpdates[1].data as Record<string, unknown>).deleted_at).toBeNull()
+      expect((setUpdates[1].data as Record<string, unknown>).deleted_at).toBeNull()
+      // Final state: all rows active
+      expect(fakeSupabase.tables.exercises[0].deleted_at).toBeNull()
+      expect(fakeSupabase.tables.sets[0].deleted_at).toBeNull()
+    })
+
+    it('_fetchFromSupabase filters soft-deleted rows (uses .is(deleted_at, null))', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-active', user_id: userId, name: 'Active', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+          deleted_at: null },
+        { id: 'ex-deleted', user_id: userId, name: 'Deleted', tags: [],
+          created_at: '2026-01-02T00:00:00Z', updated_at: '2026-01-02T00:00:00Z',
+          deleted_at: '2026-04-01T00:00:00Z' },
+      ])
+      fakeSupabase.seed('sets', [
+        { id: 's-active', user_id: userId, exercise_id: 'ex-active',
+          date: '2026-01-01T12:00:00Z', weight: 225, reps: 5, estimated_1rm: 253,
+          deleted_at: null },
+        { id: 's-deleted', user_id: userId, exercise_id: 'ex-active',
+          date: '2026-01-02T12:00:00Z', weight: 235, reps: 5, estimated_1rm: 264,
+          deleted_at: '2026-04-01T00:00:00Z' },
+      ])
+
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      // Only active rows should appear in local state
+      expect(store.exercises.map(e => e.id)).toEqual(['ex-active'])
+      expect(store.exercises[0].sets.map(s => s.id)).toEqual(['s-active'])
+    })
+
+    it('bodyweight _fetchFromSupabase filters soft-deleted entries', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('bodyweight_entries', [
+        { id: 'bw-active', user_id: userId, date: '2026-01-01T12:00:00Z',
+          weight: 180, updated_at: '2026-01-01T12:00:00Z', deleted_at: null },
+        { id: 'bw-deleted', user_id: userId, date: '2026-01-02T12:00:00Z',
+          weight: 181, updated_at: '2026-01-02T12:00:00Z',
+          deleted_at: '2026-04-01T00:00:00Z' },
+      ])
+
+      const store = useBodyweightStore()
+      await store.init(userId)
+      await tick()
+
+      expect(store.entries.map(e => e.id)).toEqual(['bw-active'])
     })
   })
 })

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -61,6 +61,7 @@ export const useBodyweightStore = defineStore('bodyweight', {
         .from('bodyweight_entries')
         .select('*')
         .eq('user_id', this._userId)
+        .is('deleted_at', null)
         .order('created_at')
 
       if (!data) return
@@ -157,10 +158,13 @@ export const useBodyweightStore = defineStore('bodyweight', {
       )
       if (tombstoneEntries.length > 0) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         for (const e of tombstoneEntries) {
           const entryId = e.id as string
           syncQueue.enqueueDelete(`bodyweight:${entryId}`, () =>
-            supabase!.from('bodyweight_entries').delete().eq('id', entryId).eq('user_id', userId),
+            supabase!.from('bodyweight_entries')
+              .update({ deleted_at: deletedAt })
+              .eq('id', entryId).eq('user_id', userId),
           )
         }
       }
@@ -213,8 +217,11 @@ export const useBodyweightStore = defineStore('bodyweight', {
 
       if (sync && supabase && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete(`bodyweight:${id}`, () =>
-          supabase!.from('bodyweight_entries').delete().eq('id', id).eq('user_id', userId)
+          supabase!.from('bodyweight_entries')
+            .update({ deleted_at: deletedAt })
+            .eq('id', id).eq('user_id', userId)
         )
       }
     },
@@ -223,13 +230,28 @@ export const useBodyweightStore = defineStore('bodyweight', {
       removeTombstone(TOMBSTONE_STORE, entry.id)
       this.entries.push(entry)
       this._persist()
+
+      // Soft-delete restore: clear deleted_at on server. Uses the same key as
+      // deleteEntry so an in-flight delete is canceled by this enqueue's last-
+      // write-wins. If the delete already flushed, this un-soft-deletes the row.
+      if (supabase && !isPreviewMode.value && this._userId) {
+        const userId = this._userId
+        syncQueue.enqueue(`bodyweight:${entry.id}`, () =>
+          supabase!.from('bodyweight_entries')
+            .update({ deleted_at: null })
+            .eq('id', entry.id).eq('user_id', userId)
+        )
+      }
     },
 
     syncDeleteEntry(id: string) {
       if (supabase && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete(`bodyweight:${id}`, () =>
-          supabase!.from('bodyweight_entries').delete().eq('id', id).eq('user_id', userId)
+          supabase!.from('bodyweight_entries')
+            .update({ deleted_at: deletedAt })
+            .eq('id', id).eq('user_id', userId)
         )
       }
     },
@@ -240,8 +262,12 @@ export const useBodyweightStore = defineStore('bodyweight', {
 
       if (supabase && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete('bodyweight:clear-all', () =>
-          supabase!.from('bodyweight_entries').delete().eq('user_id', userId)
+          supabase!.from('bodyweight_entries')
+            .update({ deleted_at: deletedAt })
+            .eq('user_id', userId)
+            .is('deleted_at', null)
         )
       }
     }

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -207,8 +207,8 @@ export const useWorkoutStore = defineStore('workout', {
       if (!supabase || !this._userId) return
 
       const [{ data: exercises }, { data: sets }] = await Promise.all([
-        supabase.from('exercises').select('*').eq('user_id', this._userId).order('created_at'),
-        supabase.from('sets').select('*').eq('user_id', this._userId).order('created_at')
+        supabase.from('exercises').select('*').eq('user_id', this._userId).is('deleted_at', null).order('created_at'),
+        supabase.from('sets').select('*').eq('user_id', this._userId).is('deleted_at', null).order('created_at')
       ])
 
       if (!exercises) return
@@ -239,11 +239,14 @@ export const useWorkoutStore = defineStore('workout', {
       const remoteSetsMap = new Map<string, WorkoutSet[]>()
       for (const s of (sets || []) as Record<string, unknown>[]) {
         if (isTombstoned('sets', s.id as string)) {
-          // Re-enqueue the delete for tombstoned sets still in remote
+          // Re-enqueue the soft-delete for tombstoned sets still visible on remote
           const setId = s.id as string
           const userId = this._userId
+          const deletedAt = new Date().toISOString()
           syncQueue.enqueueDelete(`set:${setId}`, () =>
-            supabase!.from('sets').delete().eq('id', setId).eq('user_id', userId)
+            supabase!.from('sets')
+              .update({ deleted_at: deletedAt })
+              .eq('id', setId).eq('user_id', userId)
           )
           continue
         }
@@ -390,13 +393,18 @@ export const useWorkoutStore = defineStore('workout', {
         .filter((ex: Record<string, unknown>) => isTombstoned(TOMBSTONE_STORE, ex.id as string))
       if (tombstoneExercises.length > 0) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         for (const ex of tombstoneExercises) {
           const exId = ex.id as string
           syncQueue.enqueueDelete(`exercise-sets:${exId}`, () =>
-            supabase!.from('sets').delete().eq('exercise_id', exId).eq('user_id', userId)
+            supabase!.from('sets')
+              .update({ deleted_at: deletedAt })
+              .eq('exercise_id', exId).eq('user_id', userId)
           )
           syncQueue.enqueueDelete(`exercise:${exId}`, () =>
-            supabase!.from('exercises').delete().eq('id', exId).eq('user_id', userId)
+            supabase!.from('exercises')
+              .update({ deleted_at: deletedAt })
+              .eq('id', exId).eq('user_id', userId)
           )
         }
       }
@@ -528,8 +536,11 @@ export const useWorkoutStore = defineStore('workout', {
 
       if (sync && supabase && !isPreviewMode.value && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete(`set:${setId}`, () =>
-          supabase!.from('sets').delete().eq('id', setId).eq('user_id', userId)
+          supabase!.from('sets')
+            .update({ deleted_at: deletedAt })
+            .eq('id', setId).eq('user_id', userId)
         )
       }
     },
@@ -540,6 +551,18 @@ export const useWorkoutStore = defineStore('workout', {
       removeTombstone('sets', set.id)
       exercise.sets.push(set)
       this._persist()
+
+      // Soft-delete restore: clear deleted_at on server. Uses the same key as
+      // deleteSet so an in-flight delete is superseded (last-write-wins). If
+      // the delete already flushed, this un-soft-deletes the row.
+      if (supabase && !isPreviewMode.value && this._userId) {
+        const userId = this._userId
+        syncQueue.enqueue(`set:${set.id}`, () =>
+          supabase!.from('sets')
+            .update({ deleted_at: null })
+            .eq('id', set.id).eq('user_id', userId)
+        )
+      }
     },
 
     renameExercise(exerciseId: string, newName: string) {
@@ -594,11 +617,16 @@ export const useWorkoutStore = defineStore('workout', {
 
       if (sync && supabase && !isPreviewMode.value && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete(`exercise-sets:${exerciseId}`, () =>
-          supabase!.from('sets').delete().eq('exercise_id', exerciseId).eq('user_id', userId)
+          supabase!.from('sets')
+            .update({ deleted_at: deletedAt })
+            .eq('exercise_id', exerciseId).eq('user_id', userId)
         )
         syncQueue.enqueueDelete(`exercise:${exerciseId}`, () =>
-          supabase!.from('exercises').delete().eq('id', exerciseId).eq('user_id', userId)
+          supabase!.from('exercises')
+            .update({ deleted_at: deletedAt })
+            .eq('id', exerciseId).eq('user_id', userId)
         )
       }
     },
@@ -611,13 +639,38 @@ export const useWorkoutStore = defineStore('workout', {
         this.exercises.push(exercise)
       }
       this._persist()
+
+      // Soft-delete restore: clear deleted_at on both the exercise and its sets.
+      // Uses the same keys as deleteExercise so in-flight deletes are superseded.
+      // If the delete already flushed, these un-soft-delete.
+      //
+      // Note: restoring sets by exercise_id will also resurrect sets that were
+      // individually soft-deleted before the exercise delete. Edge case; the
+      // alternative (tracking per-cascade timestamps) is complexity without
+      // matching benefit for immediate-undo UX.
+      if (supabase && !isPreviewMode.value && this._userId) {
+        const userId = this._userId
+        syncQueue.enqueue(`exercise-sets:${exercise.id}`, () =>
+          supabase!.from('sets')
+            .update({ deleted_at: null })
+            .eq('exercise_id', exercise.id).eq('user_id', userId)
+        )
+        syncQueue.enqueue(`exercise:${exercise.id}`, () =>
+          supabase!.from('exercises')
+            .update({ deleted_at: null })
+            .eq('id', exercise.id).eq('user_id', userId)
+        )
+      }
     },
 
     syncDeleteSet(setId: string) {
       if (supabase && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete(`set:${setId}`, () =>
-          supabase!.from('sets').delete().eq('id', setId).eq('user_id', userId)
+          supabase!.from('sets')
+            .update({ deleted_at: deletedAt })
+            .eq('id', setId).eq('user_id', userId)
         )
       }
     },
@@ -625,11 +678,16 @@ export const useWorkoutStore = defineStore('workout', {
     syncDeleteExercise(exerciseId: string) {
       if (supabase && this._userId) {
         const userId = this._userId
+        const deletedAt = new Date().toISOString()
         syncQueue.enqueueDelete(`exercise-sets:${exerciseId}`, () =>
-          supabase!.from('sets').delete().eq('exercise_id', exerciseId).eq('user_id', userId)
+          supabase!.from('sets')
+            .update({ deleted_at: deletedAt })
+            .eq('exercise_id', exerciseId).eq('user_id', userId)
         )
         syncQueue.enqueueDelete(`exercise:${exerciseId}`, () =>
-          supabase!.from('exercises').delete().eq('id', exerciseId).eq('user_id', userId)
+          supabase!.from('exercises')
+            .update({ deleted_at: deletedAt })
+            .eq('id', exerciseId).eq('user_id', userId)
         )
       }
     },


### PR DESCRIPTION
## Summary

Activates the `deleted_at` columns added in #355. User-initiated deletes now **UPDATE deleted_at** instead of **DELETE**, SELECTs filter soft-deleted rows via `.is('deleted_at', null)`, and restore paths un-soft-delete via `UPDATE deleted_at=null`.

Phase 2 progress: **5 of 6 gates landed** (Gate 6 cron cleanup is all that's left).

## Behavioral changes

### Writes (13 sites)
- 9 in `src/stores/workout.ts`: `deleteSet`, `deleteExercise` (2-op cascade), `syncDeleteSet`, `syncDeleteExercise` (2-op cascade), 3 tombstone-re-enqueue paths in `_fetchFromSupabase`
- 4 in `src/stores/bodyweight.ts`: `deleteEntry`, `syncDeleteEntry`, `clearAll`, tombstone re-enqueue

All rewritten from `.delete().eq(...)` to `.update({ deleted_at: <iso-timestamp> }).eq(...)`.

### Reads (3 sites)
- `workout._fetchFromSupabase` exercises + sets selects
- `bodyweight._fetchFromSupabase` entries select

All now chain `.is('deleted_at', null)`.

### Restores (3 paths, new server-side behavior)
- `restoreSet`, `restoreExercise`, `restoreEntry` now enqueue `UPDATE deleted_at=null` alongside the existing local-only state push.
- Same key as the paired delete op, so in-flight deletes are superseded by last-write-wins in the syncQueue.

### Explicit non-changes
- `useAuth.deleteAccount` still hard-deletes. Account-wipe is explicit user intent and bypasses syncQueue.
- Tombstones retained — they still gate local UI visibility during the sync flush window.
- Circuit breaker (#356) unchanged. Continues to guard `enqueueDelete` volume.

## Invariants enforced

New structural test in [syncQueue.test.ts](src/lib/__tests__/syncQueue.test.ts):

> stores never call `.delete()` on a Supabase query — all removals are soft

Fails the build if any future code in `stores/*.ts` uses `supabase.from(...).delete()`. The existing "no plain-enqueue wrapping .delete()" test still holds as a weaker second line of defense.

## Blast radius

**Low.** Verified on prod via psql before opening this PR:

| Table | Active rows | Soft-deleted |
|---|---|---|
| exercises | 61 | 0 |
| sets | 422 | 0 |
| bodyweight_entries | 17 | 0 |

With zero existing soft-deleted rows, the new `.is('deleted_at', null)` filter is a no-op for existing data. Client behavior for reads is byte-identical. New deletes become soft — recoverable within the grace window once Gate 6 ships the hard-delete cron.

## Supporting changes

- **Fake Supabase in syncFuzz.test.ts**: new `.is()` method, new `updatesFor()` helper, handles `null`-or-undefined comparison for seeded rows without `deleted_at`.
- **`tombstones.ts`**: exported `_resetTombstones()` for test isolation. The in-memory `_data` cache was leaking tombstones between tests, causing false-positive cascade updates in later tests. Fixed.
- **`database.types.ts`**: manually added `deleted_at: string | null` to `exercises`, `sets`, `bodyweight_entries` Row/Insert/Update shapes. The normal regen (`npm run db:types`) needs a Supabase access token which isn't available locally; generated types will match these fields on next full regen.

## Test plan

- [x] 12/12 fuzz tests pass (6 new soft-delete behavioral cases added: cascade, restore, read filter for both stores)
- [x] 25/25 syncQueue + circuit-breaker tests pass (1 new structural test for "no .delete() in stores")
- [x] Full `npm test` → 1254/1254 pass (+6 from prior 1248)
- [x] `npm run lint` → 0 errors, 9 pre-existing warnings
- [x] `npm run typecheck` → clean after database.types.ts update
- [x] Prod row counts all active (verified via psql direct connection)

## What this does NOT do

- Does not time-travel: old sets that were hard-deleted before PR #338 are gone forever. Soft-delete only protects deletions from this point forward.
- Does not limit how far back a restore can reach: restoreSet/Exercise/Entry only surface in the immediate-undo UX toast; there's no "restore from trash" UI yet.
- Does not hard-clean old soft-deleted rows — that's Gate 6.

## Follow-ups (Gate 6 + post-Phase-2)

- Gate 6: scheduled cron to hard-delete rows where `deleted_at < now() - interval '30 days'`
- Post-Phase-2 issue #339 scope: server-authoritative `updated_at`, 7-day IDB rolling snapshots, deferred-ops persistence

Contributes to #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)