### PR TITLE
feat: PR burst celebration overlay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,21 +27,34 @@
           Viewing sample data — Tap to clear and start fresh
         </button>
         <div class="appTopBar">
-          <span v-if="syncStatus !== 'synced'" class="syncIndicator" :class="'syncIndicator--' + syncStatus" :title="syncStatusLabel" role="status">
-            <svg v-if="syncStatus === 'error'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-            <svg v-else-if="syncStatus === 'offline'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="1" y1="1" x2="23" y2="23"/><path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/><path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/><path d="M10.71 5.05A16 16 0 0 1 22.56 9"/><path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
-            <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
-          </span>
-          <button
-            class="settingsGearBtn"
-            @click="settingsOpen ? closeSettings() : (settingsOpen = true)"
-            title="Settings"
-            aria-label="Settings"
-          >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
-          </button>
+          <div class="appTopBarLeft">
+            <button
+              class="settingsGearBtn"
+              @click="settingsOpen ? closeSettings() : (settingsOpen = true)"
+              title="Settings"
+              aria-label="Settings"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            </button>
+            <span v-if="syncStatus !== 'synced'" class="syncIndicator" :class="'syncIndicator--' + syncStatus" :title="syncStatusLabel" role="status">
+              <svg v-if="syncStatus === 'error'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              <svg v-else-if="syncStatus === 'offline'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="1" y1="1" x2="23" y2="23"/><path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/><path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/><path d="M10.71 5.05A16 16 0 0 1 22.56 9"/><path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>
+              <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/></svg>
+            </span>
+          </div>
+          <div class="appTopBarRight">
+            <button
+              v-if="activeTab === 'workouts'"
+              class="topBarPlusBtn"
+              @click="triggerQuickLog"
+              title="Log a set"
+              aria-label="Log a set"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            </button>
+          </div>
         </div>
-        <div v-show="activeTab === 'workouts'" class="tabContent"><WorkoutTracker /></div>
+        <div v-show="activeTab === 'workouts'" class="tabContent"><WorkoutTracker ref="workoutTrackerRef" /></div>
         <div v-show="activeTab === 'calendar'" class="tabContent"><CalendarView /></div>
         <div v-show="activeTab === 'weight'" class="tabContent"><BodyweightTracker /></div>
       </main>
