### PR TITLE
feat: Onboarding restyle to match 01-auth.png

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -782,6 +782,11 @@
       </div>
     </transition>
   </Teleport>
+
+  <!-- Full-screen PR celebration — triggered via usePRBurst().presentPRBurst(). -->
+  <Teleport to="body">
+    <PRBurst />
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -791,6 +796,7 @@ import ErrorBoundary from './components/ErrorBoundary.vue'
 import AuthScreen from './components/AuthScreen.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
 import StarterPickerFlow from './components/StarterPickerFlow.vue'
+import PRBurst from './components/PRBurst.vue'
 
 // Lazy-load tab content — split into separate chunks for faster initial load
 import SkeletonLoader from './components/SkeletonLoader.vue'

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -3,31 +3,64 @@
     <div class="obCard">
       <!-- Step 1: Setup path -->
       <template v-if="step === 'setup'">
-        <div class="obLogo">Lift</div>
+        <div class="obHero">
+          <div class="obLogo">Lift</div>
+          <p class="obSubtitle">Strength tracking, quietly.</p>
+        </div>
         <p class="obTagline">How would you like to get started?</p>
 
         <div class="obOptions">
-          <button class="obOption" @click="chooseEmpty" aria-label="Start Empty — Add your own exercises from scratch">
-            <span class="obOptionIcon">🚀</span>
+          <button
+            class="obOption obOptionFeatured"
+            @click="chooseStarter"
+            aria-label="Popular Exercises — Pre-load 6 common lifts with tags, start logging in seconds"
+          >
+            <span class="obOptionIcon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
+                <rect x="2" y="10" width="4" height="4" rx="1"/>
+                <rect x="18" y="10" width="4" height="4" rx="1"/>
+                <rect x="5" y="8" width="3" height="8" rx="1"/>
+                <rect x="16" y="8" width="3" height="8" rx="1"/>
+                <line x1="8" y1="12" x2="16" y2="12"/>
+              </svg>
+            </span>
             <span class="obOptionText">
-              <strong>Start Empty</strong>
-              <span>Add your own exercises from scratch</span>
+              <strong>Popular exercises</strong>
+              <span>Pre-load 6 common lifts with tags — start logging in seconds.</span>
             </span>
           </button>
 
-          <button class="obOption" @click="chooseStarter" aria-label="Popular Exercises — Pre-load 6 common lifts with tags">
-            <span class="obOptionIcon">💪</span>
+          <button
+            class="obOption"
+            @click="chooseEmpty"
+            aria-label="Start Empty — Add your own exercises from scratch"
+          >
+            <span class="obOptionIcon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
+                <line x1="12" y1="5" x2="12" y2="19"/>
+                <line x1="5" y1="12" x2="19" y2="12"/>
+              </svg>
+            </span>
             <span class="obOptionText">
-              <strong>Popular Exercises</strong>
-              <span>Pre-load 6 common lifts with tags</span>
+              <strong>Start empty</strong>
+              <span>Add your own exercises from scratch.</span>
             </span>
           </button>
 
-          <button class="obOption" @click="chooseExplore" aria-label="Explore First — See the app with sample data, clear it when ready">
-            <span class="obOptionIcon">👀</span>
+          <button
+            class="obOption"
+            @click="chooseExplore"
+            aria-label="Explore First — See the app with sample data, clear it when you're ready"
+          >
+            <span class="obOptionIcon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="24" height="24">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                <circle cx="12" cy="12" r="3"/>
+              </svg>
+            </span>
             <span class="obOptionText">
-              <strong>Explore First</strong>
-              <span>See the app with sample data, clear it when ready</span>
+              <strong>Explore first</strong>
+              <span>See the app with sample data — clear it when you're ready.</span>
             </span>
           </button>
         </div>
@@ -448,27 +481,47 @@ function chooseExplore() {
   align-items: center;
   justify-content: center;
   min-height: 80svh;
-  padding: 24px;
+  padding: 24px 16px calc(24px + env(safe-area-inset-bottom, 0px));
+  background:
+    radial-gradient(ellipse 70% 55% at 15% 10%, var(--accent-subtle, rgba(212,175,55,0.08)) 0%, transparent 65%),
+    radial-gradient(ellipse 55% 45% at 85% 80%, var(--accent-subtle, rgba(212,175,55,0.06)) 0%, transparent 65%);
 }
 
 .obCard {
   width: 100%;
-  max-width: 380px;
+  max-width: 360px;
   text-align: center;
 }
 
