### PR TITLE
feat: theme-aware splash with skeleton tab bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ android/
 # Claude Code worktree metadata (not part of the public repo)
 .claude/
 .vercel
+
+# Design handoff scratchpads (not source)
+design_handoff_*/

--- a/index.html
+++ b/index.html
@@ -38,25 +38,167 @@
   <title>Lift — Workout Tracker</title>
 </head>
 <body>
-  <!-- Splash screen: shows instantly before JS loads, fades out on Vue mount -->
+  <!--
+    Resolve persisted theme + mode before the splash paints, so the splash
+    background, accent, and skeleton tab bar match the user's real theme.
+    Mirrors the boot logic in src/composables/useTheme.ts so data-theme /
+    data-mode are set on <html> before JS modules load.
+  -->
+  <script>
+    (function () {
+      try {
+        var THEME_MIGRATION = {
+          graphite: 'amethyst', arctic: 'water', forge: 'pearl',
+          aaron: 'luck', tina: 'love', bloom: 'love', metal: 'eternal',
+          void: 'eternal', sun: 'pearl', moon: 'midnight', oak: 'earth'
+        };
+        var VALID_THEMES = ['eternal','pearl','midnight','fire','water','earth','luck','amethyst','air','love'];
+        var id = localStorage.getItem('app-theme') || 'eternal';
+        if (THEME_MIGRATION[id]) { id = THEME_MIGRATION[id]; localStorage.setItem('app-theme', id); }
+        if (VALID_THEMES.indexOf(id) === -1) id = 'eternal';
+        document.documentElement.setAttribute('data-theme', id);
+
+        var storedMode = localStorage.getItem('app-mode') || 'auto';
+        if (['dark','light','auto'].indexOf(storedMode) === -1) storedMode = 'auto';
+        var resolved = storedMode;
+        if (resolved === 'auto') {
+          resolved = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+        }
+        document.documentElement.setAttribute('data-mode', resolved);
+      } catch (e) {
+        document.documentElement.setAttribute('data-theme', 'eternal');
+        document.documentElement.setAttribute('data-mode', 'dark');
+      }
+    })();
+  </script>
+
+  <!--
+    Splash screen: paints instantly before JS loads, fades out on Vue mount.
+    Layout matches design_handoff_lift_ios_pwa/screens/02-splash.png so the
+    handoff to the real Workouts screen is visually seamless. Fallback token
+    values are the Luck (dark) palette, used only if the main stylesheet hasn't
+    loaded yet (dev mode). Production extracts CSS to a render-blocking <link>,
+    so the splash picks up the user's real theme on first paint.
+  -->
   <div id="splash" aria-hidden="true">
-    <img src="/icon-192.png" alt="" width="96" height="96" />
-    <span>Lift</span>
+    <div class="splashMesh"></div>
+    <div class="splashContent">
+      <div class="splashWordmark">Lift</div>
+      <div class="splashLoadingLabel">Loading local data…</div>
+    </div>
+    <div class="splashTabBar" aria-hidden="true">
+      <div class="splashTab splashTabActive">
+        <div class="splashTabIcon"></div>
+        <div class="splashTabLabel"></div>
+      </div>
+      <div class="splashTab">
+        <div class="splashTabIcon"></div>
+        <div class="splashTabLabel"></div>
+      </div>
+      <div class="splashTab">
+        <div class="splashTabIcon"></div>
+        <div class="splashTabLabel"></div>
+      </div>
+    </div>
   </div>
   <style>
     #splash {
-      position: fixed; inset: 0; z-index: 9999;
-      display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 12px;
-      background: #0a0a0a;
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      overflow: hidden;
+      background: var(--bg-primary, #0a1210);
       transition: opacity 0.3s ease;
     }
-    #splash img { border-radius: 16px; }
-    #splash span {
-      font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif;
-      font-size: 20px; font-weight: 600; letter-spacing: 0.02em;
-      color: rgba(255,255,255,0.7);
-    }
     #splash.fade-out { opacity: 0; pointer-events: none; }
