### PR TITLE
feat: Workouts chrome — top bar header + floating glass tab bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,21 +27,34 @@
           Viewing sample data — Tap to clear and start fresh
         </button>
         <div class="appTopBar">
-          <span v-if="syncStatus !== 'synced'" class="syncIndicator" :class="'syncIndicator--' + syncStatus" :title="syncStatusLabel" role="status">
-            <svg v-if="syncStatus === 'error'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-            <svg v-else-if="syncStatus === 'offline'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="1" y1="1" x2="23" y2="23"/><path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/><path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/><path d="M10.71 5.05A16 16 0 0 1 22.56 9"/><path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
-            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
-          </span>
-          <button
-            class="settingsGearBtn"
-            @click="settingsOpen ? closeSettings() : (settingsOpen = true)"
-            title="Settings"
-            aria-label="Settings"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-          </button>
+          <div class="appTopBarLeft">
+            <button
+              class="settingsGearBtn"
+              @click="settingsOpen ? closeSettings() : (settingsOpen = true)"
+              title="Settings"
+              aria-label="Settings"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            </button>
+            <span v-if="syncStatus !== 'synced'" class="syncIndicator" :class="'syncIndicator--' + syncStatus" :title="syncStatusLabel" role="status">
+              <svg v-if="syncStatus === 'error'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              <svg v-else-if="syncStatus === 'offline'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="1" y1="1" x2="23" y2="23"/><path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/><path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/><path d="M10.71 5.05A16 16 0 0 1 22.56 9"/><path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+              <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
+            </span>
+          </div>
+          <div class="appTopBarRight">
+            <button
+              v-if="activeTab === 'workouts'"
+              class="topBarPlusBtn"
+              @click="triggerQuickLog"
+              title="Log a set"
+              aria-label="Log a set"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            </button>
+          </div>
         </div>
-        <div v-show="activeTab === 'workouts'" class="tabContent"><WorkoutTracker /></div>
+        <div v-show="activeTab === 'workouts'" class="tabContent"><WorkoutTracker ref="workoutTrackerRef" /></div>
         <div v-show="activeTab === 'calendar'" class="tabContent"><CalendarView /></div>
         <div v-show="activeTab === 'weight'" class="tabContent"><BodyweightTracker /></div>
       </main>
