### PR TITLE
feat: hide-warmups filter for timeline and exercise details

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -296,6 +296,36 @@
               </div>
             </div>
 
+            <div class="settingsGroup">
+              <div class="settingsHeader">Filters</div>
+              <div class="settingsRow">
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel">Warmup threshold</span>
+                  <span class="settingsHint">{{ Math.round(prefs.warmupThreshold * 100) }}% of the top set</span>
+                </div>
+                <div class="iosStepper">
+                  <button
+                    class="iosStepperBtn"
+                    @click="adjustWarmupThreshold(-WARMUP_THRESHOLD_STEP)"
+                    :disabled="prefs.warmupThreshold <= WARMUP_THRESHOLD_MIN + 0.001"
+                    aria-label="Decrease warmup threshold"
+                  >−</button>
+                  <span class="iosStepperValue">{{ Math.round(prefs.warmupThreshold * 100) }}%</span>
+                  <button
+                    class="iosStepperBtn"
+                    @click="adjustWarmupThreshold(WARMUP_THRESHOLD_STEP)"
+                    :disabled="prefs.warmupThreshold >= WARMUP_THRESHOLD_MAX - 0.001"
+                    aria-label="Increase warmup threshold"
+                  >+</button>
+                </div>
+              </div>
+              <div class="settingsRow">
+                <span class="settingsHint">
+                  Sets logged before your top set at or below this percentage are treated as warmups when the filter is on.
+                </span>
+              </div>
+            </div>
+
             <!-- Dev tools — only on localhost/LAN -->
             <div v-if="isDev" class="settingsGroup">
               <div class="settingsHeader">Dev Tools</div>
@@ -777,6 +807,11 @@ import { hashUserId, buildJsonExport, buildCsvExport } from './lib/dataExport'
 import { importCSV } from './lib/csvImport'
 import { usePreferencesStore } from './stores/preferences'
 import type { WeightGoalDirection } from './stores/preferences'
+import {
+  WARMUP_THRESHOLD_MIN,
+  WARMUP_THRESHOLD_MAX,
+  WARMUP_THRESHOLD_STEP,
+} from './lib/warmupFilter'
 import { useWorkoutStore } from './stores/workout'
 import { syncStatus } from './lib/syncQueue'
 import { useBodyweightStore } from './stores/bodyweight'
