### PR TITLE
fix(ci): pass commit metadata via env to Slack notify (closes #344)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,13 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
-  # Notify Slack on post-merge success (push to master only)
+  # Notify Slack on post-merge success (push to master only).
+  # SECURITY: commit message + URL come in via env var, NOT direct
+  # `${{ ... }}` interpolation into the bash body. Inline interpolation
+  # is a known GitHub Actions script-injection vector — any commit
+  # containing single quotes, parentheses, backticks, or `$(...)`
+  # would break the run step (and could execute attacker-controlled
+  # shell). See GitHub docs: "Understanding the risk of script injections".
   notify-deploy:
     runs-on: ubuntu-latest
     needs: [build-and-test, migrate-db]
@@ -72,14 +78,16 @@ jobs:
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
         run: |
-          COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
-          COMMIT_URL="${{ github.event.head_commit.url }}"
+          COMMIT_MSG=$(printf '%s' "$COMMIT_MSG_RAW" | head -1)
           MSG="✅ *Deployed to production*\nCommit: <${COMMIT_URL}|${COMMIT_MSG}>"
-          payload=$(printf '{"text": %s}' "$(echo "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+          payload=$(printf '{"text": %s}' "$(printf '%s' "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
           curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-Type: application/json' -d "$payload"
 
-  # Notify Slack on post-merge failure (push to master only)
+  # Notify Slack on post-merge failure (push to master only). Same
+  # script-injection guard as `notify-deploy` above.
   notify-failure:
     runs-on: ubuntu-latest
     needs: [build-and-test, migrate-db]
@@ -88,9 +96,11 @@ jobs:
       - name: Notify Slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          COMMIT_MSG_RAW: ${{ github.event.head_commit.message }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | head -1)
-          COMMIT_URL="${{ github.event.head_commit.url }}"
-          MSG="🔴 *Post-merge CI failed on master*\nCommit: <${COMMIT_URL}|${COMMIT_MSG}>\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>"
-          payload=$(printf '{"text": %s}' "$(echo "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
+          COMMIT_MSG=$(printf '%s' "$COMMIT_MSG_RAW" | head -1)
+          MSG="🔴 *Post-merge CI failed on master*\nCommit: <${COMMIT_URL}|${COMMIT_MSG}>\nRun: <${RUN_URL}|View logs>"
+          payload=$(printf '{"text": %s}' "$(printf '%s' "$MSG" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')")
           curl -s -X POST "$SLACK_WEBHOOK_URL" -H 'Content-Type: application/json' -d "$payload"


### PR DESCRIPTION
## Summary
Closes #344. The \`notify-deploy\` and \`notify-failure\` jobs interpolated \`\${{ github.event.head_commit.message }}\` directly into a single-quoted bash string. Multi-line commit messages or any commit containing parentheses (e.g. \`calculateBest1RM()\`), single quotes, backticks, or \`\$(...)\` would either break the shell with \"syntax error near unexpected token\" or — worst case — execute attacker-controlled shell code.

This is the canonical GitHub Actions script-injection anti-pattern (GitHub docs: [\"Understanding the risk of script injections\"](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)). Per the issue, it has failed on every master merge since at least April 12.

## Three fixes
1. **Move commit metadata into \`env:\` blocks.** \`head_commit.message\`, \`head_commit.url\`, and the run URL are now bound as environment variables. GitHub binds env vars as actual environment variables — no shell parsing of the value, so commit messages with quotes/parens/backticks pass through safely.
2. **Replace \`echo\` with \`printf '%s'\`** wherever the value is user-controlled. \`echo\` interprets backslash escapes on some shells and treats leading \`-\` as flags; \`printf '%s'\` doesn't.
3. **Add SECURITY comment** on \`notify-deploy\` referencing the anti-pattern + GitHub docs link, with a back-reference comment on \`notify-failure\`.

## Test plan
- [x] YAML structure mirrors the existing pattern (env block on the step)
- [ ] After merge, the next push to master should successfully fire the Slack notification (the next merge of this PR itself will validate)
- [ ] Sanity: a future commit with parens in the title (e.g. this one!) won't break the notify

🤖 Generated with [Claude Code](https://claude.com/claude-code)