+
+    #splash .splashMesh {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      background: var(--mesh,
+        radial-gradient(ellipse 70% 55% at 15% 10%, rgba(30, 120, 70, 0.10) 0%, transparent 65%),
+        radial-gradient(ellipse 55% 45% at 85% 80%, rgba(212, 175, 55, 0.06) 0%, transparent 65%));
+    }
+
+    #splash .splashContent {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      /* Offset wordmark up 110px (README spec) so the skeleton tab bar sits below. */
+      transform: translateY(-110px);
+      gap: 8px;
+    }
+
+    #splash .splashWordmark {
+      font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+      font-size: 72px;
+      font-weight: 800;
+      line-height: 1;
+      letter-spacing: -0.035em;
+      color: var(--accent, #d4af37);
+    }
+
+    #splash .splashLoadingLabel {
+      font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 10px;
+      font-weight: 500;
+      line-height: 1;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--text-muted, #607868);
+    }
+
+    #splash .splashTabBar {
+      position: absolute;
+      left: 14px;
+      right: 14px;
+      bottom: calc(26px + env(safe-area-inset-bottom, 0px));
+      height: 58px;
+      border-radius: 20px;
+      background: var(--glass-bar, rgba(10, 18, 16, 0.85));
+      border: 1px solid var(--glass-edge, rgba(212, 175, 55, 0.10));
+      backdrop-filter: blur(20px) saturate(1.4);
+      -webkit-backdrop-filter: blur(20px) saturate(1.4);
+      display: flex;
+      align-items: center;
+      justify-content: space-around;
+      padding: 0 12px;
+    }
+
+    #splash .splashTab {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      opacity: 0.5;
+    }
+
+    #splash .splashTabIcon {
+      width: 22px;
+      height: 22px;
+      border-radius: 5px;
+      background: var(--border-strong, #2a3e34);
+    }
+
+    #splash .splashTabLabel {
+      width: 36px;
+      height: 6px;
+      border-radius: 99px;
+      background: var(--border, #1e3028);
+    }
+
+    #splash .splashTabActive { opacity: 1; }
+    #splash .splashTabActive .splashTabIcon { background: var(--accent, #d4af37); }
+    #splash .splashTabActive .splashTabLabel { background: var(--accent-subtle, rgba(212, 175, 55, 0.12)); }
+
+    @media (prefers-reduced-motion: reduce) {
+      #splash { transition: none; }
+    }
   </style>
   <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>


### PR DESCRIPTION
Closes #360. Step 1 of the iOS PWA design handoff (see `design_handoff_lift_ios_pwa/`).

## Summary

- Replace the dark-bg + icon-192 splash with the layout from `screens/02-splash.png`: themed `--bg-primary` + `--mesh` background, 72px/800 "Lift" wordmark in `--accent` offset -110px from center, mono "LOADING LOCAL DATA…" caption, and a skeleton glass tab bar at the bottom that matches the final floating tab bar geometry (wired up in a later PR).
- Resolve persisted `app-theme` / `app-mode` before first paint via an inline script that mirrors `useTheme.ts` boot logic, so the splash matches the user's theme for all 10 themes × dark/light.
- Inline fallback token values (Luck dark palette) so dev mode still renders correctly before Vite injects the main stylesheet.
- Gitignore `design_handoff_*/` so handoff docs stay local scratch.

## Visual verification

Splash screenshot in iOS simulator (iPhone 17, iOS 26.4, user's active theme = Pearl):

![splash](data:image/png;base64,) (validated locally against `screens/02-splash.png` — layout, wordmark position, tab bar geometry, and theme-aware accent all match)

## Notes

- The handoff specifies `apple-touch-startup-image` PNGs at every iPhone PWA splash resolution. We explicitly deferred that matrix per Aaron's instruction — this PR is in-HTML only. The OS splash work can be a follow-up.
- The skeleton tab bar geometry (`bottom: 26px + safe-area`, 14L/R inset, 58h, 20 radius) is spec'd to match the final floating tab bar. The current live tab bar does not match these coordinates yet; that's step 4 (Workouts chrome). Until step 4 lands, the handoff will have a small visual jump.

## Test plan

- [x] `npm test` — 1254 tests pass
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors (9 pre-existing warnings, all unrelated)
- [x] Manual: splash renders immediately, fades on Vue mount, verified on iPhone 17 sim with Pearl theme
- [ ] Manual QA: verify wordmark color for each of the other 9 themes (deferrable — token-driven, not hardcoded)