@@ -820,6 +855,10 @@ const effectiveWeeklyTarget = computed(() =>
 function adjustWeeklyTarget(delta: number) {
   const next = Math.max(1, Math.min(7, effectiveWeeklyTarget.value + delta))
   progressionStore.setWeeklyTarget(next)
+}
+
+function adjustWarmupThreshold(delta: number) {
+  prefs.setWarmupThreshold(prefs.warmupThreshold + delta)
 }
 
 const weeklyGoalBonusLabel = computed(() => {

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -105,8 +105,22 @@
 
     <!-- Timeline view -->
     <template v-else-if="listView === 'timeline'">
+      <div v-if="timelineSets.length > 0 && timelineWarmupCount > 0" class="wtFilterBar">
+        <button
+          :class="['wtFilterToggle', { wtFilterToggleActive: hideWarmups }]"
+          :aria-pressed="hideWarmups"
+          @click="hideWarmups = !hideWarmups"
+        >
+          <svg v-if="hideWarmups" class="wtFilterCheck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+          <span>Hide warmups</span>
+          <span class="wtFilterCount">{{ timelineWarmupCount }}</span>
+        </button>
+      </div>
       <div v-if="timelineSets.length === 0" class="wtEmpty">
         No sets logged yet.
+      </div>
+      <div v-else-if="filteredTimelineSets.length === 0" class="wtEmpty">
+        All {{ timelineWarmupCount }} sets are warmups at your current threshold.
       </div>
       <div v-else class="wtTimeline">
         <template v-for="group in visibleTimelineGroups" :key="group.key">
@@ -132,8 +146,8 @@
             </div>
           </div>
         </template>
-        <button v-if="timelineLimit < timelineSets.length" class="wtTimelineShowMore" @click="timelineLimit += 50">
-          Show more ({{ timelineSets.length - timelineLimit }} remaining)
+        <button v-if="timelineLimit < filteredTimelineSets.length" class="wtTimelineShowMore" @click="timelineLimit += 50">
+          Show more ({{ filteredTimelineSets.length - timelineLimit }} remaining)
         </button>
       </div>
     </template>
@@ -169,8 +183,20 @@
 
           <!-- All Sets view -->
           <template v-if="detailTab === 'sets'">
+            <div v-if="detailWarmupCount > 0" class="wtFilterBar wtFilterBarDetail">
+              <button
+                :class="['wtFilterToggle', { wtFilterToggleActive: hideWarmups }]"
+                :aria-pressed="hideWarmups"
+                @click="hideWarmups = !hideWarmups"
+              >
+                <svg v-if="hideWarmups" class="wtFilterCheck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+                <span>Hide warmups</span>
+                <span class="wtFilterCount">{{ detailWarmupCount }}</span>
+              </button>
+            </div>
             <div class="wtSetList">
               <p v-if="detailExercise.sets.length === 0" class="wtSetEmpty">No sets logged yet.</p>
+              <p v-else-if="groupedSets.length === 0" class="wtSetEmpty">All sets are warmups at your current threshold.</p>
               <template v-for="group in groupedSets" :key="group.key">
                 <p class="wtSetDateHeader">{{ formatDate(group.date) }}</p>
                 <div class="wtSetCard">
@@ -922,14 +948,17 @@ import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
 import { usePRBaseline } from '../composables/usePRBaseline'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
+import { usePreferencesStore } from '../stores/preferences'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
 import { calculateSetXP, calculateBest1RM, applyStreakMultiplier, checkRepPR, isExerciseEstablished, XP_CONFIG } from '../lib/xp'
+import { classifyWarmupsByExercise, classifyExerciseWarmups } from '../lib/warmupFilter'
 import { logXPEvent } from '../lib/xpInstrumentation'
 import ExerciseGraph from './ExerciseGraph.vue'
 
 const store = useWorkoutStore()
 const progressionStore = useProgressionStore()
+const prefs = usePreferencesStore()
 const { logEvent } = useAnalytics()
 const { show: showUndo } = useUndoToast()
 const { currentTheme, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, setRestTimerEnabled } = useTheme()
@@ -1113,8 +1142,32 @@ const timelinePRMap = computed((): Record<string, 'pr' | 'repPR'> => {
   return map
 })
 
+// Session-only toggle — shared across timeline and exercise detail modal.
+// Intentionally not persisted: the filter is purely a view preference and we
+// never want to silently hide data across sessions.
+const hideWarmups = ref(false)
+
+// Warmup IDs computed across all exercises — used by the timeline view.
+// Recomputes when sets, threshold, or the filter toggle flip.
+const timelineWarmupIds = computed<Set<string>>(() => {
+  if (!hideWarmups.value) return new Set()
+  return classifyWarmupsByExercise(store.exercises, prefs.warmupThreshold)
+})
+
+const filteredTimelineSets = computed((): TimelineEntry[] => {
+  if (!hideWarmups.value) return timelineSets.value
+  const warmups = timelineWarmupIds.value
+  return timelineSets.value.filter(e => !warmups.has(e.set.id))
+})
+
+// Total warmup count across all exercises — shown next to the toggle so the
+// user knows how many sets the filter would hide before they turn it on.
+const timelineWarmupCount = computed(() =>
+  classifyWarmupsByExercise(store.exercises, prefs.warmupThreshold).size
+)
+
 const visibleTimelineGroups = computed(() => {
-  const limited = timelineSets.value.slice(0, timelineLimit.value)
+  const limited = filteredTimelineSets.value.slice(0, timelineLimit.value)
   const groups: { key: string; label: string; sets: TimelineEntry[] }[] = []
   for (const entry of limited) {
     const k = toLocalDateKey(entry.set.date)
@@ -1435,11 +1488,24 @@ function toLocalDateKey(iso: string): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
+// Warmup IDs scoped to the currently open detail exercise.
+const detailWarmupIds = computed<Set<string>>(() => {
+  if (!hideWarmups.value || !detailExercise.value) return new Set()
+  return classifyExerciseWarmups(detailExercise.value.sets, prefs.warmupThreshold)
+})
+
+const detailWarmupCount = computed(() => {
+  if (!detailExercise.value) return 0
+  return classifyExerciseWarmups(detailExercise.value.sets, prefs.warmupThreshold).size
+})
+
 const groupedSets = computed(() => {
   if (!detailExercise.value) return []
   const sets = visibleSets(detailExercise.value)
+  const warmups = detailWarmupIds.value
+  const filtered = warmups.size > 0 ? sets.filter(s => !warmups.has(s.id)) : sets
   const groups: { date: string; key: string; sets: WorkoutSet[] }[] = []
-  for (const set of sets) {
+  for (const set of filtered) {
     const k = toLocalDateKey(set.date)
     const last = groups[groups.length - 1]
     if (last && last.key === k) {

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -105,7 +105,7 @@
 
     <!-- Timeline view -->
     <template v-else-if="listView === 'timeline'">
-      <div v-if="timelineSets.length > 0 && timelineWarmupCount > 0" class="wtFilterBar">
+      <div v-if="timelineSets.length > 0 && timelineWarmupCount > 0 && !warmupFilterDismissed" class="wtFilterBar">
         <button
           :class="['wtFilterToggle', { wtFilterToggleActive: hideWarmups }]"
           :aria-pressed="hideWarmups"
@@ -114,6 +114,28 @@
           <svg v-if="hideWarmups" class="wtFilterCheck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
           <span>Hide warmups</span>
           <span class="wtFilterCount">{{ timelineWarmupCount }}</span>
+        </button>
+        <div class="wtFilterStepper" role="group" aria-label="Warmup threshold">
+          <button
+            class="wtFilterStepperBtn"
+            @click="adjustWarmupThreshold(-WARMUP_THRESHOLD_STEP)"
+            :disabled="prefs.warmupThreshold <= WARMUP_THRESHOLD_MIN + 0.001"
+            aria-label="Decrease warmup threshold"
+          >−</button>
+          <span class="wtFilterStepperValue">{{ Math.round(prefs.warmupThreshold * 100) }}%</span>
+          <button
+            class="wtFilterStepperBtn"
+            @click="adjustWarmupThreshold(WARMUP_THRESHOLD_STEP)"
+            :disabled="prefs.warmupThreshold >= WARMUP_THRESHOLD_MAX - 0.001"
+            aria-label="Increase warmup threshold"
+          >+</button>
+        </div>
+        <button
+          class="wtFilterDismiss"
+          @click="warmupFilterDismissed = true; hideWarmups = false"
+          aria-label="Dismiss warmup filter"
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
         </button>
       </div>
       <div v-if="timelineSets.length === 0" class="wtEmpty">
@@ -183,7 +205,7 @@
 
           <!-- All Sets view -->
           <template v-if="detailTab === 'sets'">
-            <div v-if="detailWarmupCount > 0" class="wtFilterBar wtFilterBarDetail">
+            <div v-if="detailWarmupCount > 0 && !warmupFilterDismissed" class="wtFilterBar wtFilterBarDetail">
               <button
                 :class="['wtFilterToggle', { wtFilterToggleActive: hideWarmups }]"
                 :aria-pressed="hideWarmups"
@@ -192,6 +214,28 @@
                 <svg v-if="hideWarmups" class="wtFilterCheck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" width="14" height="14" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
                 <span>Hide warmups</span>
                 <span class="wtFilterCount">{{ detailWarmupCount }}</span>
+              </button>
+              <div class="wtFilterStepper" role="group" aria-label="Warmup threshold">
+                <button
+                  class="wtFilterStepperBtn"
+                  @click="adjustWarmupThreshold(-WARMUP_THRESHOLD_STEP)"
+                  :disabled="prefs.warmupThreshold <= WARMUP_THRESHOLD_MIN + 0.001"
+                  aria-label="Decrease warmup threshold"
+                >−</button>
+                <span class="wtFilterStepperValue">{{ Math.round(prefs.warmupThreshold * 100) }}%</span>
+                <button
+                  class="wtFilterStepperBtn"
+                  @click="adjustWarmupThreshold(WARMUP_THRESHOLD_STEP)"
+                  :disabled="prefs.warmupThreshold >= WARMUP_THRESHOLD_MAX - 0.001"
+                  aria-label="Increase warmup threshold"
+                >+</button>
+              </div>
+              <button
+                class="wtFilterDismiss"
+                @click="warmupFilterDismissed = true; hideWarmups = false"
+                aria-label="Dismiss warmup filter"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
               </button>
             </div>
             <div class="wtSetList">
@@ -952,7 +996,13 @@ import { usePreferencesStore } from '../stores/preferences'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
 import { calculateSetXP, calculateBest1RM, applyStreakMultiplier, checkRepPR, isExerciseEstablished, XP_CONFIG } from '../lib/xp'
-import { classifyWarmupsByExercise, classifyExerciseWarmups } from '../lib/warmupFilter'
+import {
+  classifyWarmupsByExercise,
+  classifyExerciseWarmups,
+  WARMUP_THRESHOLD_MIN,
+  WARMUP_THRESHOLD_MAX,
+  WARMUP_THRESHOLD_STEP,
+} from '../lib/warmupFilter'
 import { logXPEvent } from '../lib/xpInstrumentation'
 import ExerciseGraph from './ExerciseGraph.vue'
 
@@ -1146,6 +1196,14 @@ const timelinePRMap = computed((): Record<string, 'pr' | 'repPR'> => {
 // Intentionally not persisted: the filter is purely a view preference and we
 // never want to silently hide data across sessions.
 const hideWarmups = ref(false)
+
+// Session-only "hide the filter bar entirely" escape hatch. Reappears on reload.
+// Lets the user fully dismiss the feature without opening Settings.
+const warmupFilterDismissed = ref(false)
+
+function adjustWarmupThreshold(delta: number) {
+  prefs.setWarmupThreshold(prefs.warmupThreshold + delta)
+}
 
 // Warmup IDs computed across all exercises — used by the timeline view.
 // Recomputes when sets, threshold, or the filter toggle flip.

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -140,6 +140,13 @@ vi.mock('../../stores/workout', () => ({
   })
 }))
 
+vi.mock('../../stores/preferences', () => ({
+  usePreferencesStore: () => ({
+    warmupThreshold: 0.75,
+    setWarmupThreshold: vi.fn(),
+  }),
+}))
+
 
 
 import WorkoutTracker from '../WorkoutTracker.vue'

--- a/src/index.css
+++ b/src/index.css
@@ -2353,9 +2353,9 @@ html.theme-fading .settingsSheet {
   padding: 0 8px;
   height: 20px;
   border-radius: 10px;
-  background: var(--surface);
+  background: var(--bg-elevated);
   color: var(--text-muted);
-  font-size: var(--font-caption-2);
+  font-size: var(--font-caption2);
   font-weight: 600;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -2305,6 +2305,65 @@ html.theme-fading .settingsSheet {
   justify-content: center;
 }
 
+/* ─── Warmup filter toggle ─────────────────────────────────────────────── */
+
+.wtFilterBar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 16px 0;
+}
+
+.wtFilterBarDetail {
+  padding: 0 0 12px;
+}
+
+.wtFilterToggle {
+  font-size: var(--font-footnote);
+  font-weight: 600;
+  padding: 8px 16px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 14px;
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.wtFilterToggleActive {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.wtFilterCheck {
+  flex-shrink: 0;
+}
+
+.wtFilterCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  padding: 0 8px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: var(--font-caption-2);
+  font-weight: 600;
+}
+
+.wtFilterToggleActive .wtFilterCount {
+  background: rgba(255, 255, 255, 0.25);
+  color: var(--text-on-accent);
+}
+
 /* ─── Tag manager modal ────────────────────────────────────────────────── */
 
 .wtTagManagerList {

--- a/src/index.css
+++ b/src/index.css
@@ -2310,8 +2310,9 @@ html.theme-fading .settingsSheet {
 .wtFilterBar {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 16px 0;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px 0;
 }
 
 .wtFilterBarDetail {
@@ -2321,7 +2322,7 @@ html.theme-fading .settingsSheet {
 .wtFilterToggle {
   font-size: var(--font-footnote);
   font-weight: 600;
-  padding: 8px 16px;
+  padding: 8px 12px;
   min-height: 44px;
   display: inline-flex;
   align-items: center;
@@ -2362,6 +2363,76 @@ html.theme-fading .settingsSheet {
 .wtFilterToggleActive .wtFilterCount {
   background: rgba(255, 255, 255, 0.25);
   color: var(--text-on-accent);
+}
+
+.wtFilterStepper {
+  display: inline-flex;
+  align-items: center;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  overflow: hidden;
+}
+
+.wtFilterStepperBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  min-height: 44px;
+  font-size: var(--font-body);
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--accent);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.wtFilterStepperBtn:active {
+  background: var(--bg-hover);
+}
+
+.wtFilterStepperBtn:disabled {
+  color: var(--text-muted);
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.wtFilterStepperValue {
+  min-width: 48px;
+  padding: 0 8px;
+  text-align: center;
+  font-size: var(--font-footnote);
+  font-weight: 600;
+  color: var(--text-primary);
+  border-left: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  line-height: 44px;
+  font-variant-numeric: tabular-nums;
+}
+
+.wtFilterDismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border-radius: 14px;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+}
+
+.wtFilterDismiss:active {
+  background: var(--bg-hover);
+  color: var(--text-primary);
 }
 
 /* ─── Tag manager modal ────────────────────────────────────────────────── */

--- a/src/lib/__tests__/warmupFilter.test.ts
+++ b/src/lib/__tests__/warmupFilter.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyExerciseWarmups,
+  classifyWarmupsByExercise,
+  normalizeWarmupThreshold,
+  WARMUP_THRESHOLD_DEFAULT,
+  WARMUP_THRESHOLD_MAX,
+  WARMUP_THRESHOLD_MIN,
+} from '../warmupFilter'
+import type { WorkoutSet } from '../../stores/workout'
+
+function makeSet(overrides: Partial<WorkoutSet> & { id: string; date: string; estimated1RM: number }): WorkoutSet {
+  return {
+    weight: 100,
+    reps: 5,
+    ...overrides,
+  }
+}
+
+describe('classifyExerciseWarmups', () => {
+  it('returns empty set for empty input', () => {
+    expect(classifyExerciseWarmups([])).toEqual(new Set())
+  })
+
+  it('single-set day is never a warmup', () => {
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'a', date: '2026-04-17T10:00:00Z', estimated1RM: 50 }),
+    ]
+    expect(classifyExerciseWarmups(sets)).toEqual(new Set())
+  })
+
+  it('classifies a ramp-up set below threshold as warmup', () => {
+    // 180 / 300 = 60% → warmup at 75% threshold
+    // 240 / 300 = 80% → working at 75% threshold
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'warmup1', date: '2026-04-17T10:00:00Z', estimated1RM: 180 }),
+      makeSet({ id: 'ramp',    date: '2026-04-17T10:05:00Z', estimated1RM: 240 }),
+      makeSet({ id: 'top',     date: '2026-04-17T10:10:00Z', estimated1RM: 300 }),
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set(['warmup1']))
+  })
+
+  it('sets logged AFTER the top set are never warmups (back-off / drop sets)', () => {
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'top',    date: '2026-04-17T10:00:00Z', estimated1RM: 300 }),
+      makeSet({ id: 'backoff',date: '2026-04-17T10:05:00Z', estimated1RM: 100 }), // 33% — would be warmup by ratio, but logged after top
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set())
+  })
+
+  it('top set itself is never a warmup even if ratio == 1.0', () => {
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'pre', date: '2026-04-17T10:00:00Z', estimated1RM: 50 }),
+      makeSet({ id: 'top', date: '2026-04-17T10:05:00Z', estimated1RM: 200 }),
+    ]
+    const result = classifyExerciseWarmups(sets, 0.75)
+    expect(result.has('top')).toBe(false)
+    expect(result.has('pre')).toBe(true)
+  })
+
+  it('threshold boundary: ratio exactly equal to threshold is a warmup (inclusive)', () => {
+    // 75 / 100 = 0.75 — should be classified as warmup at threshold 0.75
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'edge', date: '2026-04-17T10:00:00Z', estimated1RM: 75 }),
+      makeSet({ id: 'top',  date: '2026-04-17T10:05:00Z', estimated1RM: 100 }),
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set(['edge']))
+  })
+
+  it('threshold boundary: ratio just above threshold is NOT a warmup', () => {
+    // 76 / 100 = 0.76 — above threshold 0.75
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'near', date: '2026-04-17T10:00:00Z', estimated1RM: 76 }),
+      makeSet({ id: 'top',  date: '2026-04-17T10:05:00Z', estimated1RM: 100 }),
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set())
+  })
+
+  it('ties on top e1RM use the chronologically first occurrence as "the top"', () => {
+    // Two sets tie for max e1RM; first occurrence wins, second is "after top" → working.
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'wu',   date: '2026-04-17T10:00:00Z', estimated1RM: 60 }),  // 60% — warmup
+      makeSet({ id: 'top1', date: '2026-04-17T10:05:00Z', estimated1RM: 200 }), // first max → the top
+      makeSet({ id: 'low',  date: '2026-04-17T10:10:00Z', estimated1RM: 80 }),  // after top → working
+      makeSet({ id: 'top2', date: '2026-04-17T10:15:00Z', estimated1RM: 200 }), // tie after top → working
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set(['wu']))
+  })
+
+  it('groups by local date — same calendar day across timestamp jitter', () => {
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'wuDay1',  date: '2026-04-17T09:00:00Z', estimated1RM: 40 }),
+      makeSet({ id: 'topDay1', date: '2026-04-17T10:00:00Z', estimated1RM: 200 }),
+      // Different day — independent group
+      makeSet({ id: 'soloDay2', date: '2026-04-18T10:00:00Z', estimated1RM: 50 }),
+    ]
+    const result = classifyExerciseWarmups(sets, 0.75)
+    expect(result).toEqual(new Set(['wuDay1']))
+    expect(result.has('soloDay2')).toBe(false)
+  })
+
+  it('different days do not influence each other', () => {
+    // Day 1 has a heavy set (300) and a "warmup" (100)
+    // Day 2 has only light sets (50, 60) — nothing should be a warmup on day 2 since max there is 60
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'd1-wu',  date: '2026-04-17T10:00:00Z', estimated1RM: 100 }),
+      makeSet({ id: 'd1-top', date: '2026-04-17T10:05:00Z', estimated1RM: 300 }),
+      makeSet({ id: 'd2-a',   date: '2026-04-18T10:00:00Z', estimated1RM: 50 }),
+      makeSet({ id: 'd2-b',   date: '2026-04-18T10:05:00Z', estimated1RM: 60 }),
+    ]
+    const result = classifyExerciseWarmups(sets, 0.75)
+    expect(result.has('d1-wu')).toBe(true)
+    // 50 / 60 = 83% — above threshold, not a warmup
+    expect(result.has('d2-a')).toBe(false)
+    expect(result.has('d2-b')).toBe(false)
+  })
+
+  it('handles non-chronological input (sorts internally)', () => {
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'top', date: '2026-04-17T10:10:00Z', estimated1RM: 300 }),
+      makeSet({ id: 'wu',  date: '2026-04-17T10:00:00Z', estimated1RM: 100 }),
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set(['wu']))
+  })
+
+  it('ignores non-positive top e1RM defensively', () => {
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'a', date: '2026-04-17T10:00:00Z', estimated1RM: 0 }),
+      makeSet({ id: 'b', date: '2026-04-17T10:05:00Z', estimated1RM: 0 }),
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75)).toEqual(new Set())
+  })
+
+  it('higher threshold catches more sets as warmups', () => {
+    // 76 / 100 = 0.76
+    const sets: WorkoutSet[] = [
+      makeSet({ id: 'near', date: '2026-04-17T10:00:00Z', estimated1RM: 76 }),
+      makeSet({ id: 'top',  date: '2026-04-17T10:05:00Z', estimated1RM: 100 }),
+    ]
+    expect(classifyExerciseWarmups(sets, 0.75).size).toBe(0)
+    expect(classifyExerciseWarmups(sets, 0.8)).toEqual(new Set(['near']))
+  })
+})
+
+describe('classifyWarmupsByExercise', () => {
+  it('classifies per-exercise — does not mix sets across exercises', () => {
+    // Bench day: 135×10 (e1RM 180) before 225×5 (e1RM 262) — warmup
+    // Squat day: solo heavy single 405×1 (e1RM 405)
+    // If we mixed them, 180 / 405 = 44% would classify the bench warmup as a warmup
+    // correctly by accident, but the squat solo would still be working.
+    // Better test: squat's light set should NOT become a warmup because of bench's heavy set.
+    const exercises = [
+      {
+        id: 'bench',
+        sets: [
+          makeSet({ id: 'b-wu',  date: '2026-04-17T10:00:00Z', estimated1RM: 180 }),
+          makeSet({ id: 'b-top', date: '2026-04-17T10:05:00Z', estimated1RM: 262 }),
+        ],
+      },
+      {
+        id: 'squat',
+        sets: [
+          // Single set — must not be a warmup even though 100 < 262 × 0.75
+          makeSet({ id: 's-solo', date: '2026-04-17T11:00:00Z', estimated1RM: 100 }),
+        ],
+      },
+    ]
+    const result = classifyWarmupsByExercise(exercises, 0.75)
+    expect(result.has('b-wu')).toBe(true)
+    expect(result.has('s-solo')).toBe(false)
+  })
+
+  it('returns empty set when no exercises', () => {
+    expect(classifyWarmupsByExercise([], 0.75)).toEqual(new Set())
+  })
+})
+
+describe('normalizeWarmupThreshold', () => {
+  it('returns default for non-finite input', () => {
+    expect(normalizeWarmupThreshold(NaN)).toBe(WARMUP_THRESHOLD_DEFAULT)
+    expect(normalizeWarmupThreshold(Infinity)).toBe(WARMUP_THRESHOLD_DEFAULT)
+  })
+
+  it('clamps below min', () => {
+    expect(normalizeWarmupThreshold(0.1)).toBe(WARMUP_THRESHOLD_MIN)
+  })
+
+  it('clamps above max', () => {
+    expect(normalizeWarmupThreshold(0.99)).toBe(WARMUP_THRESHOLD_MAX)
+  })
+
+  it('snaps to nearest 5% step', () => {
+    expect(normalizeWarmupThreshold(0.73)).toBe(0.75)
+    expect(normalizeWarmupThreshold(0.77)).toBe(0.75)
+    expect(normalizeWarmupThreshold(0.78)).toBe(0.8)
+  })
+
+  it('preserves valid step values', () => {
+    expect(normalizeWarmupThreshold(0.75)).toBe(0.75)
+    expect(normalizeWarmupThreshold(0.85)).toBe(0.85)
+  })
+})

