### PR TITLE
fix: remove inaccurate plate delta label from card header

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -685,7 +685,6 @@
           <div v-if="plateMode && !isEditMode" class="wtPlateCalc wtPlateCard">
             <div class="wtPlateCardHeader">
               <span class="wtPlateCardHeaderLabel">{{ isPerSide ? `PER SIDE · ${currentBarWeight} ${weightUnit} BAR` : `TOTAL · ${currentBarWeight} ${weightUnit} BAR` }}</span>
-              <span v-if="plateDeltaLabel" class="wtPlateCardHeaderDelta">{{ plateDeltaLabel }}</span>
             </div>
             <div class="wtPlateGrid">
               <div v-for="denom in activeDenominations" :key="denom" class="wtPlateCol">
@@ -1730,37 +1729,6 @@ const plateCounts = computed(() => {
   const counts = new Map<number, number>()
   for (const p of currentPlates.value) counts.set(p, (counts.get(p) || 0) + 1)
   return counts
-})
-
-/**
- * "+1×5 vs last" / "−2×25 vs last" — the most significant change in plates
- * compared to the previous set. Shown in the plate calc card header per
- * screens/05-logset-platecalc.png. Returns null when no previous set exists
- * or plates are unchanged.
- *
- * Heuristic: pick the denomination with the largest |Δ × denom| weight
- * impact. Ties go to the larger denomination since that's typically the
- * meaningful change (e.g. swapping a 25 for a 10+10+5 is "+1×10").
- */
-const plateDeltaLabel = computed<string | null>(() => {
-  if (!plateMode.value) return null
-  if (previousPlates.value.length === 0 && currentPlates.value.length === 0) return null
-  const prevCounts = new Map<number, number>()
-  for (const p of previousPlates.value) prevCounts.set(p, (prevCounts.get(p) || 0) + 1)
-  const curCounts = plateCounts.value
-  const allDenoms = new Set<number>([...prevCounts.keys(), ...curCounts.keys()])
-  let best: { denom: number; delta: number } | null = null
-  for (const denom of allDenoms) {
-    const delta = (curCounts.get(denom) || 0) - (prevCounts.get(denom) || 0)
-    if (delta === 0) continue
-    const impact = Math.abs(delta) * denom
-    if (!best || impact > Math.abs(best.delta) * best.denom || (impact === Math.abs(best.delta) * best.denom && denom > best.denom)) {
-      best = { denom, delta }
-    }
-  }
-  if (!best) return null
-  const sign = best.delta > 0 ? '+' : '−'
-  return `${sign}${Math.abs(best.delta)}×${best.denom} vs last`
 })
 
 const plateWeightLbs = computed(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -3869,7 +3869,6 @@ html.theme-fading .settingsSheet {
 .wtPlateCardHeader {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
   padding: 0 4px 8px;
 }
@@ -3881,14 +3880,6 @@ html.theme-fading .settingsSheet {
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--text-muted);
-}
-
-.wtPlateCardHeaderDelta {
-  font-family: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--accent);
-  font-variant-numeric: tabular-nums;
 }
 
 .wtPlateGrid {


### PR DESCRIPTION
## Summary
Aaron flagged the \"+2×25 vs last\" subtitle in the plate-calc card header (added in step 5c, #375) as both inaccurate and mostly useless:
- The heuristic only surfaced the largest |Δ × denom| single-denomination change, so it routinely misrepresented the actual load delta (e.g. swapping a 45 for two 25s shows \"+2×25\" but ignores the −1×45)
- Even when accurate, \"you added one more 5-lb plate\" isn't the question lifters actually want answered between sets

## Pulled out
- \`plateDeltaLabel\` computed
- \`.wtPlateCardHeaderDelta\` span in the plate-calc header template
- \`.wtPlateCardHeaderDelta\` CSS block
- \`justify-content: space-between\` on \`.wtPlateCardHeader\` (no longer has a right-side element to push to the edge)

## Future
If we want a between-sets delta later it should live somewhere with more room (sub-row of the WEIGHT card, or as a chip near the live estimate) and compare *total weight*, not single-denom counts.

## Test plan
- [x] \`npm test\` — 1263/1263 passing
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] Browser verified: plate-calc header now shows only \`PER SIDE · 45 lbs BAR\` (no delta span)

🤖 Generated with [Claude Code](https://claude.com/claude-code)