### PR TITLE
feat: PR Targets restyle — card chrome + active-reps highlight (step 5d)

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -581,18 +581,31 @@
             <span class="repMaxResultPlaceholderText">Enter weight and reps to see estimate</span>
           </div>
 
-          <!-- PR targets table (always visible when exercise has a PR) -->
-          <div v-if="!isEditMode && isLogForExercise && prTargetsTable" class="wtPrTargets">
+          <!--
+            PR Targets card per screens/07-pr-targets-expanded.png. Always
+            visible when the exercise has an established PR. Header is
+            tappable to expand/collapse the scrollable list. The row
+            matching the user's current reps value is highlighted in
+            accent so they can see at a glance "this is the weight to
+            hit at the rep count you've already chosen."
+          -->
+          <div v-if="!isEditMode && isLogForExercise && prTargetsTable" :class="['wtPrTargets', { wtPrTargetsExpanded: prTableExpanded }]">
             <button class="wtPrTargetsHeader" @click="prTableExpanded = !prTableExpanded" :aria-expanded="prTableExpanded">
-              <span class="wtPrTargetsTitle">PR Targets</span>
-              <span class="wtPrTargetsSub">Beat {{ displayWeight(store.getExercisePR(selectedExerciseId, prBaselineDate)) }} {{ weightUnit }} e1RM</span>
+              <span class="wtPrTargetsTitleCol">
+                <span class="wtPrTargetsTitle">PR Targets</span>
+                <span class="wtPrTargetsSub">
+                  Beat {{ displayWeight(store.getExercisePR(selectedExerciseId, prBaselineDate)) }} {{ weightUnit }} e1RM
+                  <span class="wtPrTargetsSubDot">·</span>
+                  <span class="wtPrTargetsSubCount">{{ prTargetsTable.length }} targets 🏆</span>
+                </span>
+              </span>
               <svg :class="['wtPrTargetsChevron', { wtPrTargetsChevronOpen: prTableExpanded }]" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
             </button>
             <div v-if="prTableExpanded" class="wtPrTargetsList">
               <button
                 v-for="row in prTargetsTable"
                 :key="row.reps"
-                class="wtPrTargetsRow"
+                :class="['wtPrTargetsRow', { wtPrTargetsRowActive: reps !== null && row.reps === reps }]"
                 @click="fillFromPRTable(row)"
               >
                 <span class="wtPrTargetsReps">{{ row.reps }}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -3710,19 +3710,28 @@ html.theme-fading .settingsSheet {
   margin-top: 4px;
 }
 
-/* ─── PR Targets Table ───────────────────────────────────────────────── */
+/* ─── PR Targets card ──────────────────────────────────────────────── */
+/* Matches screens/07-pr-targets-expanded.png: bordered card with a
+   tappable header that expands a scrollable list of beat-the-PR target
+   combos. The row matching the user's current reps value gets an
+   accent-tinted highlight so the next-set target is obvious. */
 
 .wtPrTargets {
   margin: 16px 0;
-  border-radius: 10px;
-  border: 1px dashed var(--accent);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 16px;
   overflow: hidden;
+}
+
+.wtPrTargets.wtPrTargetsExpanded {
+  border-color: var(--border-strong);
 }
 
 .wtPrTargetsHeader {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
   width: 100%;
   min-height: 44px;
   padding: 12px 16px;
@@ -3733,22 +3742,44 @@ html.theme-fading .settingsSheet {
 }
 
 .wtPrTargetsHeader:active {
-  background: var(--accent-subtle);
+  background: var(--bg-hover);
+}
+
+.wtPrTargetsTitleCol {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
 }
 
 .wtPrTargetsTitle {
-  font-size: var(--font-caption2);
+  font-size: var(--font-callout);
   font-weight: 700;
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
+  color: var(--text-primary);
+  letter-spacing: -0.1px;
 }
 
 .wtPrTargetsSub {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
   font-size: var(--font-caption1);
-  color: var(--text-secondary);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.wtPrTargetsSubDot {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+.wtPrTargetsSubCount {
+  color: var(--accent);
   font-weight: 600;
-  margin-left: auto;
+  font-variant-numeric: tabular-nums;
 }
 
 .wtPrTargetsChevron {
@@ -3770,8 +3801,8 @@ html.theme-fading .settingsSheet {
 
 .wtPrTargetsRow {
   display: flex;
-  align-items: center;
-  gap: 4px;
+  align-items: baseline;
+  gap: 8px;
   width: 100%;
   min-height: 44px;
   padding: 8px 16px;
@@ -3779,7 +3810,9 @@ html.theme-fading .settingsSheet {
   border: none;
   border-bottom: 1px solid var(--border);
   cursor: pointer;
+  text-align: left;
   -webkit-tap-highlight-color: transparent;
+  transition: background-color 0.12s;
 }
 
 .wtPrTargetsRow:last-child {
@@ -3787,13 +3820,26 @@ html.theme-fading .settingsSheet {
 }
 
 .wtPrTargetsRow:active {
+  background: var(--bg-hover);
+}
+
+/* Highlight the row whose rep count matches what the user has typed
+   into the REPS card. The accent tint + slightly stronger column
+   weights pulls the eye to "this is the weight you need to hit to
+   beat your PR at the rep count you've already chosen." */
+.wtPrTargetsRow.wtPrTargetsRowActive {
   background: var(--accent-subtle);
+}
+
+.wtPrTargetsRow.wtPrTargetsRowActive .wtPrTargetsReps,
+.wtPrTargetsRow.wtPrTargetsRowActive .wtPrTargetsWeight {
+  color: var(--accent);
 }
 
 .wtPrTargetsReps {
   font-size: var(--font-body);
   font-weight: 700;
-  color: var(--accent);
+  color: var(--text-primary);
   font-variant-numeric: tabular-nums;
   min-width: 24px;
   text-align: right;


### PR DESCRIPTION
## Summary
Step 5d of the design handoff — restyles the PR Targets section in the log-set sheet to match \`screens/07-pr-targets-expanded.png\`.

### Card chrome
- Solid \`bg-elevated\` card with 16px radius, 1px border that strengthens (\`border\` → \`border-strong\`) when expanded
- Header reorganized: left-aligned title column (\"PR Targets\" + subtitle) and right-aligned chevron, dropping the awkward \`margin-left: auto\` that pushed the subtitle tight against the chevron
- Subtitle now includes targets count + 🏆 chip: \`Beat 263 lbs e1RM · 20 targets 🏆\`

### Active-reps highlight
- New \`wtPrTargetsRowActive\` class binds when the row's reps match the value the user has typed into the REPS card
- Active row gets \`accent-subtle\` background + bumps the reps and weight cells to the accent color, so the next-set target is obvious at a glance
- Hover/active states use \`bg-hover\` instead of accent-subtle to keep the accent tint exclusively for the matched row

## Verified in browser (pearl theme)
- Highlight bg: \`rgba(208,208,208,0.1)\` on the matching row
- Reactive: typed 8 → row 8 highlighted; typed 6 → row 6 highlighted
- Card border strengthens \`rgb(42,42,42)\` → \`rgb(58,58,58)\` when expanded
- Chevron rotates 180° on expand

## Test plan
- [x] \`npm test\` — 1263/1263 passing
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] CSS spacing scale regression — passing
- [x] Browser-level interaction verified (Playwright at 402×874)

A unit-level mount test for the row highlight was attempted but the mock store doesn't surface \`prTargetsTable\` for the existing fixtures (the \`isExerciseEstablished\` gate + mock store interactions need more setup); deferred to a future PR that builds out a richer mount harness for the log sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)