@@ -1204,6 +1217,17 @@ function confirmResetProgress() {
 
 const starterPickerVisible = ref(false)
 const starterPickerRef = ref<InstanceType<typeof StarterPickerFlow> | null>(null)
+
+// Exposed from WorkoutTracker via defineExpose so the top-bar "+" can trigger
+// the same quick-log exercise-picker flow the in-content "+ Log Set" uses.
+const workoutTrackerRef = ref<InstanceType<typeof WorkoutTracker> | null>(null)
+
+function triggerQuickLog() {
+  const wt = workoutTrackerRef.value
+  if (wt && typeof wt.openTimelineLogModal === 'function') {
+    wt.openTimelineLogModal()
+  }
+}
 
 // Revert any in-flight theme preview if the picker is hidden for any reason
 watch(starterPickerVisible, (visible) => { if (!visible) revertPreview() })

--- a/src/App.vue
+++ b/src/App.vue
@@ -782,6 +782,11 @@
       </div>
     </transition>
   </Teleport>
+
+  <!-- Full-screen PR celebration — triggered via usePRBurst().presentPRBurst(). -->
+  <Teleport to="body">
+    <PRBurst />
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -791,6 +796,7 @@ import ErrorBoundary from './components/ErrorBoundary.vue'
 import AuthScreen from './components/AuthScreen.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
 import StarterPickerFlow from './components/StarterPickerFlow.vue'
+import PRBurst from './components/PRBurst.vue'
 
 // Lazy-load tab content — split into separate chunks for faster initial load
 import SkeletonLoader from './components/SkeletonLoader.vue'

--- a/src/components/PRBurst.vue
+++ b/src/components/PRBurst.vue
@@ -1,0 +1,267 @@
+<!--
+  PR burst celebration — full-bleed takeover shown when the user logs a
+  genuine e1RM PR. Layout matches design_handoff_lift_ios_pwa/screens/08-pr-burst.png:
+
+  - Dim + radial-overlay backdrop (vignette + gold accent radial)
+  - SVG ring echoes that expand from r=0
+  - Eyebrow "🏆 PERSONAL RECORD"
+  - Large delta "+XX lbs" (84px / 800)
+  - Subtitle "oldE1RM → newE1RM lbs e1RM"
+  - Chip "Exercise · weight × reps"
+  - "Tap to dismiss" hint at the bottom
+
+  Tapping anywhere (or pressing Escape) dismisses.
+-->
+<template>
+  <Transition name="prBurst">
+    <div
+      v-if="visible && payload"
+      class="prBurst"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Personal record"
+      tabindex="-1"
+      @click="onDismiss"
+      @keydown.escape="onDismiss"
+    >
+      <!-- Dimmed + radial backdrop -->
+      <div class="prBurstBackdrop" aria-hidden="true"></div>
+
+      <!-- Ring echoes (pointer-events: none) -->
+      <svg class="prBurstRings" viewBox="0 0 360 360" aria-hidden="true">
+        <circle cx="180" cy="180" r="80" fill="none" stroke="currentColor" stroke-width="2" opacity="0.35" class="prRing prRing1" />
+        <circle cx="180" cy="180" r="130" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.2" class="prRing prRing2" />
+        <circle cx="180" cy="180" r="170" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12" class="prRing prRing3" />
+      </svg>
+
+      <div class="prBurstContent">
+        <div class="prBurstEyebrow">🏆 Personal Record</div>
+        <div class="prBurstDelta">+{{ deltaDisplay }} {{ unit }}</div>
+        <div class="prBurstSubtitle">
+          <span class="prBurstSubtitleOld">{{ oldDisplay }}</span>
+          <span class="prBurstSubtitleArrow"> → </span>
+          <span class="prBurstSubtitleNew">{{ newDisplay }}</span>
+          <span class="prBurstSubtitleUnit"> {{ unit }} e1RM</span>
+        </div>
+        <div class="prBurstChip">
+          {{ payload.exerciseName }} · {{ setDisplay }}
+        </div>
+      </div>
+
+      <div class="prBurstHint" aria-hidden="true">Tap to dismiss</div>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed, watch, nextTick, ref, onMounted } from 'vue'
+import { usePRBurst } from '../composables/usePRBurst'
+import { useTheme } from '../composables/useTheme'
+
+const { visible, payload, presentPRBurst, dismissPRBurst } = usePRBurst()
+const { weightUnit, displayWeight } = useTheme()
+
+// DEV-only: expose the trigger on window so we can visually verify the overlay
+// from Playwright/DevTools without needing a live PR. Stripped from prod builds
+// by Vite's dead-code elimination (import.meta.env.DEV is false in prod).
+onMounted(() => {
+  if (import.meta.env.DEV) {
+    ;(window as unknown as Record<string, unknown>).__presentPRBurst = presentPRBurst
+  }
+})
+
+const unit = computed(() => weightUnit.value)
+
+const deltaDisplay = computed(() => {
+  if (!payload.value) return '0'
+  const delta = payload.value.newE1RM - payload.value.oldE1RM
+  const shown = displayWeight(delta)
+  // Whole pounds / kg read better than 12.3 lbs for the big hero number.
+  return Number.isInteger(shown) ? String(shown) : shown.toFixed(1)
+})
+
+const oldDisplay = computed(() => {
+  if (!payload.value) return ''
+  return Math.round(displayWeight(payload.value.oldE1RM))
+})
+
+const newDisplay = computed(() => {
+  if (!payload.value) return ''
+  return Math.round(displayWeight(payload.value.newE1RM))
+})
+
+const setDisplay = computed(() => {
+  if (!payload.value) return ''
+  const w = displayWeight(payload.value.setWeight)
+  return `${Number.isInteger(w) ? w : w.toFixed(1)} × ${payload.value.setReps}`
+})
+
+function onDismiss() {
+  dismissPRBurst()
+}
+
+// Keyboard focus on present so the Escape-to-dismiss works without needing
+// a prior focus. The tabindex="-1" on the root makes this valid.
+const rootEl = ref<HTMLElement | null>(null)
+watch(visible, async (v) => {
+  if (v) {
+    await nextTick()
+    const root = document.querySelector('.prBurst') as HTMLElement | null
+    rootEl.value = root
+    root?.focus()
+  }
+})
+</script>
+
+<style scoped>
+.prBurst {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  /* Outline on focus is noisy for a celebration — keep it invisible but focusable. */
+  outline: none;
+  cursor: pointer;
+}
+
+.prBurstBackdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 90% 70% at 50% 48%, var(--accent-subtle, rgba(212, 175, 55, 0.12)) 0%, transparent 70%),
+    radial-gradient(ellipse 120% 120% at 50% 48%, transparent 35%, rgba(0, 0, 0, 0.85) 100%),
+    rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px) saturate(0.7) brightness(0.35);
+  -webkit-backdrop-filter: blur(8px) saturate(0.7) brightness(0.35);
+  pointer-events: none;
+}
+
+.prBurstRings {
+  position: absolute;
+  top: 48%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 360px;
+  height: 360px;
+  max-width: 90vw;
+  max-height: 90vw;
+  pointer-events: none;
+  color: var(--accent);
+}
+
+.prBurstContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 24px;
+  max-width: 360px;
+  /* Anchor content slightly above vertical center, matching the ring echoes. */
+  transform: translateY(-2vh);
+}
+
+.prBurstEyebrow {
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.prBurstDelta {
+  font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+  font-size: 84px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--accent);
+  text-shadow: 0 0 40px var(--accent-subtle, rgba(212, 175, 55, 0.30));
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 12px;
+}
+
+.prBurstSubtitle {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 24px;
+}
+
+.prBurstSubtitleNew {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.prBurstChip {
+  display: inline-block;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 99px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.prBurstHint {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(44px + env(safe-area-inset-bottom, 0px));
+  text-align: center;
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Ring echo entrance: scale from 0 to 1 with stagger. */
+.prRing {
+  transform-origin: 180px 180px;
+  animation: prRingIn 480ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.prRing1 { animation-delay: 0ms; }
+.prRing2 { animation-delay: 80ms; }
+.prRing3 { animation-delay: 160ms; }
+
+@keyframes prRingIn {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); }
+}
+
+/* Overall fade in/out (vue <Transition>). */
+.prBurst-enter-active { transition: opacity 180ms ease-out; }
+.prBurst-leave-active { transition: opacity 180ms ease-in; }
+.prBurst-enter-from,
+.prBurst-leave-to { opacity: 0; }
+
+/* Delta number: slight "pop" on entrance. */
+.prBurstDelta {
+  animation: prDeltaPop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: 120ms;
+}
+@keyframes prDeltaPop {
+  from { transform: scale(0.6); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prRing,
+  .prBurstDelta {
+    animation: none !important;
+  }
+  .prBurst-enter-active,
+  .prBurst-leave-active { transition: none; }
+}
+</style>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -921,6 +921,7 @@ import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
 import { usePRBaseline } from '../composables/usePRBaseline'
+import { usePRBurst } from '../composables/usePRBurst'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
@@ -935,6 +936,7 @@ const { show: showUndo } = useUndoToast()
 const { currentTheme, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, setRestTimerEnabled } = useTheme()
 const { impactLight, notifySuccess } = useHaptics()
 const { prBaselineDate } = usePRBaseline()
+const { presentPRBurst } = usePRBurst()
 
 // Filter sets to those on/after the user-set PR baseline.
 // When no baseline is set, returns sets unchanged (legacy all-time behavior).
@@ -2537,6 +2539,8 @@ function saveSet() {
     }
     if (hasSetData.value && weight.value !== null && reps.value !== null) {
       const wasPR = isNewPR.value
+      // Capture the pre-log baseline PR so the burst can show old → new e1RM.
+      const oldE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
       store.logSet(exerciseId, toLbs(weight.value), reps.value, date.value)
       logEvent('set_log', { exercise: selectedExerciseName.value, isPR: wasPR })
       // XP: get the just-logged set (last in array) and compute XP
@@ -2548,6 +2552,16 @@ function saveSet() {
       // Haptic feedback — stronger for PRs
       if (wasPR) {
         notifySuccess()
+        // Full-bleed PR celebration (respects the PR baseline via oldE1RM,
+        // and the prCelebrations opt-out inside presentPRBurst).
+        const newE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
+        presentPRBurst({
+          exerciseName: selectedExerciseName.value,
+          oldE1RM,
+          newE1RM,
+          setWeight: toLbs(weight.value),
+          setReps: reps.value,
+        })
       } else {
         impactLight()
       }

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2831,4 +2831,8 @@ onUnmounted(() => {
   stopTimer()
   document.documentElement.classList.remove('modal-open')
 })
+
+// Exposed so the app's top-bar "+" button can trigger quick-log without
+// duplicating the exercise-picker state in App.vue.
+defineExpose({ openTimelineLogModal })
 </script>

--- a/src/composables/__tests__/usePRBurst.test.ts
+++ b/src/composables/__tests__/usePRBurst.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock useHaptics before we import the module under test so its inline
+// haptics.notifySuccess() call on present is observable.
+const notifySuccessMock = vi.fn()
+vi.mock('../useHaptics', () => ({
+  useHaptics: () => ({
+    impactLight: vi.fn(),
+    impactMedium: vi.fn(),
+    impactHeavy: vi.fn(),
+    notifySuccess: notifySuccessMock,
+    notifyWarning: vi.fn(),
+    notifyError: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn() },
+}))
+
+import { usePRBurst } from '../usePRBurst'
+import { usePreferencesStore } from '../../stores/preferences'
+
+describe('usePRBurst', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    notifySuccessMock.mockClear()
+    const { dismissPRBurst } = usePRBurst()
+    dismissPRBurst()
+  })
+
+  it('presents when new e1RM beats old and celebrations are enabled', () => {
+    const { presentPRBurst, visible, payload } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 594,
+      newE1RM: 606,
+      setWeight: 505,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(true)
+    expect(payload.value?.exerciseName).toBe('Hack Squat')
+    expect(payload.value?.oldE1RM).toBe(594)
+    expect(payload.value?.newE1RM).toBe(606)
+    expect(notifySuccessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips when the user disables PR celebrations', () => {
+    const prefs = usePreferencesStore()
+    prefs.setExperienceFlag('prCelebrations', false)
+
+    const { presentPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 500,
+      newE1RM: 600,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+    expect(notifySuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('guards against malformed payloads where new <= old', () => {
+    const { presentPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 600,
+      newE1RM: 600,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 600,
+      newE1RM: 550,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+  })
+
+  it('dismissPRBurst hides the overlay', () => {
+    const { presentPRBurst, dismissPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 594,
+      newE1RM: 606,
+      setWeight: 505,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(true)
+    dismissPRBurst()
+    expect(visible.value).toBe(false)
+  })
+})

--- a/src/composables/usePRBurst.ts
+++ b/src/composables/usePRBurst.ts
@@ -1,0 +1,81 @@
+/**
+ * PR burst composable — singleton reactive state for the full-bleed PR
+ * celebration overlay described in `design_handoff_lift_ios_pwa/screens/08-pr-burst.png`.
+ *
+ * Usage:
+ *   // From a log-set handler, after the set has been persisted:
+ *   const { presentPRBurst } = usePRBurst()
+ *   presentPRBurst({ exerciseName, oldE1RM, newE1RM, setWeight, setReps })
+ *
+ * Respects the user's `experience.prCelebrations` preference (no-ops when
+ * the toggle is off, even if presentPRBurst is called). Also fires a
+ * success haptic via useHaptics, which itself honors the haptics toggle.
+ *
+ * PR baseline: callers are expected to compare new vs. previous e1RM using
+ * `workoutStore.getExercisePR(id, prBaselineDate)` so the burst respects
+ * the user's selected baseline. This composable does not itself perform
+ * the comparison — it only decides whether to render once the caller has
+ * determined a true PR occurred.
+ */
+
+import { ref, type Ref } from 'vue'
+import { usePreferencesStore } from '../stores/preferences'
+import { useHaptics } from './useHaptics'
+
+export interface PRBurstPayload {
+  exerciseName: string
+  /** Previous best e1RM for this exercise, relative to the PR baseline. */
+  oldE1RM: number
+  /** New best e1RM after the current set. */
+  newE1RM: number
+  /** Weight (in lbs) of the set that triggered the PR. */
+  setWeight: number
+  /** Reps of the set that triggered the PR. */
+  setReps: number
+}
+
+const visible: Ref<boolean> = ref(false)
+const payload: Ref<PRBurstPayload | null> = ref(null)
+
+function presentPRBurst(p: PRBurstPayload): void {
+  // Skip if the user opted out of PR celebrations (Settings → Experience).
+  try {
+    const prefs = usePreferencesStore()
+    if (prefs.experience?.prCelebrations === false) return
+  } catch {
+    // Pinia unavailable (e.g. in certain test setups) — proceed.
+  }
+
+  // Guard against malformed payloads — a "PR" where new <= old is a bug.
+  if (p.newE1RM <= p.oldE1RM) return
+
+  payload.value = p
+  visible.value = true
+
+  // Success haptic on present. useHaptics short-circuits if the user
+  // disabled haptics.
+  try {
+    const haptics = useHaptics()
+    haptics.notifySuccess()
+  } catch {
+    /* silent — haptics are best-effort */
+  }
+}
+
+function dismissPRBurst(): void {
+  visible.value = false
+  // Clear payload slightly after the fade-out so the component can animate
+  // with the final values; a CSS transition handles opacity.
+  setTimeout(() => {
+    if (!visible.value) payload.value = null
+  }, 200)
+}
+
+export function usePRBurst() {
+  return {
+    visible,
+    payload,
+    presentPRBurst,
+    dismissPRBurst,
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -841,11 +841,23 @@ button, [role="tab"], [role="switch"], a {
 
 .appTopBar {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
-  padding: 4px 0;
+  padding: 8px 4px;
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.appTopBarLeft,
+.appTopBarRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex-shrink: 0;
 }
+
+.appTopBarLeft { justify-content: flex-start; }
+.appTopBarRight { justify-content: flex-end; }
 
 .tabContent {
   flex: 1;
@@ -853,7 +865,8 @@ button, [role="tab"], [role="switch"], a {
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   padding-top: 12px;
-  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 110px);
+  /* Reserve room for the floating tab bar: 58h + 26 offset + 16 padding + safe area */
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 120px);
 }
 
 html.modal-open .tabContent {
@@ -862,35 +875,43 @@ html.modal-open .tabContent {
 }
 
 
-/* ─── Tab bar ────────────────────────────────────────────────────────────── */
-
+/* ─── Floating glass tab bar ────────────────────────────────────────────── */
+/*
+  Geometry matches the skeleton tab bar painted on the splash screen
+  (index.html #splash), so the handoff from OS splash → Vue app is invisible:
+    left: 14px, right: 14px, bottom: calc(26px + safe-area-inset-bottom),
+    height: 58px, radius: 20px.
+*/
 .tabBar {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  left: 14px;
+  right: 14px;
+  bottom: calc(26px + env(safe-area-inset-bottom, 0px));
+  height: 58px;
   display: flex;
+  border-radius: 20px;
   background: var(--glass-bar, var(--bg-secondary));
-  backdrop-filter: blur(28px) saturate(180%);
-  -webkit-backdrop-filter: blur(28px) saturate(180%);
-  border-top: 1px solid var(--glass-edge, var(--border));
-  padding-bottom: env(safe-area-inset-bottom, 0px);
-  padding-left: env(safe-area-inset-left, 0px);
-  padding-right: env(safe-area-inset-right, 0px);
+  backdrop-filter: blur(20px) saturate(1.8);
+  -webkit-backdrop-filter: blur(20px) saturate(1.8);
+  border: 1px solid var(--glass-edge, var(--border));
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.25);
   z-index: 90;
+  /* Horizontal padding gives the active-tab pill some breathing room. */
+  padding: 0 4px;
 }
 
 .tabBarTabs {
   flex: 1;
   display: flex;
   position: relative;
+  height: 100%;
 }
 
 .tabIndicator {
   position: absolute;
-  top: 4px;
-  bottom: 4px;
-  border-radius: 12px;
+  top: 6px;
+  bottom: 6px;
+  border-radius: 14px;
   background: var(--accent-subtle);
   border: none;
   backdrop-filter: blur(12px);
@@ -906,46 +927,72 @@ html.modal-open .tabContent {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 12px 0 8px;
+  gap: 2px;
+  padding: 0;
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-family: inherit;
   transition: color 0.25s;
   position: relative;
   z-index: 1;
+  height: 100%;
+  /* Minimum HIG touch target */
+  min-width: 44px;
 }
 
 .tabBtn.active {
   color: var(--accent);
 }
 
-.settingsGearBtn {
+.settingsGearBtn,
+.topBarPlusBtn {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 44px;
   height: 44px;
   padding: 0;
-  background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-muted);
-  border-radius: 8px;
-  transition: color 0.2s, background-color 0.2s;
+  font-family: inherit;
   flex-shrink: 0;
+  border-radius: 999px;
+  transition: background-color 0.2s, color 0.2s, transform 0.1s;
+}
+
+.settingsGearBtn {
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
 }
 
 .settingsGearBtn:active {
   background: var(--accent-subtle);
   color: var(--accent);
+  transform: scale(0.95);
 }
 
 .settingsGearBtn svg {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
+}
+
+.topBarPlusBtn {
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.topBarPlusBtn:active {
+  transform: scale(0.94);
+  background: var(--accent-hover, var(--accent));
+}
+
+.topBarPlusBtn svg {
+  width: 22px;
+  height: 22px;
 }
 
 .syncIndicator {


### PR DESCRIPTION
Closes #366. Stacks on #365 (Workouts chrome), which stacks on #363 (settings), which stacks on #361 (splash). Merge in order.

## Summary

Full-bleed celebration when the user logs a genuine e1RM PR, matching \`screens/08-pr-burst.png\`:
- Dim + radial backdrop (accent-subtle radial + vignette + backdrop-blur)
- 3 SVG ring echoes (r=80, 130, 170) that scale in with 80ms stagger
- 🏆 PERSONAL RECORD eyebrow, +XX lbs delta at 84px/800, old → new e1RM subtitle, exercise chip, "Tap to dismiss"
- 180ms fade in/out; respects \`prefers-reduced-motion\`

## Trigger rules

- Fires from \`WorkoutTracker.saveSet\` when \`isNewPR.value\` is true (forward-logged sets only — not edits or calendar backfill)
- **Respects PR baseline** — uses \`getExercisePR(id, prBaselineDate)\` for both old and new e1RM
- **Respects \`prefs.experience.prCelebrations\`** — \`presentPRBurst\` short-circuits if the toggle from the previous PR is off
- **Respects haptics toggle** via \`useHaptics.notifySuccess()\`

## Architecture

- \`usePRBurst.ts\` — singleton composable \`{ visible, payload, presentPRBurst, dismissPRBurst }\`
- \`PRBurst.vue\` — Teleport-to-body overlay
- \`window.__presentPRBurst\` exposed in dev only (DCE'd in prod via \`import.meta.env.DEV\`) for QA

## Screenshot (Luck dark)

![pr-burst](step4-pr-burst-luck.png)

## Test plan

- [x] \`npm test\` — 1262 pass (4 new)
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] Manual: burst presents for PR, respects toggle, dismisses on tap + Escape