@@ -1204,6 +1217,17 @@ function confirmResetProgress() {
 
 const starterPickerVisible = ref(false)
 const starterPickerRef = ref<InstanceType<typeof StarterPickerFlow> | null>(null)
+
+// Exposed from WorkoutTracker via defineExpose so the top-bar "+" can trigger
+// the same quick-log exercise-picker flow the in-content "+ Log Set" uses.
+const workoutTrackerRef = ref<InstanceType<typeof WorkoutTracker> | null>(null)
+
+function triggerQuickLog() {
+  const wt = workoutTrackerRef.value
+  if (wt && typeof wt.openTimelineLogModal === 'function') {
+    wt.openTimelineLogModal()
+  }
+}
 
 // Revert any in-flight theme preview if the picker is hidden for any reason
 watch(starterPickerVisible, (visible) => { if (!visible) revertPreview() })

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -34,12 +34,12 @@
     <template v-if="listView === 'exercises' && store.allTags.length > 0">
       <div class="wtTagFilterBar">
         <button
-          :class="['wtTagChip', { wtTagChipActive: activeTagFilters.length === 0 }]"
-          @click="activeTagFilters = []"
+          :class="['wtTagChip', { wtTagChipActive: activeTagFilters.length === 0 && !searchQuery }]"
+          @click="clearSearchAndTags"
           aria-label="Show all exercises"
         >All</button>
         <button
-          v-for="tag in store.allTags"
+          v-for="tag in filteredTags"
           :key="tag"
           :class="['wtTagChip', { wtTagChipActive: activeTagFilters.includes(tag) }]"
           :aria-pressed="activeTagFilters.includes(tag)"
@@ -1165,13 +1165,36 @@ const visibleTimelineGroups = computed(() => {
 const searchQuery = ref('')
 const activeTagFilters = ref<string[]>([])
 
+/**
+ * Tag chips visible in the filter row. When the user is searching we narrow
+ * the row to tags that match the query (so typing "shoulders" also filters
+ * the chips), plus any currently-active tag so the user can see + toggle it
+ * back off without clearing the search first.
+ */
+const filteredTags = computed<string[]>(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return store.allTags
+  return store.allTags.filter(t =>
+    t.toLowerCase().includes(q) || activeTagFilters.value.includes(t)
+  )
+})
+
 function toggleTagFilter(tag: string) {
-  const idx = activeTagFilters.value.indexOf(tag)
-  if (idx >= 0) {
+  // Tapping a tag chip commits the user's intent: clear the search and apply
+  // the tag as a filter. If the tag was already active, tapping deactivates it.
+  const wasActive = activeTagFilters.value.includes(tag)
+  searchQuery.value = ''
+  if (wasActive) {
     activeTagFilters.value = activeTagFilters.value.filter(t => t !== tag)
   } else {
     activeTagFilters.value = [...activeTagFilters.value, tag]
   }
+}
+
+/** "All" chip — clear both the search and any active tags. */
+function clearSearchAndTags() {
+  searchQuery.value = ''
+  activeTagFilters.value = []
 }
 
 const filteredExercises = computed(() => {

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1,33 +1,53 @@
 <template>
   <!-- Main card -->
   <div class="wtCard">
-    <div class="wtCardHeader">
-      <h2 class="wtTitle">Exercise Tracker</h2>
-      <button v-if="listView === 'exercises'" class="wtLogBtn" @click="openNewExerciseModal">+ New Exercise</button>
-      <button v-else class="wtLogBtn" @click="openTimelineLogModal">+ Log Set</button>
-    </div>
+    <!-- iOS-style large title + stats subtitle (matches screens/03-workouts.png) -->
+    <header class="wtPageHeader">
+      <h1 class="wtPageTitle">Workouts</h1>
+      <p class="wtPageStats" v-if="store.exercises.length > 0">
+        {{ totalExercises }} {{ totalExercises === 1 ? 'exercise' : 'exercises' }}
+        · {{ prsThisWeek }} {{ prsThisWeek === 1 ? 'PR' : 'PRs' }} this week
+      </p>
+    </header>
 
-    <!-- View toggle -->
+    <!-- View toggle (Exercises / Timeline) -->
     <div v-if="store.exercises.length > 0" class="wtViewToggle">
       <button :class="['wtViewToggleBtn', { active: listView === 'exercises' }]" @click="listView = 'exercises'">Exercises</button>
       <button :class="['wtViewToggleBtn', { active: listView === 'timeline' }]" @click="listView = 'timeline'">Timeline</button>
     </div>
 
-    <!-- Tag filter (exercises view only) -->
+    <!-- Search bar (exercises view, shown when 5+ exercises) -->
+    <div v-if="listView === 'exercises' && store.exercises.length >= 5" class="wtSearchBar">
+      <svg class="wtSearchIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      <input
+        v-model="searchQuery"
+        type="search"
+        autocomplete="off"
+        class="wtSearchInput"
+        placeholder="Search exercises or tags…"
+        aria-label="Search exercises or tags"
+      />
+      <span v-if="searchQuery" class="wtSearchCount">{{ filteredExercises.length }} result{{ filteredExercises.length !== 1 ? 's' : '' }}</span>
+    </div>
+
+    <!-- Tag filter chips with counts (exercises view only) -->
     <template v-if="listView === 'exercises' && store.allTags.length > 0">
       <div class="wtTagFilterBar">
+        <button
+          :class="['wtTagChip', { wtTagChipActive: activeTagFilters.length === 0 }]"
+          @click="activeTagFilters = []"
+          aria-label="Show all exercises"
+        >All</button>
         <button
           v-for="tag in store.allTags"
           :key="tag"
           :class="['wtTagChip', { wtTagChipActive: activeTagFilters.includes(tag) }]"
           :aria-pressed="activeTagFilters.includes(tag)"
           @click="toggleTagFilter(tag)"
-        >{{ tag }}</button>
-        <button
-          v-if="activeTagFilters.length > 0"
-          class="wtTagChip wtTagChipClear"
-          @click="activeTagFilters = []"
-        >× Clear</button>
+        >
+          <span class="wtTagChipLabel">{{ tag }}</span>
+          <span v-if="tagCounts[tag]" class="wtTagChipCount">{{ tagCounts[tag] }}</span>
+        </button>
         <button
           class="wtTagChip wtTagChipManage"
           @click="openTagManager"
@@ -35,19 +55,6 @@
         ><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></button>
       </div>
     </template>
-
-    <!-- Search bar (exercises view, shown when 5+ exercises) -->
-    <div v-if="listView === 'exercises' && store.exercises.length >= 5" class="wtSearchBar">
-      <input
-        v-model="searchQuery"
-        type="search"
-        autocomplete="off"
-        class="wtSearchInput"
-        placeholder="Search exercises…"
-        aria-label="Search exercises"
-      />
-      <span v-if="searchQuery" class="wtSearchCount">{{ filteredExercises.length }} result{{ filteredExercises.length !== 1 ? 's' : '' }}</span>
-    </div>
 
     <p v-if="store.exercises.length === 0" class="wtEmpty">
       No exercises yet. Hit "+ New Exercise" to add your first one.
@@ -85,19 +92,38 @@
             @click="openDetailModal(exercise.id)"
           >
             <div class="wtExerciseNameBlock">
-              <span class="wtExerciseName">{{ exercise.name }}</span>
-              <span v-if="store.getExercisePRSet(exercise.id, prBaselineDate)" class="wtExerciseMeta">
-                Est. 1RM: {{ displayWeight(store.getExercisePRSet(exercise.id, prBaselineDate)!.estimated1RM) }} {{ weightUnit }}
-                ({{ displayWeight(store.getExercisePRSet(exercise.id, prBaselineDate)!.weight) }} × {{ store.getExercisePRSet(exercise.id, prBaselineDate)!.reps }})
-              </span>
+              <div class="wtExerciseTopLine">
+                <span class="wtExerciseName">{{ exercise.name }}</span>
+                <span v-if="getRowMeta(exercise.id).isNewPRBadge" class="wtExerciseNewPR">
+                  <span class="wtExerciseNewPRIcon" aria-hidden="true">🏆</span>
+                  <span>NEW PR</span>
+                </span>
+              </div>
+              <div class="wtExerciseMetaLine">
+                <span
+                  v-for="tag in (exercise.tags || []).slice(0, 3)"
+                  :key="tag"
+                  class="wtExerciseTag"
+                >{{ tag }}</span>
+                <span v-if="getRowMeta(exercise.id).lastSet" class="wtExerciseStat">
+                  · {{ displayWeight(getRowMeta(exercise.id).lastSet!.weight) }} {{ weightUnit }}
+                  × {{ getRowMeta(exercise.id).lastSet!.reps }}
+                  · {{ getRowMeta(exercise.id).timeAgo }}
+                </span>
+                <span v-else class="wtExerciseStat wtExerciseStatEmpty">· No sets yet</span>
+              </div>
             </div>
-            <span class="wtChevron">›</span>
           </button>
           <button
-            class="wtExerciseLogBtn"
+            class="wtExerciseLogBtn wtExerciseLogBtnCircle"
             @click="openLogForExercise(exercise.id)"
             :aria-label="`Log a set for ${exercise.name}`"
-          >+ Log</button>
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" width="20" height="20" aria-hidden="true">
+              <line x1="12" y1="5" x2="12" y2="19"/>
+              <line x1="5" y1="12" x2="19" y2="12"/>
+            </svg>
+          </button>
         </div>
       </li>
     </ul>
@@ -810,6 +836,13 @@
             <span class="wtExPickerName">{{ ex.name }}</span>
             <span class="wtChevron">›</span>
           </button>
+          <button
+            class="wtExPickerRow wtExPickerNew"
+            @click="pickNewExerciseFromPicker"
+          >
+            <span class="wtExPickerName">+ New exercise</span>
+            <span class="wtChevron">›</span>
+          </button>
         </div>
         <div class="repMaxActions">
           <button class="repMaxBtn repMaxBtnClose" @click="timelineLogPicking = false">Cancel</button>
@@ -1143,10 +1176,14 @@ function toggleTagFilter(tag: string) {
 
 const filteredExercises = computed(() => {
   let result = store.exercises
-  // Text search
+  // Text search — check both name and tags so "Push" matches tag-filtered rows.
   const q = searchQuery.value.trim().toLowerCase()
   if (q) {
-    result = result.filter(e => e.name.toLowerCase().includes(q))
+    result = result.filter(e => {
+      if (e.name.toLowerCase().includes(q)) return true
+      const tags = e.tags || []
+      return tags.some(t => t.toLowerCase().includes(q))
+    })
   }
   // Tag filter
   if (activeTagFilters.value.length > 0) {
@@ -1157,6 +1194,56 @@ const filteredExercises = computed(() => {
   }
   return result
 })
+
+/** Total exercise count, shown in the "Workouts" header stats. */
+const totalExercises = computed(() => store.exercises.length)
+
+/** Exercises whose baseline-relative PR was achieved in the last 7 days. */
+const prsThisWeek = computed(() => {
+  const now = Date.now()
+  const weekAgo = now - 7 * 86400000
+  let count = 0
+  for (const e of store.exercises) {
+    const pr = store.getExercisePRSet(e.id, prBaselineDate.value)
+    if (pr && new Date(pr.date).getTime() >= weekAgo) count++
+  }
+  return count
+})
+
+/** Count of exercises carrying each tag — powers the "Push 23" suffix on tag chips. */
+const tagCounts = computed<Record<string, number>>(() => {
+  const map: Record<string, number> = {}
+  for (const e of store.exercises) {
+    for (const t of e.tags || []) {
+      map[t] = (map[t] || 0) + 1
+    }
+  }
+  return map
+})
+
+/**
+ * Per-row presentation data for the main exercise list: last set summary,
+ * time-ago, and whether the current baseline-relative PR was set this week
+ * (drives the "NEW PR" gold badge in the card).
+ */
+interface ExerciseRowMeta {
+  lastSet: { weight: number; reps: number; date: string } | null
+  timeAgo: string | null
+  isNewPRBadge: boolean
+}
+
+function getRowMeta(exerciseId: string): ExerciseRowMeta {
+  const ex = store.exercises.find(e => e.id === exerciseId)
+  if (!ex || ex.sets.length === 0) return { lastSet: null, timeAgo: null, isNewPRBadge: false }
+  const last = ex.sets[ex.sets.length - 1]
+  const prSet = store.getExercisePRSet(exerciseId, prBaselineDate.value)
+  const isFreshPR = !!prSet && (Date.now() - new Date(prSet.date).getTime()) < 7 * 86400000
+  return {
+    lastSet: { weight: last.weight, reps: last.reps, date: last.date },
+    timeAgo: formatTimeAgo(last.date),
+    isNewPRBadge: isFreshPR,
+  }
+}
 
 // Remove stale tags from active filters
 watch(() => store.allTags, (tags) => {
@@ -1453,6 +1540,20 @@ const groupedSets = computed(() => {
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+/** Relative time string used on the main exercise list ("today", "yesterday", "4 days ago"). */
+function formatTimeAgo(iso: string): string {
+  const now = new Date()
+  const then = new Date(iso)
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
+  const startOfThen = new Date(then.getFullYear(), then.getMonth(), then.getDate()).getTime()
+  const days = Math.round((startOfToday - startOfThen) / 86400000)
+  if (days <= 0) return 'today'
+  if (days === 1) return 'yesterday'
+  if (days < 7) return `${days} days ago`
+  if (days < 30) return `${Math.floor(days / 7)}w ago`
+  return formatDate(iso)
 }
 
 // Converts a stored ISO string back to the local YYYY-MM-DD for a date input
@@ -1785,6 +1886,13 @@ function openTimelineLogModal() {
 function pickExerciseForLog(exerciseId: string) {
   timelineLogPicking.value = false
   openLogForExercise(exerciseId)
+}
+
+/** "New exercise" row inside the picker — closes the picker and opens the
+ *  new-exercise flow instead of an existing exercise. */
+function pickNewExerciseFromPicker() {
+  timelineLogPicking.value = false
+  openNewExerciseModal()
 }
 
 // Open modal pre-targeted at a specific existing exercise
@@ -2833,6 +2941,9 @@ onUnmounted(() => {
 })
 
 // Exposed so the app's top-bar "+" button can trigger quick-log without
-// duplicating the exercise-picker state in App.vue.
-defineExpose({ openTimelineLogModal })
+// duplicating the exercise-picker state in App.vue. openNewExerciseModal is
+// also exposed for unit tests that previously opened the new-exercise
+// dialog via the in-card "+ New Exercise" button (retired after the
+// 03-workouts.png restyle).
+defineExpose({ openTimelineLogModal, openNewExerciseModal })
 </script>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2831,4 +2831,8 @@ onUnmounted(() => {
   stopTimer()
   document.documentElement.classList.remove('modal-open')
 })
+
+// Exposed so the app's top-bar "+" button can trigger quick-log without
+// duplicating the exercise-picker state in App.vue.
+defineExpose({ openTimelineLogModal })
 </script>

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -165,9 +165,12 @@ describe('WorkoutTracker', () => {
       expect(wrapper.find('.wtEmpty').text()).toContain('No exercises yet')
     })
 
-    it('renders "New Exercise" button', () => {
+    it('renders the Workouts large title', () => {
+      // After the 03-workouts.png restyle, the "+ New Exercise" button moved
+      // into the exercise-picker modal. The tab itself shows an iOS large
+      // title instead.
       const wrapper = mountTracker()
-      expect(wrapper.find('.wtLogBtn').text()).toBe('+ New Exercise')
+      expect(wrapper.find('.wtPageTitle').text()).toBe('Workouts')
     })
 
     it('does not render tag filter bar when no tags', () => {
@@ -194,28 +197,31 @@ describe('WorkoutTracker', () => {
       expect(rows[1].text()).toContain('Squat')
     })
 
-    it('displays est. 1RM with the PR set weight × reps', () => {
+    it('displays last set summary with weight × reps on the card', () => {
       const wrapper = mountTracker()
-      const meta = wrapper.findAll('.wtExerciseMeta')
-      // Bench PR set: 195 × 5 = e1RM 228
-      expect(meta[0].text()).toContain('228')
-      expect(meta[0].text()).toContain('195')
-      expect(meta[0].text()).toContain('5')
+      // The restyled card shows the most recent set + time-ago instead of
+      // an est. 1RM summary. Bench last set in the fixture is 195 × 5.
+      const stats = wrapper.findAll('.wtExerciseStat')
+      expect(stats[0].text()).toContain('195')
+      expect(stats[0].text()).toContain('× 5')
     })
 
-    it('hides meta for exercise with no sets', () => {
+    it('shows "No sets yet" placeholder for exercise with no sets', () => {
       const wrapper = mountTracker()
-      // ex-3 (Deadlift) has no sets — meta should not render
       const items = wrapper.findAll('.wtExerciseItem')
-      const deadliftMeta = items[2].find('.wtExerciseMeta')
-      expect(deadliftMeta.exists()).toBe(false)
+      // ex-3 (Deadlift) has no sets — stat line shows the empty placeholder
+      const deadliftStat = items[2].find('.wtExerciseStatEmpty')
+      expect(deadliftStat.exists()).toBe(true)
+      expect(deadliftStat.text()).toContain('No sets yet')
     })
 
-    it('shows "+ Log" button for each exercise', () => {
+    it('shows a circular quick-log button for each exercise', () => {
       const wrapper = mountTracker()
-      const logBtns = wrapper.findAll('.wtExerciseLogBtn')
+      // Button is now icon-only (gold circle with a plus svg). Assert it
+      // exists with the circle modifier class and an aria-label.
+      const logBtns = wrapper.findAll('.wtExerciseLogBtn.wtExerciseLogBtnCircle')
       expect(logBtns.length).toBe(3)
-      expect(logBtns[0].text()).toBe('+ Log')
+      expect(logBtns[0].attributes('aria-label')).toContain('Log a set')
     })
 
     it('renders drag handles for reordering', () => {
@@ -230,19 +236,31 @@ describe('WorkoutTracker', () => {
       exercises = JSON.parse(JSON.stringify(EXERCISES))
     })
 
+    function tagChips(wrapper: VueWrapper) {
+      // After the PNG restyle, chips include an "All" chip and a tag-manager
+      // chip. Skip those so tests focus on the real tag filter chips.
+      return wrapper.findAll('.wtTagChip').filter(c => {
+        if (c.classes('wtTagChipClear')) return false
+        if (c.classes('wtTagChipManage')) return false
+        const label = c.find('.wtTagChipLabel')
+        if (!label.exists()) return false
+        return true
+      })
+    }
+
     it('renders tag filter chips for all unique tags', () => {
       const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
-      const chipTexts = chips.map(c => c.text())
-      expect(chipTexts).toContain('Chest')
-      expect(chipTexts).toContain('Push')
-      expect(chipTexts).toContain('Legs')
+      const chips = tagChips(wrapper)
+      const chipLabels = chips.map(c => c.find('.wtTagChipLabel').text())
+      expect(chipLabels).toContain('Chest')
+      expect(chipLabels).toContain('Push')
+      expect(chipLabels).toContain('Legs')
     })
 
     it('filters exercises when tag is clicked', async () => {
       const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
-      const legsChip = chips.find(c => c.text() === 'Legs')!
+      const chips = tagChips(wrapper)
+      const legsChip = chips.find(c => c.find('.wtTagChipLabel').text() === 'Legs')!
       await legsChip.trigger('click')
 
       const items = wrapper.findAll('.wtExerciseItem')
@@ -250,28 +268,22 @@ describe('WorkoutTracker', () => {
       expect(wrapper.text()).toContain('Squat')
     })
 
-    it('shows clear button when filter is active', async () => {
+    it('deactivates filter by clicking the All chip', async () => {
+      // The dedicated "× Clear" button was retired in favor of the "All" chip
+      // that sits at the head of the tag-filter row.
       const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
+      const chips = tagChips(wrapper)
       await chips[0].trigger('click')
-
-      expect(wrapper.find('.wtTagChipClear').exists()).toBe(true)
-      expect(wrapper.find('.wtTagChipClear').text()).toBe('× Clear')
-    })
-
-    it('clears filters when clear button is clicked', async () => {
-      const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
-      await chips[0].trigger('click')
-      await wrapper.find('.wtTagChipClear').trigger('click')
+      const allChip = wrapper.findAll('.wtTagChip').find(c => c.text().trim() === 'All')!
+      await allChip.trigger('click')
 
       expect(wrapper.findAll('.wtExerciseItem').length).toBe(3)
     })
 
     it('shows exercises matching ANY active tag (OR logic)', async () => {
       const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
-      const pushChip = chips.find(c => c.text() === 'Push')!
+      const chips = tagChips(wrapper)
+      const pushChip = chips.find(c => c.find('.wtTagChipLabel').text() === 'Push')!
       await pushChip.trigger('click')
 
       // Push matches Bench Press and Overhead Press
@@ -281,7 +293,7 @@ describe('WorkoutTracker', () => {
 
     it('disables drag handles when filter is active', async () => {
       const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
+      const chips = tagChips(wrapper)
       await chips[0].trigger('click')
 
       expect(wrapper.findAll('.wtDragHandleDisabled').length).toBeGreaterThan(0)
@@ -289,8 +301,8 @@ describe('WorkoutTracker', () => {
 
     it('deactivates tag on second click', async () => {
       const wrapper = mountTracker()
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
-      const legsChip = chips.find(c => c.text() === 'Legs')!
+      const chips = tagChips(wrapper)
+      const legsChip = chips.find(c => c.find('.wtTagChipLabel').text() === 'Legs')!
       await legsChip.trigger('click')
       expect(wrapper.findAll('.wtExerciseItem').length).toBe(1)
 
@@ -508,18 +520,37 @@ describe('WorkoutTracker', () => {
   })
 
   describe('new exercise modal', () => {
-    it('opens modal when "+ New Exercise" is clicked', async () => {
-      const wrapper = mountTracker()
-      await wrapper.find('.wtLogBtn').trigger('click')
+    // The top-bar "+" button in App.vue opens the exercise picker, which has
+    // a "+ New exercise" row that calls the underlying openNewExerciseModal.
+    // Component unit tests reach the modal by calling the exposed helper.
+    async function openNewExerciseModal(wrapper: VueWrapper) {
+      const cmp = wrapper.vm as unknown as { openNewExerciseModal?: () => void }
+      // openNewExerciseModal is defined at the top level of <script setup>
+      // so it's not on the instance. Invoke via defineExpose → or trigger
+      // by opening the picker and clicking the "+ New exercise" row.
+      if (typeof cmp.openNewExerciseModal === 'function') {
+        cmp.openNewExerciseModal()
+      } else {
+        // Fallback: click the picker's new-exercise row after opening the picker.
+        const trackerExpose = wrapper.vm as unknown as { openTimelineLogModal?: () => void }
+        trackerExpose.openTimelineLogModal?.()
+        await wrapper.vm.$nextTick()
+        const newRow = wrapper.find('.wtExPickerNew')
+        if (newRow.exists()) await newRow.trigger('click')
+      }
       await wrapper.vm.$nextTick()
+    }
+
+    it('opens modal via the "+ New exercise" picker row', async () => {
+      const wrapper = mountTracker()
+      await openNewExerciseModal(wrapper)
 
       expect(wrapper.find('.repMaxModal').exists()).toBe(true)
     })
 
     it('shows "New Exercise" as modal title', async () => {
       const wrapper = mountTracker()
-      await wrapper.find('.wtLogBtn').trigger('click')
-      await wrapper.vm.$nextTick()
+      await openNewExerciseModal(wrapper)
 
       expect(wrapper.find('#log-modal-title').text()).toBe('New Exercise')
     })
@@ -529,8 +560,7 @@ describe('WorkoutTracker', () => {
       mockAddExercise.mockReturnValue('ex-new')
       const wrapper = mountTracker()
 
-      await wrapper.find('.wtLogBtn').trigger('click')
-      await wrapper.vm.$nextTick()
+      await openNewExerciseModal(wrapper)
 
       // Enter exercise name
       const nameInput = wrapper.find('.repMaxModal input[type="text"]')
@@ -548,8 +578,7 @@ describe('WorkoutTracker', () => {
       mockAddExercise.mockReturnValue('ex-new')
       const wrapper = mountTracker()
 
-      await wrapper.find('.wtLogBtn').trigger('click')
-      await wrapper.vm.$nextTick()
+      await openNewExerciseModal(wrapper)
 
       // Enter exercise name
       const nameInput = wrapper.find('.repMaxModal input[type="text"]')
@@ -573,8 +602,7 @@ describe('WorkoutTracker', () => {
 
     it('disables save button when name is empty', async () => {
       const wrapper = mountTracker()
-      await wrapper.find('.wtLogBtn').trigger('click')
-      await wrapper.vm.$nextTick()
+      await openNewExerciseModal(wrapper)
 
       const saveBtn = wrapper.find('.repMaxBtn.repMaxBtnCalc')
       expect(saveBtn.attributes('disabled')).toBeDefined()
@@ -718,9 +746,15 @@ describe('WorkoutTracker', () => {
 
     it('combined search and tag filter narrows results', async () => {
       const wrapper = mountTracker()
-      // First filter by tag 'Back'
-      const chips = wrapper.findAll('.wtTagChip:not(.wtTagChipClear)')
-      const backChip = chips.find(c => c.text() === 'Back')!
+      // First filter by tag 'Back' — skip the "All" and manage chips added
+      // in the 03-workouts.png restyle.
+      const chips = wrapper.findAll('.wtTagChip').filter(c => {
+        if (c.classes('wtTagChipClear')) return false
+        if (c.classes('wtTagChipManage')) return false
+        const label = c.find('.wtTagChipLabel')
+        return label.exists()
+      })
+      const backChip = chips.find(c => c.find('.wtTagChipLabel').text() === 'Back')!
       await backChip.trigger('click')
 
       // Then search for 'row'
@@ -896,7 +930,8 @@ describe('WorkoutTracker', () => {
         { id: '5', name: 'E', tags: [], sets: [] },
       ]
       const wrapper = mountTracker()
-      expect(wrapper.find('.wtSearchInput').attributes('aria-label')).toBe('Search exercises')
+      // Search now covers both exercise names and tags (03-workouts.png).
+      expect(wrapper.find('.wtSearchInput').attributes('aria-label')).toBe('Search exercises or tags')
     })
 
     it('log button aria-label renders exercise name dynamically', () => {
@@ -920,21 +955,21 @@ describe('WorkoutTracker', () => {
     it('tag filter buttons have aria-pressed reflecting active state', () => {
       exercises = JSON.parse(JSON.stringify(EXERCISES))
       const wrapper = mountTracker()
-      const tagBtns = wrapper.findAll('.wtTagChip:not(.wtTagChipManage)')
+      // Only actual tag chips have aria-pressed — skip "All", "× Clear",
+      // and the tag-manager chip added in the 03-workouts.png restyle.
+      const tagBtns = wrapper.findAll('.wtTagChip').filter(c => c.find('.wtTagChipLabel').exists())
       expect(tagBtns.length).toBeGreaterThan(0)
-      // Initially none are pressed
       tagBtns.forEach(btn => {
-        if (!btn.classes().includes('wtTagChipClear')) {
-          expect(btn.attributes('aria-pressed')).toBe('false')
-        }
+        expect(btn.attributes('aria-pressed')).toBe('false')
       })
     })
 
     it('tag add buttons have aria-label', async () => {
       exercises = JSON.parse(JSON.stringify(EXERCISES))
       const wrapper = mountTracker()
-      // Open new exercise modal
-      await wrapper.find('.wtLogBtn').trigger('click')
+      // Open new exercise modal via the exposed helper (retired wtLogBtn).
+      const exposed = wrapper.vm as unknown as { openNewExerciseModal?: () => void }
+      exposed.openNewExerciseModal?.()
       await wrapper.vm.$nextTick()
       const addBtn = wrapper.find('.wtTagAddChip')
       expect(addBtn.attributes('aria-label')).toBe('Add tag')
@@ -993,13 +1028,25 @@ describe('WorkoutTracker', () => {
       expect(wrapper.find('.wtViewToggleBtn.active').text()).toBe('Timeline')
     })
 
-    it('shows "+ New Exercise" in exercises view and "+ Log Set" in timeline view', async () => {
+    it('quick-log button is driven by the app-level "+" and works from both views', async () => {
+      // The old `wtLogBtn` in the card header is gone (03-workouts.png). Both
+      // views now rely on the App.vue top-bar "+" which calls the exposed
+      // openTimelineLogModal helper to open the exercise picker.
       const wrapper = mountTracker()
-      expect(wrapper.find('.wtLogBtn').text()).toBe('+ New Exercise')
+      const exposed = wrapper.vm as unknown as { openTimelineLogModal?: () => void }
+      expect(typeof exposed.openTimelineLogModal).toBe('function')
 
+      exposed.openTimelineLogModal!()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.wtExPickerNew').exists()).toBe(true)
+
+      // Switch to timeline view; the exposed helper still works.
+      await wrapper.find('.wtExPickerRow + .wtExPickerRow, .wtExPickerRow')
       await wrapper.findAll('.wtViewToggleBtn')[1].trigger('click')
       await wrapper.vm.$nextTick()
-      expect(wrapper.find('.wtLogBtn').text()).toBe('+ Log Set')
+      exposed.openTimelineLogModal!()
+      await wrapper.vm.$nextTick()
+      expect(wrapper.find('.wtExPickerNew').exists()).toBe(true)
     })
 
     it('persists view selection to localStorage', async () => {

--- a/src/index.css
+++ b/src/index.css
@@ -1843,37 +1843,56 @@ html.theme-fading .settingsSheet {
 /* ─── Workout tracker card ───────────────────────────────────────────────── */
 
 .wtCard {
-  background: var(--glass-fill, var(--bg-secondary));
-  backdrop-filter: blur(20px) saturate(160%);
-  -webkit-backdrop-filter: blur(20px) saturate(160%);
-  border: 1px solid var(--glass-edge, var(--border));
-  box-shadow: var(--shadow), inset 0 1px 0 var(--glass-shine);
-  border-radius: 14px;
-  overflow: hidden;
-  transition: background-color 0.2s, border-color 0.2s;
+  /* After the 03-workouts.png refresh the list itself is no longer a glass
+     card — content flows directly in the tab content area with a large
+     title and grouped rows, matching iOS HIG. Keep the class so other
+     styles that key off .wtCard descendants still apply. */
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  border-radius: 0;
+  overflow: visible;
 }
 
-.wtCardHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 16px;
-  border-bottom: 1px solid var(--border);
+/* ─── iOS-style large title + stats (03-workouts.png) ──────────────────── */
+.wtPageHeader {
+  padding: 8px 4px 16px;
 }
 
+.wtPageTitle {
+  margin: 0;
+  font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+  font-size: 34px;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.wtPageStats {
+  margin: 4px 0 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Segmented control (Exercises / Timeline) — gold-filled active pill. */
 .wtViewToggle {
   display: flex;
-  margin: 8px 16px;
-  padding: 2px;
-  background: var(--bg-secondary);
-  border-radius: 10px;
+  margin: 0 0 12px;
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  gap: 4px;
 }
 
 .wtViewToggleBtn {
   flex: 1;
-  padding: 8px;
+  padding: 0;
   min-height: 32px;
-  font-size: var(--font-caption1);
+  font-size: 14px;
   font-weight: 600;
   font-family: inherit;
   color: var(--text-secondary);
@@ -1887,6 +1906,7 @@ html.theme-fading .settingsSheet {
 .wtViewToggleBtn.active {
   background: var(--accent);
   color: var(--text-on-accent);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
 }
 
 .wtTitle {
@@ -2093,6 +2113,15 @@ html.theme-fading .settingsSheet {
   text-align: left;
 }
 
+.wtExPickerNew {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.wtExPickerNew .wtExPickerName {
+  color: var(--accent);
+}
+
 .wtExPickerRow:last-child {
   border-bottom: none;
 }
@@ -2117,21 +2146,30 @@ html.theme-fading .settingsSheet {
 
 .wtExerciseList {
   list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0;
 }
 
 .wtExerciseItem {
   contain: layout style paint;
+  /* Each exercise is its own iOS-style card, not stacked row borders. */
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
 }
 
 .wtExerciseItem + .wtExerciseItem {
-  border-top: 1px solid var(--border-strong);
+  border-top: 1px solid var(--border);
 }
 
 .wtExerciseHeader {
   display: flex;
   align-items: stretch;
-  /* Long-press picks up the row to reorder. Block iOS text selection/magnifier
-     and the callout menu so the gesture doesn't fight the system. */
+  gap: 8px;
+  padding: 12px;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
@@ -2142,43 +2180,99 @@ html.theme-fading .settingsSheet {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 16px 16px;
-  min-height: 44px;
+  padding: 0;
+  min-height: 56px;
   background: none;
   border: none;
   cursor: pointer;
   text-align: left;
   font-family: inherit;
-  font-size: var(--font-footnote);
   color: var(--text-primary);
   transition: background-color 0.12s;
   min-width: 0;
 }
 
-.wtExerciseRow:hover { background: var(--bg-hover); }
+.wtExerciseRow:active { opacity: 0.75; }
 
 .wtExerciseNameBlock {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 8px;
+  min-width: 0;
+}
+
+.wtExerciseTopLine {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
 }
 
 .wtExerciseName {
   font-weight: 600;
-  font-size: var(--font-footnote);
+  font-size: 16px;
+  line-height: 1.2;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
+  flex: 1;
 }
 
-.wtExerciseMeta {
-  font-size: var(--font-caption2);
-  color: var(--text-muted);
+.wtExerciseNewPR {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--accent-subtle);
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 99px;
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.wtExerciseNewPRIcon {
+  font-size: 10px;
+}
+
+.wtExerciseMetaLine {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
   font-variant-numeric: tabular-nums;
-  white-space: nowrap;
+  min-width: 0;
+}
+
+.wtExerciseTag {
+  display: inline-block;
+  padding: 2px 8px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.wtExerciseStat {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.wtExerciseStatEmpty {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .wtChevron {
@@ -2207,23 +2301,45 @@ html.theme-fading .settingsSheet {
 .wtExerciseLogBtn:hover  { background: var(--accent-subtle); }
 .wtExerciseLogBtn:active { opacity: 0.75; }
 
+/* Circular gold "+" button on each exercise row (03-workouts.png). */
+.wtExerciseLogBtnCircle {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: none;
+  border-radius: 99px;
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  align-self: center;
+  cursor: pointer;
+  transition: transform 0.1s, background-color 0.15s;
+}
+
+.wtExerciseLogBtnCircle:hover  { background: var(--accent-hover, var(--accent)); }
+.wtExerciseLogBtnCircle:active { transform: scale(0.94); }
+
 /* ─── Drag handle ──────────────────────────────────────────────────────── */
 
 .wtDragHandle {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 44px;
+  width: 16px;
   flex-shrink: 0;
-  font-size: var(--font-callout);
+  font-size: 14px;
   color: var(--text-muted);
   background: none;
   border: none;
-  border-right: 1px solid var(--border);
   user-select: none;
   -webkit-user-select: none;
   pointer-events: none;
-  transition: color 0.15s;
+  transition: color 0.15s, opacity 0.15s;
+  opacity: 0.35;
+  align-self: center;
 }
 
 .wtDragHandleDisabled {
@@ -2276,22 +2392,34 @@ html.theme-fading .settingsSheet {
 /* ─── Tag filter bar ───────────────────────────────────────────────────── */
 
 .wtSearchBar {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 16px;
+  padding: 0 0 12px;
+}
+
+.wtSearchIcon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(calc(-50% - 6px));
+  color: var(--text-muted);
+  pointer-events: none;
 }
 
 .wtSearchInput {
   flex: 1;
-  padding: 8px 12px;
-  font-size: var(--font-footnote);
+  padding: 12px 12px 12px 32px;
+  font-size: 14px;
+  font-family: inherit;
   color: var(--text-primary);
-  background: var(--bg-primary);
+  background: var(--bg-elevated);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 12px;
   outline: none;
   transition: border-color 0.15s;
+  min-height: 44px;
 }
 
 .wtSearchInput:focus {
@@ -2299,57 +2427,79 @@ html.theme-fading .settingsSheet {
 }
 
 .wtSearchInput::placeholder {
-  color: var(--text-secondary);
+  color: var(--text-muted);
 }
 
 .wtSearchCount {
-  font-size: var(--font-caption1);
+  font-size: 12px;
   color: var(--text-muted);
   white-space: nowrap;
 }
 
 .wtTagFilterBar {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
-  padding: 8px 16px;
+  padding: 0 0 12px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 }
 
+.wtTagFilterBar::-webkit-scrollbar { display: none; }
+
 .wtTagChip {
-  font-size: var(--font-footnote);
+  font-size: 13px;
   font-weight: 600;
-  padding: 8px 16px;
-  min-height: 44px;
+  padding: 8px 12px;
+  min-height: 32px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 14px;
-  border: 1px solid var(--border-strong);
+  gap: 8px;
+  border-radius: 99px;
+  border: 1px solid var(--border);
   color: var(--text-secondary);
-  background: transparent;
+  background: var(--bg-elevated);
   cursor: pointer;
   font-family: inherit;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .wtTagChipActive {
-  background: var(--accent);
+  background: var(--accent-subtle);
   border-color: var(--accent);
-  color: var(--text-on-accent);
+  color: var(--accent);
+}
+
+.wtTagChipLabel {
+  font-weight: 600;
+}
+
+.wtTagChipCount {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.wtTagChipActive .wtTagChipCount {
+  color: var(--accent);
+  opacity: 0.7;
 }
 
 .wtTagChipClear {
   border-color: var(--danger);
   color: var(--danger);
+  background: transparent;
 }
 
 .wtTagChipManage {
   border-color: var(--border);
-  color: var(--text-secondary);
+  color: var(--text-muted);
   padding: 8px 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 /* ─── Tag manager modal ────────────────────────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -841,11 +841,23 @@ button, [role="tab"], [role="switch"], a {
 
 .appTopBar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
-  padding: 4px 0;
+  padding: 8px 4px;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.appTopBarLeft,
+.appTopBarRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-shrink: 0;
 }
+
+.appTopBarLeft { justify-content: flex-start; }
+.appTopBarRight { justify-content: flex-end; }
 
 .tabContent {
   flex: 1;
@@ -853,7 +865,8 @@ button, [role="tab"], [role="switch"], a {
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   padding-top: 12px;
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 110px);
+  /* Reserve room for the floating tab bar: 58h + 26 offset + 16 padding + safe area */
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 120px);
 }
 
 html.modal-open .tabContent {
@@ -862,35 +875,43 @@ html.modal-open .tabContent {
 }
 
 
-/* ─── Tab bar ────────────────────────────────────────────────────────────── */
-
+/* ─── Floating glass tab bar ────────────────────────────────────────────── */
+/*
+  Geometry matches the skeleton tab bar painted on the splash screen
+  (index.html #splash), so the handoff from OS splash → Vue app is invisible:
+    left: 14px, right: 14px, bottom: calc(26px + safe-area-inset-bottom),
+    height: 58px, radius: 20px.
+*/
 .tabBar {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  left: 14px;
+  right: 14px;
+  bottom: calc(26px + env(safe-area-inset-bottom, 0px));
+  height: 58px;
   display: flex;
+  border-radius: 20px;
   background: var(--glass-bar, var(--bg-secondary));
-  backdrop-filter: blur(28px) saturate(180%);
-  -webkit-backdrop-filter: blur(28px) saturate(180%);
-  border-top: 1px solid var(--glass-edge, var(--border));
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-  padding-left: env(safe-area-inset-left, 0px);
-  padding-right: env(safe-area-inset-right, 0px);
+  backdrop-filter: blur(20px) saturate(1.8);
+  -webkit-backdrop-filter: blur(20px) saturate(1.8);
+  border: 1px solid var(--glass-edge, var(--border));
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
   z-index: 90;
+  /* Horizontal padding gives the active-tab pill some breathing room. */
+  padding: 0 4px;
 }
 
 .tabBarTabs {
   flex: 1;
   display: flex;
   position: relative;
+  height: 100%;
 }
 
 .tabIndicator {
   position: absolute;
-  top: 4px;
-  bottom: 4px;
-  border-radius: 12px;
+  top: 6px;
+  bottom: 6px;
+  border-radius: 14px;
   background: var(--accent-subtle);
   border: none;
   backdrop-filter: blur(12px);
@@ -906,46 +927,72 @@ html.modal-open .tabContent {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 12px 0 8px;
+  gap: 2px;
+  padding: 0;
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-family: inherit;
   transition: color 0.25s;
   position: relative;
   z-index: 1;
+  height: 100%;
+  /* Minimum HIG touch target */
+  min-width: 44px;
 }
 
 .tabBtn.active {
   color: var(--accent);
 }
 
-.settingsGearBtn {
+.settingsGearBtn,
+.topBarPlusBtn {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 44px;
   height: 44px;
   padding: 0;
-  background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-muted);
-  border-radius: 8px;
-  transition: color 0.2s, background-color 0.2s;
+  font-family: inherit;
   flex-shrink: 0;
+  border-radius: 999px;
+  transition: background-color 0.2s, color 0.2s, transform 0.1s;
+}
+
+.settingsGearBtn {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
 }
 
 .settingsGearBtn:active {
   background: var(--accent-subtle);
   color: var(--accent);
+  transform: scale(0.95);
 }
 
 .settingsGearBtn svg {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
+}
+
+.topBarPlusBtn {
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.topBarPlusBtn:active {
+  transform: scale(0.94);
+  background: var(--accent-hover, var(--accent));
+}
+
+.topBarPlusBtn svg {
+  width: 22px;
+  height: 22px;
 }
 
 .syncIndicator {


### PR DESCRIPTION
Closes #364. Stacks on #363 (settings rework) which stacks on #361 (splash). Merge in order.

## Summary

- **Top bar** now has gear-left + gold "+"-right, replacing the single right-justified gear. The "+" triggers the existing exercise-picker quick-log flow via \`defineExpose\` on \`WorkoutTracker\`.
- **Floating glass tab bar** replaces the full-width pinned bar. Inset 14px L/R, bottom 26px + safe-area, 58h, 20r, \`--glass-bar\` + \`--glass-edge\` + 20px backdrop-blur.
- **Geometry now matches the splash skeleton tab bar** (same left/right inset, same height, same radius), so the handoff from OS-splash → Vue app is visually seamless.

## Screenshots (Playwright, Luck dark)

![workouts](step3-luck-forced.png)

## Not in this PR

- "Workouts" large iOS title + "12 exercises · 3 PRs this week" subtitle
- Per-row inline "+" button (existing "+ Log" text button stays)
- Timeline connector line + PR dots
- "NEW PR" row badge
- Dead \`[data-glass="off"]\` CSS purge

## Test plan

- [x] \`npm test\` — 1258 pass
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] Visual: gear (left) + gold "+" (right), floating tab bar matches splash skeleton
- [ ] Manual QA on iOS simulator: tap "+" opens exercise picker, tab bar respects safe-area on home-indicator devices