+.obHero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 32px;
+}
+
 .obLogo {
-  font-size: 48px;
+  font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+  font-size: 72px;
   font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.035em;
   color: var(--accent);
-  letter-spacing: -1.5px;
-  margin-bottom: 8px;
+}
+
+.obSubtitle {
+  font-size: var(--font-callout, 14px);
+  font-weight: 500;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  margin: 0;
 }
 
 .obTagline {
-  font-size: var(--font-callout);
-  color: var(--text-secondary);
-  margin-bottom: 32px;
+  font-size: var(--font-callout, 14px);
+  color: var(--text-muted);
+  margin-bottom: 16px;
   line-height: 1.5;
 }
 
@@ -481,49 +534,71 @@ function chooseExplore() {
 .obOption {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   width: 100%;
   padding: 16px;
-  min-height: 44px;
-  background: var(--bg-secondary);
+  min-height: 72px;
+  background: var(--bg-elevated);
   border: 1px solid var(--border-strong);
-  border-radius: 14px;
+  border-radius: 16px;
   cursor: pointer;
   font-family: inherit;
   text-align: left;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.obOption:hover {
-  border-color: var(--accent);
-  background: var(--bg-hover);
+  color: var(--text-primary);
+  transition: border-color 0.15s, background 0.15s, transform 0.1s;
 }
 
 .obOption:active {
+  transform: scale(0.98);
   opacity: 0.85;
 }
 
+/* "Recommended" path — same card chrome with a gold glow + gold border. */
+.obOptionFeatured {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 1px var(--accent),
+    0 4px 24px var(--accent-subtle, rgba(212,175,55,0.18));
+}
+
+.obOptionFeatured .obOptionIcon {
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  box-shadow: 0 2px 12px var(--accent-subtle, rgba(212,175,55,0.35));
+}
+
 .obOptionIcon {
-  font-size: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   flex-shrink: 0;
+  background: var(--bg-secondary);
+  color: var(--accent);
+  border-radius: 12px;
+  border: 1px solid var(--border);
 }
 
 .obOptionText {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
 }
 
 .obOptionText strong {
-  font-size: var(--font-callout);
+  font-size: 16px;
   font-weight: 600;
   color: var(--text-primary);
+  line-height: 1.2;
 }
 
 .obOptionText span {
-  font-size: var(--font-footnote);
+  font-size: 13px;
   color: var(--text-secondary);
-  line-height: 1.3;
+  line-height: 1.4;
 }
 
 </style>

--- a/src/components/PRBurst.vue
+++ b/src/components/PRBurst.vue
@@ -1,0 +1,267 @@
+<!--
+  PR burst celebration — full-bleed takeover shown when the user logs a
+  genuine e1RM PR. Layout matches design_handoff_lift_ios_pwa/screens/08-pr-burst.png:
+
+  - Dim + radial-overlay backdrop (vignette + gold accent radial)
+  - SVG ring echoes that expand from r=0
+  - Eyebrow "🏆 PERSONAL RECORD"
+  - Large delta "+XX lbs" (84px / 800)
+  - Subtitle "oldE1RM → newE1RM lbs e1RM"
+  - Chip "Exercise · weight × reps"
+  - "Tap to dismiss" hint at the bottom
+
+  Tapping anywhere (or pressing Escape) dismisses.
+-->
+<template>
+  <Transition name="prBurst">
+    <div
+      v-if="visible && payload"
+      class="prBurst"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Personal record"
+      tabindex="-1"
+      @click="onDismiss"
+      @keydown.escape="onDismiss"
+    >
+      <!-- Dimmed + radial backdrop -->
+      <div class="prBurstBackdrop" aria-hidden="true"></div>
+
+      <!-- Ring echoes (pointer-events: none) -->
+      <svg class="prBurstRings" viewBox="0 0 360 360" aria-hidden="true">
+        <circle cx="180" cy="180" r="80" fill="none" stroke="currentColor" stroke-width="2" opacity="0.35" class="prRing prRing1" />
+        <circle cx="180" cy="180" r="130" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.2" class="prRing prRing2" />
+        <circle cx="180" cy="180" r="170" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12" class="prRing prRing3" />
+      </svg>
+
+      <div class="prBurstContent">
+        <div class="prBurstEyebrow">🏆 Personal Record</div>
+        <div class="prBurstDelta">+{{ deltaDisplay }} {{ unit }}</div>
+        <div class="prBurstSubtitle">
+          <span class="prBurstSubtitleOld">{{ oldDisplay }}</span>
+          <span class="prBurstSubtitleArrow"> → </span>
+          <span class="prBurstSubtitleNew">{{ newDisplay }}</span>
+          <span class="prBurstSubtitleUnit"> {{ unit }} e1RM</span>
+        </div>
+        <div class="prBurstChip">
+          {{ payload.exerciseName }} · {{ setDisplay }}
+        </div>
+      </div>
+
+      <div class="prBurstHint" aria-hidden="true">Tap to dismiss</div>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed, watch, nextTick, ref, onMounted } from 'vue'
+import { usePRBurst } from '../composables/usePRBurst'
+import { useTheme } from '../composables/useTheme'
+
+const { visible, payload, presentPRBurst, dismissPRBurst } = usePRBurst()
+const { weightUnit, displayWeight } = useTheme()
+
+// DEV-only: expose the trigger on window so we can visually verify the overlay
+// from Playwright/DevTools without needing a live PR. Stripped from prod builds
+// by Vite's dead-code elimination (import.meta.env.DEV is false in prod).
+onMounted(() => {
+  if (import.meta.env.DEV) {
+    ;(window as unknown as Record<string, unknown>).__presentPRBurst = presentPRBurst
+  }
+})
+
+const unit = computed(() => weightUnit.value)
+
+const deltaDisplay = computed(() => {
+  if (!payload.value) return '0'
+  const delta = payload.value.newE1RM - payload.value.oldE1RM
+  const shown = displayWeight(delta)
+  // Whole pounds / kg read better than 12.3 lbs for the big hero number.
+  return Number.isInteger(shown) ? String(shown) : shown.toFixed(1)
+})
+
+const oldDisplay = computed(() => {
+  if (!payload.value) return ''
+  return Math.round(displayWeight(payload.value.oldE1RM))
+})
+
+const newDisplay = computed(() => {
+  if (!payload.value) return ''
+  return Math.round(displayWeight(payload.value.newE1RM))
+})
+
+const setDisplay = computed(() => {
+  if (!payload.value) return ''
+  const w = displayWeight(payload.value.setWeight)
+  return `${Number.isInteger(w) ? w : w.toFixed(1)} × ${payload.value.setReps}`
+})
+
+function onDismiss() {
+  dismissPRBurst()
+}
+
+// Keyboard focus on present so the Escape-to-dismiss works without needing
+// a prior focus. The tabindex="-1" on the root makes this valid.
+const rootEl = ref<HTMLElement | null>(null)
+watch(visible, async (v) => {
+  if (v) {
+    await nextTick()
+    const root = document.querySelector('.prBurst') as HTMLElement | null
+    rootEl.value = root
+    root?.focus()
+  }
+})
+</script>
+
+<style scoped>
+.prBurst {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  /* Outline on focus is noisy for a celebration — keep it invisible but focusable. */
+  outline: none;
+  cursor: pointer;
+}
+
+.prBurstBackdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 90% 70% at 50% 48%, var(--accent-subtle, rgba(212, 175, 55, 0.12)) 0%, transparent 70%),
+    radial-gradient(ellipse 120% 120% at 50% 48%, transparent 35%, rgba(0, 0, 0, 0.85) 100%),
+    rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px) saturate(0.7) brightness(0.35);
+  -webkit-backdrop-filter: blur(8px) saturate(0.7) brightness(0.35);
+  pointer-events: none;
+}
+
+.prBurstRings {
+  position: absolute;
+  top: 48%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 360px;
+  height: 360px;
+  max-width: 90vw;
+  max-height: 90vw;
+  pointer-events: none;
+  color: var(--accent);
+}
+
+.prBurstContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 24px;
+  max-width: 360px;
+  /* Anchor content slightly above vertical center, matching the ring echoes. */
+  transform: translateY(-2vh);
+}
+
+.prBurstEyebrow {
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.prBurstDelta {
+  font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+  font-size: 84px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--accent);
+  text-shadow: 0 0 40px var(--accent-subtle, rgba(212, 175, 55, 0.30));
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 12px;
+}
+
+.prBurstSubtitle {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 24px;
+}
+
+.prBurstSubtitleNew {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.prBurstChip {
+  display: inline-block;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 99px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.prBurstHint {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(44px + env(safe-area-inset-bottom, 0px));
+  text-align: center;
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Ring echo entrance: scale from 0 to 1 with stagger. */
+.prRing {
+  transform-origin: 180px 180px;
+  animation: prRingIn 480ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.prRing1 { animation-delay: 0ms; }
+.prRing2 { animation-delay: 80ms; }
+.prRing3 { animation-delay: 160ms; }
+
+@keyframes prRingIn {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); }
+}
+
+/* Overall fade in/out (vue <Transition>). */
+.prBurst-enter-active { transition: opacity 180ms ease-out; }
+.prBurst-leave-active { transition: opacity 180ms ease-in; }
+.prBurst-enter-from,
+.prBurst-leave-to { opacity: 0; }
+
+/* Delta number: slight "pop" on entrance. */
+.prBurstDelta {
+  animation: prDeltaPop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: 120ms;
+}
+@keyframes prDeltaPop {
+  from { transform: scale(0.6); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prRing,
+  .prBurstDelta {
+    animation: none !important;
+  }
+  .prBurst-enter-active,
+  .prBurst-leave-active { transition: none; }
+}
+</style>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -954,6 +954,7 @@ import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
 import { usePRBaseline } from '../composables/usePRBaseline'
+import { usePRBurst } from '../composables/usePRBurst'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
@@ -968,6 +969,7 @@ const { show: showUndo } = useUndoToast()
 const { currentTheme, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, setRestTimerEnabled } = useTheme()
 const { impactLight, notifySuccess } = useHaptics()
 const { prBaselineDate } = usePRBaseline()
+const { presentPRBurst } = usePRBurst()
 
 // Filter sets to those on/after the user-set PR baseline.
 // When no baseline is set, returns sets unchanged (legacy all-time behavior).
@@ -2668,6 +2670,8 @@ function saveSet() {
     }
     if (hasSetData.value && weight.value !== null && reps.value !== null) {
       const wasPR = isNewPR.value
+      // Capture the pre-log baseline PR so the burst can show old → new e1RM.
+      const oldE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
       store.logSet(exerciseId, toLbs(weight.value), reps.value, date.value)
       logEvent('set_log', { exercise: selectedExerciseName.value, isPR: wasPR })
       // XP: get the just-logged set (last in array) and compute XP
@@ -2679,6 +2683,16 @@ function saveSet() {
       // Haptic feedback — stronger for PRs
       if (wasPR) {
         notifySuccess()
+        // Full-bleed PR celebration (respects the PR baseline via oldE1RM,
+        // and the prCelebrations opt-out inside presentPRBurst).
+        const newE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
+        presentPRBurst({
+          exerciseName: selectedExerciseName.value,
+          oldE1RM,
+          newE1RM,
+          setWeight: toLbs(weight.value),
+          setReps: reps.value,
+        })
       } else {
         impactLight()
       }

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -61,30 +61,39 @@ describe('OnboardingScreen', () => {
       expect(options.length).toBe(3)
     })
 
-    it('shows Start Empty option', () => {
-      expect(wrapper.text()).toContain('Start Empty')
+    it('shows Start empty option', () => {
+      expect(wrapper.text()).toContain('Start empty')
       expect(wrapper.text()).toContain('Add your own exercises from scratch')
     })
 
-    it('shows Popular Exercises option', () => {
-      expect(wrapper.text()).toContain('Popular Exercises')
+    it('shows Popular exercises option', () => {
+      expect(wrapper.text()).toContain('Popular exercises')
       expect(wrapper.text()).toContain('Pre-load 6 common lifts')
     })
 
-    it('shows Explore First option', () => {
-      expect(wrapper.text()).toContain('Explore First')
+    it('shows Explore first option', () => {
+      expect(wrapper.text()).toContain('Explore first')
       expect(wrapper.text()).toContain('sample data')
+    })
+
+    it('features Popular exercises as the recommended option (gold glow)', () => {
+      // Popular exercises is now the first / featured option in the restyled
+      // onboarding per design_handoff_lift_ios_pwa/screens/01-auth.png.
+      const featured = wrapper.find('.obOptionFeatured')
+      expect(featured.exists()).toBe(true)
+      expect(featured.text()).toContain('Popular exercises')
     })
   })
 
-  describe('Start Empty', () => {
+  describe('Start empty', () => {
     async function chooseEmptyAndSkip() {
-      await wrapper.findAll('.obOption')[0].trigger('click')
+      // Order after 01-auth.png restyle: [0] Popular, [1] Empty, [2] Explore.
+      await wrapper.findAll('.obOption')[1].trigger('click')
       await wrapper.find('.spfSecondary').trigger('click')
     }
 
     it('advances to progression explainer step', async () => {
-      await wrapper.findAll('.obOption')[0].trigger('click')
+      await wrapper.findAll('.obOption')[1].trigger('click')
       expect(wrapper.text()).toContain('Theme Progression')
       expect(wrapper.find('.spfExplainer').exists()).toBe(true)
     })
@@ -113,9 +122,10 @@ describe('OnboardingScreen', () => {
     })
   })
 
-  describe('Popular Exercises', () => {
+  describe('Popular exercises', () => {
     it('adds 6 starter exercises with tags', async () => {
-      await wrapper.findAll('.obOption')[1].trigger('click')
+      // Popular is the featured / first option after the 01-auth.png restyle.
+      await wrapper.findAll('.obOption')[0].trigger('click')
       expect(mockAddExercise).toHaveBeenCalledTimes(6)
       expect(mockAddExercise).toHaveBeenCalledWith('Bench Press', ['Push', 'Chest'])
       expect(mockAddExercise).toHaveBeenCalledWith('Squat', ['Legs'])
@@ -126,18 +136,18 @@ describe('OnboardingScreen', () => {
     })
 
     it('emits complete event after skipping starter', async () => {
-      await wrapper.findAll('.obOption')[1].trigger('click')
+      await wrapper.findAll('.obOption')[0].trigger('click')
       await wrapper.find('.spfSecondary').trigger('click')
       expect(wrapper.emitted('complete')).toHaveLength(1)
     })
 
     it('does not log any sets', async () => {
-      await wrapper.findAll('.obOption')[1].trigger('click')
+      await wrapper.findAll('.obOption')[0].trigger('click')
       expect(mockLogSet).not.toHaveBeenCalled()
     })
   })
 
-  describe('Explore First (sample data)', () => {
+  describe('Explore first (sample data)', () => {
     it('adds exercises with sample sets', async () => {
       await wrapper.findAll('.obOption')[2].trigger('click')
       expect(mockAddExercise).toHaveBeenCalled()
@@ -176,7 +186,7 @@ describe('OnboardingScreen', () => {
       // Simulate existing exercises by having addExercise return the same id
       // (the real store returns existing id for duplicates)
       mockAddExercise.mockReturnValue('existing-id')
-      await wrapper.findAll('.obOption')[1].trigger('click')
+      await wrapper.findAll('.obOption')[0].trigger('click')
       // Should still call addExercise 6 times — dedup is the store's job
       expect(mockAddExercise).toHaveBeenCalledTimes(6)
       // No sets should be logged for starter path
@@ -211,8 +221,9 @@ describe('OnboardingScreen', () => {
     })
 
     it('sets onboarding-complete even if no exercises are added', async () => {
-      // Start Empty path → skip starter
-      await wrapper.findAll('.obOption')[0].trigger('click')
+      // Start empty path → skip starter. After 01-auth.png restyle, the "Start empty"
+      // option is the second one (index 1) — Popular exercises is featured/first.
+      await wrapper.findAll('.obOption')[1].trigger('click')
       await wrapper.find('.spfSecondary').trigger('click')
       expect(localStorageMock.setItem).toHaveBeenCalledWith('onboarding-complete', 'true')
       expect(mockAddExercise).not.toHaveBeenCalled()

--- a/src/components/__tests__/accessibility.test.ts
+++ b/src/components/__tests__/accessibility.test.ts
@@ -222,10 +222,11 @@ describe('Accessibility', () => {
     it('option buttons have aria-label attributes', () => {
       const wrapper = mount(OnboardingScreen)
 
+      // Order after 01-auth.png restyle: [0] Popular (featured), [1] Empty, [2] Explore.
       const buttons = wrapper.findAll('.obOption')
       expect(buttons.length).toBe(3)
-      expect(buttons[0].attributes('aria-label')).toContain('Start Empty')
-      expect(buttons[1].attributes('aria-label')).toContain('Popular Exercises')
+      expect(buttons[0].attributes('aria-label')).toContain('Popular Exercises')
+      expect(buttons[1].attributes('aria-label')).toContain('Start Empty')
       expect(buttons[2].attributes('aria-label')).toContain('Explore First')
     })
 
@@ -233,8 +234,8 @@ describe('Accessibility', () => {
       const wrapper = mount(OnboardingScreen)
 
       const buttons = wrapper.findAll('.obOption')
-      expect(buttons[0].attributes('aria-label')).toContain('Add your own exercises from scratch')
-      expect(buttons[1].attributes('aria-label')).toContain('Pre-load 6 common lifts with tags')
+      expect(buttons[0].attributes('aria-label')).toContain('Pre-load 6 common lifts with tags')
+      expect(buttons[1].attributes('aria-label')).toContain('Add your own exercises from scratch')
       expect(buttons[2].attributes('aria-label')).toContain('See the app with sample data')
     })
   })

--- a/src/composables/__tests__/usePRBurst.test.ts
+++ b/src/composables/__tests__/usePRBurst.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock useHaptics before we import the module under test so its inline
+// haptics.notifySuccess() call on present is observable.
+const notifySuccessMock = vi.fn()
+vi.mock('../useHaptics', () => ({
+  useHaptics: () => ({
+    impactLight: vi.fn(),
+    impactMedium: vi.fn(),
+    impactHeavy: vi.fn(),
+    notifySuccess: notifySuccessMock,
+    notifyWarning: vi.fn(),
+    notifyError: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn() },
+}))
+
+import { usePRBurst } from '../usePRBurst'
+import { usePreferencesStore } from '../../stores/preferences'
+
+describe('usePRBurst', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    notifySuccessMock.mockClear()
+    const { dismissPRBurst } = usePRBurst()
+    dismissPRBurst()
+  })
+
+  it('presents when new e1RM beats old and celebrations are enabled', () => {
+    const { presentPRBurst, visible, payload } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 594,
+      newE1RM: 606,
+      setWeight: 505,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(true)
+    expect(payload.value?.exerciseName).toBe('Hack Squat')
+    expect(payload.value?.oldE1RM).toBe(594)
+    expect(payload.value?.newE1RM).toBe(606)
+    expect(notifySuccessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips when the user disables PR celebrations', () => {
+    const prefs = usePreferencesStore()
+    prefs.setExperienceFlag('prCelebrations', false)
+
+    const { presentPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 500,
+      newE1RM: 600,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+    expect(notifySuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('guards against malformed payloads where new <= old', () => {
+    const { presentPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 600,
+      newE1RM: 600,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 600,
+      newE1RM: 550,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+  })
+
+  it('dismissPRBurst hides the overlay', () => {
+    const { presentPRBurst, dismissPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 594,
+      newE1RM: 606,
+      setWeight: 505,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(true)
+    dismissPRBurst()
+    expect(visible.value).toBe(false)
+  })
+})

--- a/src/composables/usePRBurst.ts
+++ b/src/composables/usePRBurst.ts
@@ -1,0 +1,81 @@
+/**
+ * PR burst composable — singleton reactive state for the full-bleed PR
+ * celebration overlay described in `design_handoff_lift_ios_pwa/screens/08-pr-burst.png`.
+ *
+ * Usage:
+ *   // From a log-set handler, after the set has been persisted:
+ *   const { presentPRBurst } = usePRBurst()
+ *   presentPRBurst({ exerciseName, oldE1RM, newE1RM, setWeight, setReps })
+ *
+ * Respects the user's `experience.prCelebrations` preference (no-ops when
+ * the toggle is off, even if presentPRBurst is called). Also fires a
+ * success haptic via useHaptics, which itself honors the haptics toggle.
+ *
+ * PR baseline: callers are expected to compare new vs. previous e1RM using
+ * `workoutStore.getExercisePR(id, prBaselineDate)` so the burst respects
+ * the user's selected baseline. This composable does not itself perform
+ * the comparison — it only decides whether to render once the caller has
+ * determined a true PR occurred.
+ */
+
+import { ref, type Ref } from 'vue'
+import { usePreferencesStore } from '../stores/preferences'
+import { useHaptics } from './useHaptics'
+
+export interface PRBurstPayload {
+  exerciseName: string
+  /** Previous best e1RM for this exercise, relative to the PR baseline. */
+  oldE1RM: number
+  /** New best e1RM after the current set. */
+  newE1RM: number
+  /** Weight (in lbs) of the set that triggered the PR. */
+  setWeight: number
+  /** Reps of the set that triggered the PR. */
+  setReps: number
+}
+
+const visible: Ref<boolean> = ref(false)
+const payload: Ref<PRBurstPayload | null> = ref(null)
+
+function presentPRBurst(p: PRBurstPayload): void {
+  // Skip if the user opted out of PR celebrations (Settings → Experience).
+  try {
+    const prefs = usePreferencesStore()
+    if (prefs.experience?.prCelebrations === false) return
+  } catch {
+    // Pinia unavailable (e.g. in certain test setups) — proceed.
+  }
+
+  // Guard against malformed payloads — a "PR" where new <= old is a bug.
+  if (p.newE1RM <= p.oldE1RM) return
+
+  payload.value = p
+  visible.value = true
+
+  // Success haptic on present. useHaptics short-circuits if the user
+  // disabled haptics.
+  try {
+    const haptics = useHaptics()
+    haptics.notifySuccess()
+  } catch {
+    /* silent — haptics are best-effort */
+  }
+}
+
+function dismissPRBurst(): void {
+  visible.value = false
+  // Clear payload slightly after the fade-out so the component can animate
+  // with the final values; a CSS transition handles opacity.
+  setTimeout(() => {
+    if (!visible.value) payload.value = null
+  }, 200)
+}
+
+export function usePRBurst() {
+  return {
+    visible,
+    payload,
+    presentPRBurst,
+    dismissPRBurst,
+  }
+}


### PR DESCRIPTION
Closes #368. Stacks on #367 (PR burst), #365 (chrome), #363 (settings), #361 (splash). Merge in order.

## Summary

Restyle \`OnboardingScreen.vue\` to match \`screens/01-auth.png\`:

- 72px gold **Lift** wordmark + **"Strength tracking, quietly."** subtitle
- Mesh gradient backdrop (matches splash + Workouts)
- Three starter options as 16-radius cards with 40pt icon tiles
- **Popular exercises** is first and styled as the **featured/recommended** option (gold border + gold glow + gold-filled icon tile)
- Line SVG icons replace emoji (dumbbell / + / eye)
- Casing adjusted to match PNG ("Popular exercises", "Start empty", "Explore first")

## Conflict surfaced (not resolved)

The PNG includes a "Have an account? Sign in →" link at the bottom, implying a **pre-auth** landing screen. The existing app shows onboarding **post-auth**, so a sign-in link here doesn't fit the current routing. Implementing a pre-auth landing flow is a product-level change — left for Aaron's direction.

## Screenshots

OnboardingScreen on Luck (dark) — starter option cards match PNG layout with Popular exercises as featured.

## Test plan

- [x] 1263 tests pass (updated order + casing in \`OnboardingScreen.test.ts\` and \`accessibility.test.ts\`, added \`.obOptionFeatured\` regression test)
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean