### PR TITLE
feat: settings rework — drop glass toggle, add PR celebration + haptics

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -154,12 +154,6 @@
                 </div>
               </div>
               <div class="settingsRow">
-                <span class="settingsLabel">Liquid Glass</span>
-                <button :class="['glassToggle', { on: glassEnabled }]" @click="toggleGlass" role="switch" :aria-checked="glassEnabled" :aria-label="glassEnabled ? 'Disable liquid glass' : 'Enable liquid glass'">
-                  <span class="glassToggleThumb"></span>
-                </button>
-              </div>
-              <div class="settingsRow">
                 <span class="settingsLabel">Units</span>
                 <div class="modeSegmented">
                   <button :class="['modeSegBtn', { active: weightUnit === 'lbs' }]" @click="weightUnit = 'lbs'" aria-label="Use pounds" :aria-pressed="weightUnit === 'lbs'">lbs</button>
@@ -169,26 +163,42 @@
             </div>
 
             <div class="settingsGroup">
-              <div class="settingsHeader">Features</div>
-              <div
-                v-for="tab in TAB_DEFS"
-                :key="tab.id"
-                class="settingsRow"
-              >
-                <span class="settingsLabel">{{ tab.label }}</span>
+              <div class="settingsHeader">Experience</div>
+              <div class="settingsRow">
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel">Haptics</span>
+                  <span class="settingsHint">Taps, PRs, timer end</span>
+                </div>
                 <button
-                  :class="['glassToggle', { on: prefs.features[tab.id] }]"
-                  @click="toggleFeature(tab.id)"
-                  :disabled="prefs.features[tab.id] && prefs.enabledCount <= 1"
+                  :class="['glassToggle', { on: prefs.experience.haptics }]"
+                  @click="toggleExperience('haptics')"
                   role="switch"
-                  :aria-checked="prefs.features[tab.id]"
-                  :aria-label="(prefs.features[tab.id] ? 'Disable ' : 'Enable ') + tab.label"
+                  :aria-checked="prefs.experience.haptics"
+                  :aria-label="prefs.experience.haptics ? 'Disable haptics' : 'Enable haptics'"
                 >
                   <span class="glassToggleThumb"></span>
                 </button>
               </div>
               <div class="settingsRow">
-                <span class="settingsLabel">Rest Timer</span>
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel">PR celebration</span>
+                  <span class="settingsHint">Full-screen burst on new PRs</span>
+                </div>
+                <button
+                  :class="['glassToggle', { on: prefs.experience.prCelebrations }]"
+                  @click="toggleExperience('prCelebrations')"
+                  role="switch"
+                  :aria-checked="prefs.experience.prCelebrations"
+                  :aria-label="prefs.experience.prCelebrations ? 'Disable PR celebrations' : 'Enable PR celebrations'"
+                >
+                  <span class="glassToggleThumb"></span>
+                </button>
+              </div>
+              <div class="settingsRow">
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel">Rest Timer</span>
+                  <span v-if="restTimerEnabled && restTimerAutoStart" class="settingsHint">Auto-start after save</span>
+                </div>
                 <button
                   :class="['glassToggle', { on: restTimerEnabled }]"
                   @click="restTimerEnabled = !restTimerEnabled"
@@ -207,6 +217,27 @@
                   role="switch"
                   :aria-checked="restTimerAutoStart"
                   :aria-label="restTimerAutoStart ? 'Disable auto-start' : 'Enable auto-start'"
+                >
+                  <span class="glassToggleThumb"></span>
+                </button>
+              </div>
+            </div>
+
+            <div class="settingsGroup">
+              <div class="settingsHeader">Features</div>
+              <div
+                v-for="tab in TAB_DEFS"
+                :key="tab.id"
+                class="settingsRow"
+              >
+                <span class="settingsLabel">{{ tab.label }}</span>
+                <button
+                  :class="['glassToggle', { on: prefs.features[tab.id] }]"
+                  @click="toggleFeature(tab.id)"
+                  :disabled="prefs.features[tab.id] && prefs.enabledCount <= 1"
+                  role="switch"
+                  :aria-checked="prefs.features[tab.id]"
+                  :aria-label="(prefs.features[tab.id] ? 'Disable ' : 'Enable ') + tab.label"
                 >
                   <span class="glassToggleThumb"></span>
                 </button>
@@ -786,7 +817,7 @@ import { useFocusTrap } from './composables/useFocusTrap'
 import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
 import { registerSW } from 'virtual:pwa-register'
 
