### PR TITLE
feat: PR burst celebration overlay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -782,6 +782,11 @@
       </div>
     </transition>
   </Teleport>
+
+  <!-- Full-screen PR celebration — triggered via usePRBurst().presentPRBurst(). -->
+  <Teleport to="body">
+    <PRBurst />
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -791,6 +796,7 @@ import ErrorBoundary from './components/ErrorBoundary.vue'
 import AuthScreen from './components/AuthScreen.vue'
 import OnboardingScreen from './components/OnboardingScreen.vue'
 import StarterPickerFlow from './components/StarterPickerFlow.vue'
+import PRBurst from './components/PRBurst.vue'
 
 // Lazy-load tab content — split into separate chunks for faster initial load
 import SkeletonLoader from './components/SkeletonLoader.vue'

--- a/src/components/PRBurst.vue
+++ b/src/components/PRBurst.vue
@@ -1,0 +1,267 @@
+<!--
+  PR burst celebration — full-bleed takeover shown when the user logs a
+  genuine e1RM PR. Layout matches design_handoff_lift_ios_pwa/screens/08-pr-burst.png:
+
+  - Dim + radial-overlay backdrop (vignette + gold accent radial)
+  - SVG ring echoes that expand from r=0
+  - Eyebrow "🏆 PERSONAL RECORD"
+  - Large delta "+XX lbs" (84px / 800)
+  - Subtitle "oldE1RM → newE1RM lbs e1RM"
+  - Chip "Exercise · weight × reps"
+  - "Tap to dismiss" hint at the bottom
+
+  Tapping anywhere (or pressing Escape) dismisses.
+-->
+<template>
+  <Transition name="prBurst">
+    <div
+      v-if="visible && payload"
+      class="prBurst"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Personal record"
+      tabindex="-1"
+      @click="onDismiss"
+      @keydown.escape="onDismiss"
+    >
+      <!-- Dimmed + radial backdrop -->
+      <div class="prBurstBackdrop" aria-hidden="true"></div>
+
+      <!-- Ring echoes (pointer-events: none) -->
+      <svg class="prBurstRings" viewBox="0 0 360 360" aria-hidden="true">
+        <circle cx="180" cy="180" r="80" fill="none" stroke="currentColor" stroke-width="2" opacity="0.35" class="prRing prRing1" />
+        <circle cx="180" cy="180" r="130" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.2" class="prRing prRing2" />
+        <circle cx="180" cy="180" r="170" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12" class="prRing prRing3" />
+      </svg>
+
+      <div class="prBurstContent">
+        <div class="prBurstEyebrow">🏆 Personal Record</div>
+        <div class="prBurstDelta">+{{ deltaDisplay }} {{ unit }}</div>
+        <div class="prBurstSubtitle">
+          <span class="prBurstSubtitleOld">{{ oldDisplay }}</span>
+          <span class="prBurstSubtitleArrow"> → </span>
+          <span class="prBurstSubtitleNew">{{ newDisplay }}</span>
+          <span class="prBurstSubtitleUnit"> {{ unit }} e1RM</span>
+        </div>
+        <div class="prBurstChip">
+          {{ payload.exerciseName }} · {{ setDisplay }}
+        </div>
+      </div>
+
+      <div class="prBurstHint" aria-hidden="true">Tap to dismiss</div>
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed, watch, nextTick, ref, onMounted } from 'vue'
+import { usePRBurst } from '../composables/usePRBurst'
+import { useTheme } from '../composables/useTheme'
+
+const { visible, payload, presentPRBurst, dismissPRBurst } = usePRBurst()
+const { weightUnit, displayWeight } = useTheme()
+
+// DEV-only: expose the trigger on window so we can visually verify the overlay
+// from Playwright/DevTools without needing a live PR. Stripped from prod builds
+// by Vite's dead-code elimination (import.meta.env.DEV is false in prod).
+onMounted(() => {
+  if (import.meta.env.DEV) {
+    ;(window as unknown as Record<string, unknown>).__presentPRBurst = presentPRBurst
+  }
+})
+
+const unit = computed(() => weightUnit.value)
+
+const deltaDisplay = computed(() => {
+  if (!payload.value) return '0'
+  const delta = payload.value.newE1RM - payload.value.oldE1RM
+  const shown = displayWeight(delta)
+  // Whole pounds / kg read better than 12.3 lbs for the big hero number.
+  return Number.isInteger(shown) ? String(shown) : shown.toFixed(1)
+})
+
+const oldDisplay = computed(() => {
+  if (!payload.value) return ''
+  return Math.round(displayWeight(payload.value.oldE1RM))
+})
+
+const newDisplay = computed(() => {
+  if (!payload.value) return ''
+  return Math.round(displayWeight(payload.value.newE1RM))
+})
+
+const setDisplay = computed(() => {
+  if (!payload.value) return ''
+  const w = displayWeight(payload.value.setWeight)
+  return `${Number.isInteger(w) ? w : w.toFixed(1)} × ${payload.value.setReps}`
+})
+
+function onDismiss() {
+  dismissPRBurst()
+}
+
+// Keyboard focus on present so the Escape-to-dismiss works without needing
+// a prior focus. The tabindex="-1" on the root makes this valid.
+const rootEl = ref<HTMLElement | null>(null)
+watch(visible, async (v) => {
+  if (v) {
+    await nextTick()
+    const root = document.querySelector('.prBurst') as HTMLElement | null
+    rootEl.value = root
+    root?.focus()
+  }
+})
+</script>
+
+<style scoped>
+.prBurst {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  /* Outline on focus is noisy for a celebration — keep it invisible but focusable. */
+  outline: none;
+  cursor: pointer;
+}
+
+.prBurstBackdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 90% 70% at 50% 48%, var(--accent-subtle, rgba(212, 175, 55, 0.12)) 0%, transparent 70%),
+    radial-gradient(ellipse 120% 120% at 50% 48%, transparent 35%, rgba(0, 0, 0, 0.85) 100%),
+    rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px) saturate(0.7) brightness(0.35);
+  -webkit-backdrop-filter: blur(8px) saturate(0.7) brightness(0.35);
+  pointer-events: none;
+}
+
+.prBurstRings {
+  position: absolute;
+  top: 48%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 360px;
+  height: 360px;
+  max-width: 90vw;
+  max-height: 90vw;
+  pointer-events: none;
+  color: var(--accent);
+}
+
+.prBurstContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0 24px;
+  max-width: 360px;
+  /* Anchor content slightly above vertical center, matching the ring echoes. */
+  transform: translateY(-2vh);
+}
+
+.prBurstEyebrow {
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 16px;
+}
+
+.prBurstDelta {
+  font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+  font-size: 84px;
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: -0.04em;
+  color: var(--accent);
+  text-shadow: 0 0 40px var(--accent-subtle, rgba(212, 175, 55, 0.30));
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 12px;
+}
+
+.prBurstSubtitle {
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  margin-bottom: 24px;
+}
+
+.prBurstSubtitleNew {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.prBurstChip {
+  display: inline-block;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 99px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.prBurstHint {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(44px + env(safe-area-inset-bottom, 0px));
+  text-align: center;
+  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Ring echo entrance: scale from 0 to 1 with stagger. */
+.prRing {
+  transform-origin: 180px 180px;
+  animation: prRingIn 480ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.prRing1 { animation-delay: 0ms; }
+.prRing2 { animation-delay: 80ms; }
+.prRing3 { animation-delay: 160ms; }
+
+@keyframes prRingIn {
+  from { transform: scale(0); opacity: 0; }
+  to   { transform: scale(1); }
+}
+
+/* Overall fade in/out (vue <Transition>). */
+.prBurst-enter-active { transition: opacity 180ms ease-out; }
+.prBurst-leave-active { transition: opacity 180ms ease-in; }
+.prBurst-enter-from,
+.prBurst-leave-to { opacity: 0; }
+
+/* Delta number: slight "pop" on entrance. */
+.prBurstDelta {
+  animation: prDeltaPop 420ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  animation-delay: 120ms;
+}
+@keyframes prDeltaPop {
+  from { transform: scale(0.6); opacity: 0; }
+  to   { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prRing,
+  .prBurstDelta {
+    animation: none !important;
+  }
+  .prBurst-enter-active,
+  .prBurst-leave-active { transition: none; }
+}
+</style>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -954,6 +954,7 @@ import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
 import { usePRBaseline } from '../composables/usePRBaseline'
+import { usePRBurst } from '../composables/usePRBurst'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
@@ -968,6 +969,7 @@ const { show: showUndo } = useUndoToast()
 const { currentTheme, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, setRestTimerEnabled } = useTheme()
 const { impactLight, notifySuccess } = useHaptics()
 const { prBaselineDate } = usePRBaseline()
+const { presentPRBurst } = usePRBurst()
 
 // Filter sets to those on/after the user-set PR baseline.
 // When no baseline is set, returns sets unchanged (legacy all-time behavior).
@@ -2668,6 +2670,8 @@ function saveSet() {
     }
     if (hasSetData.value && weight.value !== null && reps.value !== null) {
       const wasPR = isNewPR.value
+      // Capture the pre-log baseline PR so the burst can show old → new e1RM.
+      const oldE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
       store.logSet(exerciseId, toLbs(weight.value), reps.value, date.value)
       logEvent('set_log', { exercise: selectedExerciseName.value, isPR: wasPR })
       // XP: get the just-logged set (last in array) and compute XP
@@ -2679,6 +2683,16 @@ function saveSet() {
       // Haptic feedback — stronger for PRs
       if (wasPR) {
         notifySuccess()
+        // Full-bleed PR celebration (respects the PR baseline via oldE1RM,
+        // and the prCelebrations opt-out inside presentPRBurst).
+        const newE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
+        presentPRBurst({
+          exerciseName: selectedExerciseName.value,
+          oldE1RM,
+          newE1RM,
+          setWeight: toLbs(weight.value),
+          setReps: reps.value,
+        })
       } else {
         impactLight()
       }

--- a/src/composables/__tests__/usePRBurst.test.ts
+++ b/src/composables/__tests__/usePRBurst.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock useHaptics before we import the module under test so its inline
+// haptics.notifySuccess() call on present is observable.
+const notifySuccessMock = vi.fn()
+vi.mock('../useHaptics', () => ({
+  useHaptics: () => ({
+    impactLight: vi.fn(),
+    impactMedium: vi.fn(),
+    impactHeavy: vi.fn(),
+    notifySuccess: notifySuccessMock,
+    notifyWarning: vi.fn(),
+    notifyError: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn() },
+}))
+
+import { usePRBurst } from '../usePRBurst'
+import { usePreferencesStore } from '../../stores/preferences'
+
+describe('usePRBurst', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    notifySuccessMock.mockClear()
+    const { dismissPRBurst } = usePRBurst()
+    dismissPRBurst()
+  })
+
+  it('presents when new e1RM beats old and celebrations are enabled', () => {
+    const { presentPRBurst, visible, payload } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 594,
+      newE1RM: 606,
+      setWeight: 505,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(true)
+    expect(payload.value?.exerciseName).toBe('Hack Squat')
+    expect(payload.value?.oldE1RM).toBe(594)
+    expect(payload.value?.newE1RM).toBe(606)
+    expect(notifySuccessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips when the user disables PR celebrations', () => {
+    const prefs = usePreferencesStore()
+    prefs.setExperienceFlag('prCelebrations', false)
+
+    const { presentPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 500,
+      newE1RM: 600,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+    expect(notifySuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('guards against malformed payloads where new <= old', () => {
+    const { presentPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 600,
+      newE1RM: 600,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 600,
+      newE1RM: 550,
+      setWeight: 500,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(false)
+  })
+
+  it('dismissPRBurst hides the overlay', () => {
+    const { presentPRBurst, dismissPRBurst, visible } = usePRBurst()
+    presentPRBurst({
+      exerciseName: 'Hack Squat',
+      oldE1RM: 594,
+      newE1RM: 606,
+      setWeight: 505,
+      setReps: 6,
+    })
+    expect(visible.value).toBe(true)
+    dismissPRBurst()
+    expect(visible.value).toBe(false)
+  })
+})

--- a/src/composables/usePRBurst.ts
+++ b/src/composables/usePRBurst.ts
@@ -1,0 +1,81 @@
+/**
+ * PR burst composable — singleton reactive state for the full-bleed PR
+ * celebration overlay described in `design_handoff_lift_ios_pwa/screens/08-pr-burst.png`.
+ *
+ * Usage:
+ *   // From a log-set handler, after the set has been persisted:
+ *   const { presentPRBurst } = usePRBurst()
+ *   presentPRBurst({ exerciseName, oldE1RM, newE1RM, setWeight, setReps })
+ *
+ * Respects the user's `experience.prCelebrations` preference (no-ops when
+ * the toggle is off, even if presentPRBurst is called). Also fires a
+ * success haptic via useHaptics, which itself honors the haptics toggle.
+ *
+ * PR baseline: callers are expected to compare new vs. previous e1RM using
+ * `workoutStore.getExercisePR(id, prBaselineDate)` so the burst respects
+ * the user's selected baseline. This composable does not itself perform
+ * the comparison — it only decides whether to render once the caller has
+ * determined a true PR occurred.
+ */
+
+import { ref, type Ref } from 'vue'
+import { usePreferencesStore } from '../stores/preferences'
+import { useHaptics } from './useHaptics'
+
+export interface PRBurstPayload {
+  exerciseName: string
+  /** Previous best e1RM for this exercise, relative to the PR baseline. */
+  oldE1RM: number
+  /** New best e1RM after the current set. */
+  newE1RM: number
+  /** Weight (in lbs) of the set that triggered the PR. */
+  setWeight: number
+  /** Reps of the set that triggered the PR. */
+  setReps: number
+}
+
+const visible: Ref<boolean> = ref(false)
+const payload: Ref<PRBurstPayload | null> = ref(null)
+
+function presentPRBurst(p: PRBurstPayload): void {
+  // Skip if the user opted out of PR celebrations (Settings → Experience).
+  try {
+    const prefs = usePreferencesStore()
+    if (prefs.experience?.prCelebrations === false) return
+  } catch {
+    // Pinia unavailable (e.g. in certain test setups) — proceed.
+  }
+
+  // Guard against malformed payloads — a "PR" where new <= old is a bug.
+  if (p.newE1RM <= p.oldE1RM) return
+
+  payload.value = p
+  visible.value = true
+
+  // Success haptic on present. useHaptics short-circuits if the user
+  // disabled haptics.
+  try {
+    const haptics = useHaptics()
+    haptics.notifySuccess()
+  } catch {
+    /* silent — haptics are best-effort */
+  }
+}
+
+function dismissPRBurst(): void {
+  visible.value = false
+  // Clear payload slightly after the fade-out so the component can animate
+  // with the final values; a CSS transition handles opacity.
+  setTimeout(() => {
+    if (!visible.value) payload.value = null
+  }, 200)
+}
+
+export function usePRBurst() {
+  return {
+    visible,
+    payload,
+    presentPRBurst,
+    dismissPRBurst,
+  }
+}


### PR DESCRIPTION
Supersedes #367 (auto-closed when #365 merged and its base branch was deleted). Same content, now targeting master directly.

Closes #366.

## Summary

Full-bleed celebration when the user logs a genuine e1RM PR, matching \`design_handoff_lift_ios_pwa/screens/08-pr-burst.png\`:

- Dim + radial backdrop (accent-subtle radial + vignette + backdrop-blur)
- 3 SVG ring echoes (r=80, 130, 170) that scale in with 80ms stagger
- 🏆 PERSONAL RECORD eyebrow, +XX lbs delta at 84px/800, old → new e1RM subtitle, exercise chip, "Tap to dismiss"
- 180ms fade in/out; respects \`prefers-reduced-motion\`

## Trigger rules

- Fires from \`WorkoutTracker.saveSet\` when \`isNewPR.value\` is true (forward-logged sets only — not edits or calendar backfill)
- **Respects PR baseline** — uses \`getExercisePR(id, prBaselineDate)\` for both old and new e1RM
- **Respects \`prefs.experience.prCelebrations\`** — short-circuits if the toggle from the previous PR is off
- **Respects haptics toggle** via \`useHaptics.notifySuccess()\`

## Architecture

- \`usePRBurst.ts\` — singleton composable \`{ visible, payload, presentPRBurst, dismissPRBurst }\`
- \`PRBurst.vue\` — Teleport-to-body overlay
- \`window.__presentPRBurst\` exposed in dev only (DCE'd in prod via \`import.meta.env.DEV\`) for QA

## Test plan

- [x] \`npm test\` — 1261 pass (4 new)
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build\` — clean
- [x] Manual: burst presents on PR, respects toggle, dismisses on tap + Escape