--- a/src/lib/warmupFilter.ts
+++ b/src/lib/warmupFilter.ts
@@ -1,0 +1,102 @@
+/**
+ * Warmup set classification — session-relative, no manual tagging.
+ *
+ * For each (exercise, local-date) group:
+ *   1. Sort sets chronologically by full timestamp.
+ *   2. Find the top-e1RM set (first occurrence of the max within the day).
+ *   3. Sets chronologically BEFORE the top set whose e1RM / topE1RM <= threshold
+ *      are classified as warmups.
+ *   4. Everything else — the top set itself, anything logged after it (back-off /
+ *      drop sets), and single-set days — is a working set.
+ *
+ * The output is a Set of set IDs that are classified as warmups, intended to be
+ * used as a client-side filter (sets are never mutated or deleted).
+ */
+
+import type { WorkoutSet } from '../stores/workout'
+
+/** Allowed range for the warmup threshold, in ratio-of-top-e1RM space. */
+export const WARMUP_THRESHOLD_MIN = 0.5
+export const WARMUP_THRESHOLD_MAX = 0.95
+export const WARMUP_THRESHOLD_DEFAULT = 0.75
+/** Increment for the Settings stepper. */
+export const WARMUP_THRESHOLD_STEP = 0.05
+
+function toLocalDateKey(iso: string): string {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * Classify warmup set IDs for a list of sets belonging to a SINGLE exercise.
+ * Sets for different exercises must be classified separately — otherwise a
+ * heavy squat day would incorrectly re-classify a bench warmup.
+ */
+export function classifyExerciseWarmups(
+  sets: WorkoutSet[],
+  threshold: number = WARMUP_THRESHOLD_DEFAULT,
+): Set<string> {
+  const warmupIds = new Set<string>()
+  if (sets.length === 0) return warmupIds
+
+  const byDay = new Map<string, WorkoutSet[]>()
+  for (const s of sets) {
+    const key = toLocalDateKey(s.date)
+    const list = byDay.get(key)
+    if (list) list.push(s)
+    else byDay.set(key, [s])
+  }
+
+  for (const daySets of byDay.values()) {
+    if (daySets.length < 2) continue
+
+    const sorted = [...daySets].sort((a, b) => a.date.localeCompare(b.date))
+    let topIdx = 0
+    let topE1RM = sorted[0].estimated1RM
+    for (let i = 1; i < sorted.length; i++) {
+      if (sorted[i].estimated1RM > topE1RM) {
+        topIdx = i
+        topE1RM = sorted[i].estimated1RM
+      }
+    }
+
+    if (topE1RM <= 0) continue
+
+    for (let i = 0; i < topIdx; i++) {
+      if (sorted[i].estimated1RM / topE1RM <= threshold) {
+        warmupIds.add(sorted[i].id)
+      }
+    }
+  }
+
+  return warmupIds
+}
+
+/**
+ * Classify warmup set IDs across many exercises at once.
+ * Groups by exercise first, then delegates to `classifyExerciseWarmups`.
+ */
+export function classifyWarmupsByExercise(
+  exercises: Array<{ id: string; sets: WorkoutSet[] }>,
+  threshold: number = WARMUP_THRESHOLD_DEFAULT,
+): Set<string> {
+  const all = new Set<string>()
+  for (const ex of exercises) {
+    for (const id of classifyExerciseWarmups(ex.sets, threshold)) {
+      all.add(id)
+    }
+  }
+  return all
+}
+
+/**
+ * Clamp a threshold value to the allowed range and snap to the nearest step.
+ * Useful when loading from persisted storage or user input.
+ */
+export function normalizeWarmupThreshold(value: number): number {
+  if (!Number.isFinite(value)) return WARMUP_THRESHOLD_DEFAULT
+  const clamped = Math.max(WARMUP_THRESHOLD_MIN, Math.min(WARMUP_THRESHOLD_MAX, value))
+  const steps = Math.round((clamped - WARMUP_THRESHOLD_MIN) / WARMUP_THRESHOLD_STEP)
+  const snapped = WARMUP_THRESHOLD_MIN + steps * WARMUP_THRESHOLD_STEP
+  return Math.round(snapped * 100) / 100
+}

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { supabase } from '../lib/supabase'
 import { syncQueue } from '../lib/syncQueue'
 import { logError } from '../lib/logger'
+import { normalizeWarmupThreshold, WARMUP_THRESHOLD_DEFAULT } from '../lib/warmupFilter'
 
 const STORAGE_KEY = 'user-preferences'
 
@@ -56,25 +57,31 @@ export const usePreferencesStore = defineStore('preferences', {
   state: () => ({
     features: { ...DEFAULTS } as FeatureFlags,
     weightGoal: { ...DEFAULT_WEIGHT_GOAL } as WeightGoalConfig,
+    warmupThreshold: WARMUP_THRESHOLD_DEFAULT as number,
     _userId: null as string | null,
   }),
 
   actions: {
     _persist() {
       try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify({ features: this.features, weightGoal: this.weightGoal }))
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({
+          features: this.features,
+          weightGoal: this.weightGoal,
+          warmupThreshold: this.warmupThreshold,
+        }))
       } catch (e) {
         logError(e, { source: 'preferences._persist' })
       }
       if (supabase && this._userId) {
         const features = { ...this.features }
         const weightGoal = this.weightGoal
+        const warmupThreshold = this.warmupThreshold
         const userId = this._userId
         syncQueue.enqueue(`preferences:${userId}`, () =>
           supabase!
             .from('user_preferences')
             .upsert(
-              { user_id: userId, preferences: { features, weightGoal }, updated_at: new Date().toISOString() },
+              { user_id: userId, preferences: { features, weightGoal, warmupThreshold }, updated_at: new Date().toISOString() },
               { onConflict: 'user_id' }
             )
         )
@@ -93,6 +100,9 @@ export const usePreferencesStore = defineStore('preferences', {
           if (parsed.weightGoal) {
             this.weightGoal = _migrateWeightGoal(parsed.weightGoal)
           }
+          if (typeof parsed.warmupThreshold === 'number') {
+            this.warmupThreshold = normalizeWarmupThreshold(parsed.warmupThreshold)
+          }
         } catch { /* ignore corrupt data */ }
       }
 
@@ -110,7 +120,14 @@ export const usePreferencesStore = defineStore('preferences', {
             if (prefs.weightGoal) {
               this.weightGoal = _migrateWeightGoal(prefs.weightGoal as { target?: number; unit?: string })
             }
-            localStorage.setItem(STORAGE_KEY, JSON.stringify({ features: this.features, weightGoal: this.weightGoal }))
+            if (typeof prefs.warmupThreshold === 'number') {
+              this.warmupThreshold = normalizeWarmupThreshold(prefs.warmupThreshold)
+            }
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({
+              features: this.features,
+              weightGoal: this.weightGoal,
+              warmupThreshold: this.warmupThreshold,
+            }))
           }
         } catch { /* table may not exist yet or no row */ }
       }
@@ -146,6 +163,11 @@ export const usePreferencesStore = defineStore('preferences', {
       this.weightGoal.gainTarget = null
       this.weightGoal.maintainMin = null
       this.weightGoal.maintainMax = null
+      this._persist()
+    },
+
+    setWarmupThreshold(value: number) {
+      this.warmupThreshold = normalizeWarmupThreshold(value)
       this._persist()
     },
   },


### PR DESCRIPTION
## Summary
- Adds a session-only **"Hide warmups"** toggle on the timeline view and the exercise details modal
- Classification is automatic and session-relative: for each `(exercise, local-date)` group, sets chronologically before the top-e1RM set whose ratio to that top is ≤ threshold are warmups; top set, back-off/drop sets, and single-set days are never classified as warmups
- Threshold configurable in new **Settings → Filters** section, default 75%, range 50–95% in 5% steps
- Client-side only — no set is mutated or deleted

Closes #358

## Design decisions
- **Default off.** The toggle is discoverable but never silently hides data until the user opts in.
- **Session-only.** Intentionally not persisted across sessions. The threshold *preference* IS persisted (via the existing preferences store), but the per-session toggle is not.
- **Session-relative top set.** Handles deload weeks naturally (if every set is light, nothing is classified as a warmup — the top set of the day wins). Handles back-off/drop sets correctly (anything logged after the top set is never a warmup even if ratio is low).
- **Inclusive threshold boundary** (`ratio ≤ threshold` is warmup). Matches the user expectation that "75%" means "up to and including 75%".
- **Filter chip UI reuses the tag-chip pattern** — keeps one interaction path per CLAUDE.md.

## Files
- `src/lib/warmupFilter.ts` (new) — `classifyExerciseWarmups`, `classifyWarmupsByExercise`, `normalizeWarmupThreshold`, constants
- `src/lib/__tests__/warmupFilter.test.ts` (new) — 20 tests covering single-set days, back-off sets, threshold boundary (inclusive), ties on top set, chronological sort, zero-e1RM defense, and cross-exercise isolation
- `src/stores/preferences.ts` — `warmupThreshold` state + `setWarmupThreshold` action, localStorage + Supabase sync
- `src/components/WorkoutTracker.vue` — `hideWarmups` ref, `timelineWarmupIds` / `detailWarmupIds` / `detailWarmupCount` / `timelineWarmupCount` computeds, toggle UI in timeline and detail modal, empty-state fallback when all sets are warmups
- `src/App.vue` — new Filters group in Settings with iOS stepper (− 75% +) and helper text
- `src/index.css` — new `.wtFilterBar` / `.wtFilterToggle` / `.wtFilterCount` styles modeled on the existing `.wtTagChip` pattern (44pt min touch target, uses theme tokens)

## Test plan
- [x] 1,274 existing tests pass + 20 new warmup filter tests
- [x] ESLint clean (0 errors)
- [x] `npm run build` succeeds
- [x] Browser preview verification:
  - [x] Timeline toggle shows `Hide warmups N` count and correctly filters rows
  - [x] Exercise details modal toggle shows the same and correctly hides rows
  - [x] Settings → Filters stepper adjusts threshold and persists to localStorage
  - [x] Adjusting threshold live-updates the warmup count
  - [x] Min boundary (50%) disables the − button
- [ ] Manually verify on iOS device once deployed

## Out of scope (intentionally)
- Persisting toggle state across sessions
- Per-exercise warmup overrides
- Manual "mark as warmup" flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)