-const { currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode, glassEnabled, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, selectTheme: themeSelectFn, previewTheme, revertPreview, isThemeUnlocked } = useTheme()
+const { currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, selectTheme: themeSelectFn, previewTheme, revertPreview, isThemeUnlocked } = useTheme()
 const { prBaselineDate, setPRBaseline, startNewTrainingBlock, clearPRBaseline } = usePRBaseline()
 
 function formatBaselineLabel(iso: string | null): string {
@@ -1499,9 +1530,10 @@ function setMode(mode: 'light' | 'dark' | 'auto') {
   logEvent('mode_toggle', { mode })
 }
 
-function toggleGlass() {
-  glassEnabled.value = !glassEnabled.value
-  logEvent('glass_toggle', { enabled: glassEnabled.value })
+function toggleExperience(key: 'prCelebrations' | 'haptics') {
+  const next = !prefs.experience[key]
+  prefs.setExperienceFlag(key, next)
+  logEvent('experience_toggle', { key, enabled: next })
 }
 
 function showConfirm(message: string, onConfirm: () => void) {

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -32,7 +32,7 @@ export function mockAnalytics() {
   }
 }
 
-/** Default useTheme mock — lbs, no rest timer. */
+/** Default useTheme mock — lbs, no rest timer. Glass is always on as of the 2026 refresh. */
 export function mockTheme(overrides: Record<string, unknown> = {}) {
   return {
     useTheme: () => ({
@@ -45,7 +45,6 @@ export function mockTheme(overrides: Record<string, unknown> = {}) {
       THEME_PREVIEWS: {},
       colorMode: ref('dark'),
       resolvedMode: ref('dark'),
-      glassEnabled: ref(true),
       ...overrides,
     })
   }

--- a/src/components/__tests__/accessibility.test.ts
+++ b/src/components/__tests__/accessibility.test.ts
@@ -29,7 +29,6 @@ vi.mock('../../composables/useTheme', () => ({
     THEMES: [],
     colorMode: { value: 'dark' },
     resolvedMode: { value: 'dark' },
-    glassEnabled: { value: true },
   }),
   THEME_PREVIEWS: {
     fire: { dark: { accent: '#ff4500', bg: '#1a0000' }, light: { accent: '#ff4500', bg: '#fff5f0' } },

--- a/src/composables/__tests__/useTheme.test.ts
+++ b/src/composables/__tests__/useTheme.test.ts
@@ -91,17 +91,14 @@ describe('useTheme', () => {
     })
   })
 
-  describe('glass toggle', () => {
-    it('toggles glass morphism on and off', async () => {
-      theme.glassEnabled.value = false
-      await nextTick()
-      expect(theme.glassEnabled.value).toBe(false)
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('app-glass', 'off')
-
-      theme.glassEnabled.value = true
-      await nextTick()
-      expect(theme.glassEnabled.value).toBe(true)
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('app-glass', 'on')
+  describe('glass (always on as of 2026 refresh)', () => {
+    it('forces data-glass="on" at import time and does not expose a toggle', () => {
+      // Theme module set data-glass on import; verify it's still 'on' and
+      // that the legacy app-glass localStorage key was removed.
+      expect(document.documentElement.getAttribute('data-glass')).toBe('on')
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith('app-glass')
+      // The composable should no longer expose glassEnabled.
+      expect((theme as unknown as Record<string, unknown>).glassEnabled).toBeUndefined()
     })
   })
 

--- a/src/composables/useHaptics.ts
+++ b/src/composables/useHaptics.ts
@@ -4,7 +4,12 @@
  * Prefers Capacitor Haptics (available when wrapped as a native app),
  * falls back to the Web Vibration API (Android browsers), and silently
  * no-ops when neither is available (desktop, iOS Safari).
+ *
+ * Respects the user's `experience.haptics` preference: when the toggle is
+ * off (Settings → Experience → Haptics), impact/notification calls no-op.
  */
+
+import { usePreferencesStore } from '../stores/preferences'
 
 type ImpactStyle = 'light' | 'medium' | 'heavy'
 
@@ -15,6 +20,16 @@ interface CapacitorHaptics {
 
 let capacitorHaptics: CapacitorHaptics | null = null
 let capacitorChecked = false
+
+function hapticsAllowed(): boolean {
+  // Defensive: Pinia may not be active (e.g. some test setups).
+  try {
+    const prefs = usePreferencesStore()
+    return prefs.experience?.haptics !== false
+  } catch {
+    return true
+  }
+}
 
 async function getCapacitorHaptics(): Promise<CapacitorHaptics | null> {
   if (capacitorChecked) return capacitorHaptics
@@ -39,6 +54,7 @@ function vibrate(ms: number | number[]): void {
 }
 
 async function impact(style: ImpactStyle = 'light'): Promise<void> {
+  if (!hapticsAllowed()) return
   const haptics = await getCapacitorHaptics()
   if (haptics) {
     const styleMap: Record<ImpactStyle, string> = {
@@ -55,6 +71,7 @@ async function impact(style: ImpactStyle = 'light'): Promise<void> {
 }
 
 async function notification(type: 'success' | 'warning' | 'error' = 'success'): Promise<void> {
+  if (!hapticsAllowed()) return
   const haptics = await getCapacitorHaptics()
   if (haptics) {
     const typeMap: Record<string, string> = {

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -109,11 +109,6 @@ function updateMetaColor(): void {
   meta.setAttribute('content', colors[mode] ?? colors.dark)
 }
 
-function applyGlass(enabled: boolean): void {
-  document.documentElement.setAttribute('data-glass', enabled ? 'on' : 'off')
-  localStorage.setItem('app-glass', enabled ? 'on' : 'off')
-}
-
 // Apply immediately at import time to prevent flash
 let storedId = localStorage.getItem('app-theme') || 'eternal'
 // Migrate old theme names
@@ -127,21 +122,23 @@ const validMode: ColorMode = (['light', 'dark', 'auto'] as const).includes(store
 applyTheme(validId)
 applyMode(validMode)
 
-const storedGlass = localStorage.getItem('app-glass') !== 'off'
-applyGlass(storedGlass)
+// Glass is always on as of the 2026 iOS PWA refresh — the opt-out toggle was
+// removed after data showed no users disabling it. Set the attribute once so
+// any residual [data-glass="off"] rules still in third-party CSS resolve to
+// the glass-on state, and drop the legacy `app-glass` key from localStorage.
+document.documentElement.setAttribute('data-glass', 'on')
+try { localStorage.removeItem('app-glass') } catch { /* ignore */ }
 
 const currentTheme: Ref<string> = ref(validId)
 const colorMode: Ref<ColorMode> = ref(validMode)
 const resolvedMode: ComputedRef<'dark' | 'light'> = computed(() =>
   colorMode.value === 'auto' ? getSystemMode() : colorMode.value
 )
-const glassEnabled: Ref<boolean> = ref(storedGlass)
 const restTimerEnabled: Ref<boolean> = ref(localStorage.getItem('rest-timer') !== 'off')
 const restTimerAutoStart: Ref<boolean> = ref(localStorage.getItem('rest-timer-autostart') !== 'off')
 const weightUnit: Ref<WeightUnit> = ref((localStorage.getItem('weight-unit') || 'lbs') as WeightUnit)
 watch(currentTheme, applyTheme)
 watch(colorMode, applyMode)
-watch(glassEnabled, applyGlass)
 
 // Listen for OS theme changes when in auto mode
 const mql = window.matchMedia('(prefers-color-scheme: dark)')
@@ -235,7 +232,7 @@ export function useTheme() {
 
   return {
     currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode,
-    glassEnabled, restTimerEnabled, restTimerAutoStart, weightUnit,
+    restTimerEnabled, restTimerAutoStart, weightUnit,
     displayWeight, toLbs, selectTheme, previewTheme, revertPreview,
     isThemeUnlocked, setRestTimerEnabled,
   }

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -266,4 +266,51 @@ describe('usePreferencesStore', () => {
       expect(freshStore.weightGoal.maintainMax).toBe(180)
     })
   })
+
+  describe('experience flags', () => {
+    it('defaults prCelebrations and haptics to enabled', () => {
+      expect(store.experience.prCelebrations).toBe(true)
+      expect(store.experience.haptics).toBe(true)
+    })
+
+    it('setExperienceFlag updates state and persists', () => {
+      store.setExperienceFlag('prCelebrations', false)
+      expect(store.experience.prCelebrations).toBe(false)
+
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences') as string)
+      expect(stored.experience.prCelebrations).toBe(false)
+      expect(stored.experience.haptics).toBe(true)
+    })
+
+    it('init() rehydrates experience flags from localStorage', async () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        experience: { prCelebrations: false, haptics: false },
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.experience.prCelebrations).toBe(false)
+      expect(freshStore.experience.haptics).toBe(false)
+    })
+
+    it('init() backfills missing experience keys with defaults', async () => {
+      // Older clients may have persisted prefs without experience — make sure
+      // init() merges defaults rather than leaving the field undefined.
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.experience.prCelebrations).toBe(true)
+      expect(freshStore.experience.haptics).toBe(true)
+    })
+  })
 })

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -22,6 +22,13 @@ export interface WeightGoalConfig {
   maintainMax: number | null    // optional ceiling for maintain
 }
 
+export interface ExperienceFlags {
+  /** Fire the full-screen PR burst when a set beats the user's e1RM for an exercise. */
+  prCelebrations: boolean
+  /** Allow haptic feedback on taps, PRs, and timer end. */
+  haptics: boolean
+}
+
 const DEFAULT_WEIGHT_GOAL: WeightGoalConfig = {
   direction: 'lose',
   loseTarget: null,
@@ -34,6 +41,11 @@ const DEFAULTS: FeatureFlags = {
   workouts: true,
   calendar: true,
   weight: true,
+}
+
+const DEFAULT_EXPERIENCE: ExperienceFlags = {
+  prCelebrations: true,
+  haptics: true,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -56,25 +68,30 @@ export const usePreferencesStore = defineStore('preferences', {
   state: () => ({
     features: { ...DEFAULTS } as FeatureFlags,
     weightGoal: { ...DEFAULT_WEIGHT_GOAL } as WeightGoalConfig,
+    experience: { ...DEFAULT_EXPERIENCE } as ExperienceFlags,
     _userId: null as string | null,
   }),
 
   actions: {
     _persist() {
       try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify({ features: this.features, weightGoal: this.weightGoal }))
+        localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
+        )
       } catch (e) {
         logError(e, { source: 'preferences._persist' })
       }
       if (supabase && this._userId) {
         const features = { ...this.features }
         const weightGoal = this.weightGoal
+        const experience = { ...this.experience }
         const userId = this._userId
         syncQueue.enqueue(`preferences:${userId}`, () =>
           supabase!
             .from('user_preferences')
             .upsert(
-              { user_id: userId, preferences: { features, weightGoal }, updated_at: new Date().toISOString() },
+              { user_id: userId, preferences: { features, weightGoal, experience }, updated_at: new Date().toISOString() },
               { onConflict: 'user_id' }
             )
         )
@@ -93,6 +110,9 @@ export const usePreferencesStore = defineStore('preferences', {
           if (parsed.weightGoal) {
             this.weightGoal = _migrateWeightGoal(parsed.weightGoal)
           }
+          if (parsed.experience) {
+            this.experience = { ...DEFAULT_EXPERIENCE, ...parsed.experience }
+          }
         } catch { /* ignore corrupt data */ }
       }
 
@@ -110,7 +130,13 @@ export const usePreferencesStore = defineStore('preferences', {
             if (prefs.weightGoal) {
               this.weightGoal = _migrateWeightGoal(prefs.weightGoal as { target?: number; unit?: string })
             }
-            localStorage.setItem(STORAGE_KEY, JSON.stringify({ features: this.features, weightGoal: this.weightGoal }))
+            if (prefs.experience) {
+              this.experience = { ...DEFAULT_EXPERIENCE, ...(prefs.experience as Partial<ExperienceFlags>) }
+            }
+            localStorage.setItem(
+              STORAGE_KEY,
+              JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
+            )
           }
         } catch { /* table may not exist yet or no row */ }
       }
@@ -120,6 +146,11 @@ export const usePreferencesStore = defineStore('preferences', {
       // Prevent disabling the last enabled tab
       if (this.features[featureId] && this.enabledCount <= 1) return
       this.features[featureId] = !this.features[featureId]
+      this._persist()
+    },
+
+    setExperienceFlag<K extends keyof ExperienceFlags>(key: K, value: ExperienceFlags[K]) {
+      this.experience[key] = value
       this._persist()
     },
 


### PR DESCRIPTION
Closes #362. Stacks on top of #361 (step 1 — splash). Merge #361 first.

## Summary

- **Remove Liquid Glass toggle** and the `glassEnabled` code path. Glass is always on per Aaron's instruction ("nobody uses glass off").
- **Add Experience section** with Haptics, PR celebration, and Rest Timer toggles — all persisted to `user-preferences.experience` (localStorage + Supabase).
- **Wire `useHaptics` through the preference** — no-ops when the user disables haptics.
- **PR celebration toggle** primes the PR burst feature shipping in a later PR.

## Screenshot (Playwright mobile viewport, eternal dark)

![settings](step2-settings-1.png)

## What's NOT in this PR

- Purging dead `[data-glass=\"off\"]` CSS rules in `src/index.css` (safe to leave)
- Compact theme summary row (\"Luck · 4 themes unlocked\" + 3 dots instead of full grid)
- Sticky \"Settings / X\" sheet header

These can follow up once the rest of the handoff lands.

## Test plan

- [x] `npm test` — 1258 pass (4 new)
- [x] `npm run lint` — 0 errors (9 pre-existing warnings)
- [x] `npm run build` — clean
- [x] Manual (Playwright iPhone 15 Pro viewport): Experience section renders, toggles persist across reload
- [ ] Manual QA on iOS simulator: verify toggle tap targets ≥ 44pt and subtitles render cleanly