### PR TITLE
feat: log-set modal → 78% bottom sheet shell

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -275,8 +275,9 @@
 
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
-    <div v-if="showModal" class="repMaxOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
-      <div class="repMaxModal" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
+    <div v-if="showModal" class="repMaxOverlay logSetOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
+      <div class="repMaxModal logSetSheet" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
+        <div class="logSetSheetHandle" aria-hidden="true"></div>
 
         <!-- Rest timer view -->
         <template v-if="timerActive">

--- a/src/index.css
+++ b/src/index.css
@@ -3254,6 +3254,50 @@ html.theme-fading .settingsSheet {
   animation: modalScaleIn 0.25s cubic-bezier(0.2, 0, 0, 1);
 }
 
+/* ─── Log-set bottom sheet (05-logset-platecalc.png) ─────────────────── */
+/*
+  The set-log overlay + modal opt into a 78%-viewport bottom sheet with a
+  drag handle at top. Scoped to just .logSetOverlay / .logSetSheet so the
+  detail, tag-manager, exercise-picker, and edit-exercise dialogs keep
+  the existing top-anchored centered modal layout.
+*/
+.repMaxOverlay.logSetOverlay {
+  align-items: flex-end;
+  padding: 0;
+  padding-top: 0;
+  animation: overlayFadeIn 0.2s ease-out;
+}
+
+.repMaxModal.logSetSheet {
+  max-width: 100%;
+  width: 100%;
+  height: 78dvh;
+  max-height: 78dvh;
+  padding: 16px 20px calc(24px + env(safe-area-inset-bottom, 0px));
+  border-radius: 24px 24px 0 0;
+  border-bottom: none;
+  animation: sheetSlideUp 0.28s cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* Drag handle pill at the top of the sheet. */
+.logSetSheetHandle {
+  width: 36px;
+  height: 4px;
+  margin: 0 auto 12px;
+  border-radius: 99px;
+  background: var(--border-strong);
+  flex-shrink: 0;
+}
+
+@keyframes sheetSlideUp {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .repMaxModal.logSetSheet { animation: none; }
+}
+
 .repMaxModal h2 {
   font-size: var(--font-body);
   font-weight: 700;


### PR DESCRIPTION
Closes #371. First of several PRs that bring the set-log modal to the 78%-viewport bottom sheet layout in \`design_handoff_lift_ios_pwa/screens/05-logset-platecalc.png\`.

## This PR — the shell

- Bottom-aligned, full-width, only top corners rounded (24)
- Drag handle pill (36×4, \`--border-strong\`) at the top
- 78dvh max height
- Slide-up entrance (0.28s cubic-bezier) with \`prefers-reduced-motion\` guard

Scoped via \`.logSetOverlay\` / \`.logSetSheet\` modifier classes so the detail dialog, tag manager, exercise picker, and edit-exercise modal keep their existing top-anchored centered layout. No existing functionality changed — this is purely a shell swap.

## Follow-ups (separate PRs)

1. Side-by-side WEIGHT + REPS cards, 72px weight number
2. Plate calculator restyle (per-side gold +N chips, count row, delta-vs-last)
3. Collapsible "PR Targets" (matches 07-pr-targets-expanded.png)
4. Custom in-sheet numpad replacing iOS keyboard
5. Swipe-down-on-handle to dismiss

## Test plan

- [x] \`npm test\` — 1262 pass
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] Manual (iOS sim): log-set modal opens as bottom sheet with drag handle + blurred Workouts backdrop; other modals unchanged