### PR TITLE
feat(security): add Content-Security-Policy header to vercel.json (closes #340)

### DIFF
--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Regression tests for the security headers shipped via vercel.json.
+ *
+ * These pin the presence + key directives of each header so nobody can
+ * accidentally loosen or drop them. Tightening (e.g. removing
+ * `'unsafe-inline'` once we ship nonces) is explicitly fine — update the
+ * test in the same PR as the policy change.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+interface HeaderRule {
+  source: string
+  headers: Array<{ key: string; value: string }>
+}
+
+interface VercelConfig {
+  headers?: HeaderRule[]
+}
+
+function loadVercelConfig(): VercelConfig {
+  const path = resolve(__dirname, '../../../vercel.json')
+  const raw = readFileSync(path, 'utf8')
+  return JSON.parse(raw) as VercelConfig
+}
+
+function findGlobalHeaderRule(config: VercelConfig): HeaderRule {
+  const rule = (config.headers || []).find(r => r.source === '/(.*)')
+  if (!rule) throw new Error('expected a global /(.*) header rule in vercel.json')
+  return rule
+}
+
+function getHeader(rule: HeaderRule, key: string): string | undefined {
+  return rule.headers.find(h => h.key === key)?.value
+}
+
+describe('vercel.json security headers', () => {
+  const config = loadVercelConfig()
+  const globalRule = findGlobalHeaderRule(config)
+
+  describe('baseline headers still present', () => {
+    it.each([
+      ['X-Content-Type-Options', 'nosniff'],
+      ['X-Frame-Options', 'DENY'],
+      ['Referrer-Policy', 'strict-origin-when-cross-origin'],
+    ])('has %s: %s', (key, expected) => {
+      expect(getHeader(globalRule, key)).toBe(expected)
+    })
+
+    it('has Permissions-Policy locking down camera/mic/geolocation', () => {
+      const v = getHeader(globalRule, 'Permissions-Policy')
+      expect(v).toContain('camera=()')
+      expect(v).toContain('microphone=()')
+      expect(v).toContain('geolocation=()')
+    })
+  })
+
+  describe('Content-Security-Policy', () => {
+    const csp = getHeader(globalRule, 'Content-Security-Policy') ?? ''
+
+    it('is present', () => {
+      expect(csp).not.toBe('')
+    })
+
+    /**
+     * `default-src 'self'` is the fallback for unspecified directives
+     * and is the single most important CSP setting. Without it, any
+     * directive we forget to enumerate silently falls back to `*`.
+     */
+    it("falls back to 'self' via default-src", () => {
+      expect(csp).toMatch(/default-src\s+'self'/)
+    })
+
+    it('restricts script-src to self (+ unsafe-inline for the index.html theme script)', () => {
+      expect(csp).toMatch(/script-src\s+[^;]*'self'/)
+      // We still allow 'unsafe-inline' for the splash theme bootstrap
+      // script — remove this branch once we ship a nonce/hash strategy.
+      expect(csp).toMatch(/script-src\s+[^;]*'unsafe-inline'/)
+      // Explicitly ensure no third-party CDN is allow-listed
+      expect(csp).not.toMatch(/script-src[^;]*https?:\/\//)
+    })
+
+    it('allows Supabase REST + realtime on connect-src', () => {
+      expect(csp).toMatch(/connect-src\s+[^;]*'self'/)
+      expect(csp).toContain('https://*.supabase.co')
+      expect(csp).toContain('wss://*.supabase.co')
+    })
+
+    it('allows Sentry ingest on connect-src', () => {
+      expect(csp).toContain('https://*.sentry.io')
+      expect(csp).toContain('https://*.ingest.sentry.io')
+    })
+
+    it('allows Vercel Analytics on connect-src', () => {
+      expect(csp).toContain('https://vitals.vercel-insights.com')
+    })
+
+    it('blocks framing (clickjacking defense)', () => {
+      expect(csp).toMatch(/frame-ancestors\s+'none'/)
+    })
+
+    it('blocks plugin objects', () => {
+      expect(csp).toMatch(/object-src\s+'none'/)
+    })
+
+    it('pins base-uri + form-action to self', () => {
+      expect(csp).toMatch(/base-uri\s+'self'/)
+      expect(csp).toMatch(/form-action\s+'self'/)
+    })
+
+    it('allows data:/blob: for img-src (inline SVG + canvas blobs)', () => {
+      expect(csp).toMatch(/img-src\s+[^;]*'self'/)
+      expect(csp).toMatch(/img-src\s+[^;]*data:/)
+      expect(csp).toMatch(/img-src\s+[^;]*blob:/)
+    })
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -36,7 +36,8 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://vitals.vercel-insights.com; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
Closes #340. CSP is the single most effective XSS mitigation for web apps. We already shipped \`X-Content-Type-Options\`, \`X-Frame-Options\`, \`Referrer-Policy\`, and \`Permissions-Policy\` — this closes the gap.

## Policy
\`\`\`
default-src 'self';
script-src 'self' 'unsafe-inline';
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob:;
connect-src 'self' https://*.supabase.co wss://*.supabase.co
            https://*.sentry.io https://*.ingest.sentry.io
            https://vitals.vercel-insights.com;
font-src 'self' data:;
frame-ancestors 'none';
base-uri 'self';
form-action 'self';
object-src 'none';
\`\`\`

## Tradeoffs
- **\`'unsafe-inline'\` stays on \`script-src\` and \`style-src\`** because \`index.html\` ships an inline theme-resolution bootstrap and an inline \`<style>\` for the splash. Moving those to a nonce/hash-based policy is worth doing but needs a Vite plugin and is out of scope for this urgent fix. The regression test makes the escape hatch explicit so the follow-up is a focused PR.
- **\`connect-src\`** is the narrowest allow-list that still works: Supabase REST + realtime, Sentry ingest, Vercel Analytics. **No third-party CDN is allow-listed on \`script-src\`** — the test pins this.
- **\`frame-ancestors 'none'\`** + \`X-Frame-Options: DENY\` defend against clickjacking (CSP supersedes XFO on modern browsers, both kept for belt-and-suspenders).
- **\`object-src 'none'\`** blocks plugin content, which we never use.
- **\`base-uri 'self'\`** + **\`form-action 'self'\`** prevent two less-obvious injection paths (base tag retargeting, form exfil).

## Regression tests
New \`src/lib/__tests__/vercelHeadersRegression.test.ts\` with 14 assertions:
- Each baseline header still present with expected value
- CSP present + \`default-src 'self'\` fallback
- \`script-src\` restricts to self + unsafe-inline, **no third-party CDN**
- \`connect-src\` includes Supabase (REST + \`wss://\`) + Sentry + Vercel Analytics
- \`frame-ancestors 'none'\`, \`object-src 'none'\`, \`base-uri 'self'\`, \`form-action 'self'\` pinned
- \`img-src\` allows \`data:\`/\`blob:\` for inline SVG + canvas blobs

## Gemini review note
Gemini flagged an unrelated pre-existing P1 in \`WorkoutTracker.vue\` drag-and-drop: \`shouldIgnorePressTarget\` checks \`activeTagFilters.length > 0\` but not \`searchQuery !== ''\`, so dragging a searched exercise corrupts the unfiltered list. Filed as a separate issue to be fixed in its own PR — not touched here.

## Test plan
- [x] \`npm test\` — 1277/1277 passing (14 new)
- [x] \`npm run lint\` — 0 errors
- [x] \`npm run typecheck\` — clean
- [ ] Post-merge: verify app still loads (Vercel Analytics beacon fires, Sentry DSN init, Supabase auth + realtime work, Google OAuth redirect works). Browser DevTools → Security tab should show "Content-Security-Policy" header active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)