### PR TITLE
feat: swipe-down-to-dismiss on log-set sheet (step 5f)

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -276,8 +276,8 @@
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
     <div v-if="showModal" class="repMaxOverlay logSetOverlay" @click.self="onOverlayClick" @keydown.escape="closeModal">
-      <div class="repMaxModal logSetSheet" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
-        <div class="logSetSheetHandle" aria-hidden="true"></div>
+      <div ref="logSheetEl" class="repMaxModal logSetSheet" :style="logSwipe.dragStyle()" @click.self="editingPresets = false" role="dialog" aria-modal="true" aria-labelledby="log-modal-title">
+        <div ref="logSheetHandleEl" class="logSetSheetHandle" aria-hidden="true"></div>
 
         <!-- Rest timer view -->
         <template v-if="timerActive">
@@ -1352,6 +1352,17 @@ watch(detailExerciseId, async (id) => {
     detailSwipe.detach()
     detailFocus.deactivate()
   }
+})
+
+// ── Swipe-to-dismiss for log-set sheet (step 5f) ────────────────
+// Drag the handle (or the sheet body, when not scrolled) down past
+// 100px to close the sheet. Uses the same composable as the detail
+// modal so the gesture feels consistent across the app.
+const logSheetEl = ref<HTMLElement | null>(null)
+const logSheetHandleEl = ref<HTMLElement | null>(null)
+const logSwipe = useSwipeToDismiss({
+  threshold: 100,
+  onDismiss: () => closeModal(),
 })
 
 function openDetailModal(id: string) {
@@ -2961,8 +2972,15 @@ watch(showModal, async (open) => {
     await nextTick()
     const el = document.querySelector<HTMLElement>('.repMaxModal')
     if (el) logModalFocus.activate(el)
+    // Attach swipe-to-dismiss gesture to the log-set sheet (step 5f).
+    // The handle gets touch events so the gesture doesn't compete with
+    // native scroll inside the sheet body.
+    if (logSheetEl.value && logSheetHandleEl.value) {
+      logSwipe.attach(logSheetEl.value, logSheetHandleEl.value)
+    }
   } else {
     logModalFocus.deactivate()
+    logSwipe.detach()
   }
 })
 

--- a/src/index.css
+++ b/src/index.css
@@ -3285,15 +3285,34 @@ html.theme-fading .settingsSheet {
 .logSetSheet .wtPrTargets { margin: 8px 0; }
 .logSetSheet .logSetFieldsRow { margin: 12px 0 16px; }
 
-/* Drag handle pill at the top of the sheet. */
+/* Drag handle pill at the top of the sheet. The visible bar is 4px tall
+   (matches iOS native sheets) but the element itself reserves a 24px tall
+   touch zone via padding so the swipe-to-dismiss gesture has a generous
+   target. The bar is rendered via the ::before pseudo so the parent is
+   the actual touch surface (touch events on ::before don't fire). */
 .logSetSheetHandle {
+  position: relative;
+  width: 100%;
+  height: 24px;
+  margin: -8px auto 4px;
+  cursor: grab;
+  flex-shrink: 0;
+  touch-action: none;
+}
+
+.logSetSheetHandle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   width: 36px;
   height: 4px;
-  margin: 0 auto 12px;
   border-radius: 99px;
   background: var(--border-strong);
-  flex-shrink: 0;
 }
+
+.logSetSheetHandle:active { cursor: grabbing; }
 
 @keyframes sheetSlideUp {
   from { transform: translateY(100%); }


### PR DESCRIPTION
## Summary
Step 5f of the design handoff — wires the existing \`useSwipeToDismiss\` composable (already used by the exercise detail modal) to the log-set sheet so users can flick the handle down to close.

(Branch name says step-5e because I created it speculatively before deciding to do 5f first; the smaller, lower-risk change ships first while step 5e \"custom in-sheet numpad\" needs more scoping discussion.)

## Changes

### WorkoutTracker.vue
- Add \`logSheetEl\` + \`logSheetHandleEl\` refs and \`logSwipe\` instance (mirrors the \`detail*\` setup right above it)
- In the \`showModal\` watcher: attach swipe to the sheet/handle pair when the modal opens; detach when it closes (alongside the existing focus-trap activate/deactivate)
- Bind \`ref=\"logSheetEl\"\` to the sheet, \`ref=\"logSheetHandleEl\"\` to the handle, and \`:style=\"logSwipe.dragStyle()\"\` to the sheet so it tracks the drag

### .logSetSheetHandle CSS
- Visible bar still 4px tall (matches iOS native sheets) but the element itself reserves a 24px tall full-width touch zone so the gesture has a generous target
- Bar is rendered via \`::before\` so touches land on the parent (touch events on \`::before\` don't fire)
- \`touch-action: none\` prevents the page from scrolling under the drag
- \`cursor: grab\` / \`:active { cursor: grabbing }\` for desktop affordance

## Verified in browser (Playwright, 402×874)
- Drag 160px past threshold → sheet animates out and dismisses, \`closeModal()\` called, overlay removed
- Drag tracks live: at 160px the sheet has \`translateY(160px)\`
- Velocity-based fast-flick path also closes (50px @ 0.55 px/ms)

## Test plan
- [x] \`npm test\` — 1263/1263 passing
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [x] Browser: drag past 100px threshold dismisses
- [x] Browser: fast flick (>0.5 px/ms) dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)