### PR TITLE
fix(workouts): block drag-reorder while list is filtered (closes #383)

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -71,8 +71,8 @@
         :key="exercise.id"
         class="wtExerciseItem"
         :class="{
-          'wt-dragging': activeTagFilters.length === 0 && dragState.dragging && dragState.fromIndex === index,
-          'wt-drag-over': activeTagFilters.length === 0 && dragState.dragging && dragState.overIndex === index && dragState.fromIndex !== index,
+          'wt-dragging': !isFilteringActive && dragState.dragging && dragState.fromIndex === index,
+          'wt-drag-over': !isFilteringActive && dragState.dragging && dragState.overIndex === index && dragState.fromIndex !== index,
         }"
         :data-index="index"
         @touchstart="onItemTouchStart(index, $event)"
@@ -84,7 +84,7 @@
       >
         <div class="wtExerciseHeader">
           <span
-            :class="['wtDragHandle', { wtDragHandleDisabled: activeTagFilters.length > 0 }]"
+            :class="['wtDragHandle', { wtDragHandleDisabled: isFilteringActive }]"
             aria-hidden="true"
           >⠿</span>
           <button
@@ -1243,6 +1243,22 @@ const filteredExercises = computed(() => {
   return result
 })
 
+/**
+ * True when the list is showing a filtered subset of exercises (either a
+ * text search query or one-or-more active tag filters). Long-press
+ * reorder is disabled in this state because `v-for` gives us indices
+ * into the filtered subset, and those indices are meaningless to the
+ * store, which splices the unfiltered `exercises` array. Dropping a
+ * filtered-index 0 row would move the absolute-index 0 row — usually
+ * a completely different exercise the user can't even see.
+ *
+ * Fixes: reordering while searching silently scrambled unrelated rows
+ * (previously only the tag-filter path was gated).
+ */
+const isFilteringActive = computed(() =>
+  activeTagFilters.value.length > 0 || searchQuery.value.trim() !== ''
+)
+
 /** Total exercise count, shown in the "Workouts" header stats. */
 const totalExercises = computed(() => store.exercises.length)
 
@@ -1430,7 +1446,10 @@ function clearLongPress() {
 }
 
 function shouldIgnorePressTarget(event: TouchEvent | MouseEvent): boolean {
-  if (activeTagFilters.value.length > 0) return true
+  // Block reorder whenever the list is filtered (tag filter OR search).
+  // Template indices are into the filtered subset, but the store splices
+  // the unfiltered array — a drop under a filter corrupts unrelated rows.
+  if (isFilteringActive.value) return true
   const target = event.target as HTMLElement | null
   // Never start a drag when pressing the "+ Log" affordance.
   if (target?.closest('.wtExerciseLogBtn')) return true

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -1464,5 +1464,67 @@ describe('WorkoutTracker', () => {
 
       expect(mockReorderExercise).not.toHaveBeenCalled()
     })
+
+    /**
+     * Regression for #383 — the tag-filter gate above had a search-shaped
+     * hole in it. `v-for` indexes into `filteredExercises`, but
+     * `store.reorderExercise` splices the unfiltered `exercises` array,
+     * so a drag during search silently moved unrelated rows at the
+     * filtered index's position in the full list (e.g. dragging filtered
+     * row 0 would reorder absolute row 0 — often an exercise the user
+     * couldn't see). Gesture is now blocked whenever the list is
+     * filtered, matching the tag-filter case.
+     */
+    it('does not arm a long-press while a search query is active (#383)', async () => {
+      // Need ≥5 exercises for the search bar to render.
+      vi.useRealTimers()
+      exercises = [
+        { id: 'ex-1', name: 'Bench Press', tags: ['Chest'], sets: [] },
+        { id: 'ex-2', name: 'Squat', tags: ['Legs'], sets: [] },
+        { id: 'ex-3', name: 'Deadlift', tags: ['Back'], sets: [] },
+        { id: 'ex-4', name: 'Overhead Press', tags: ['Shoulders'], sets: [] },
+        { id: 'ex-5', name: 'Barbell Row', tags: ['Back'], sets: [] },
+      ]
+      const wrapper = mountTracker()
+      const searchInput = wrapper.find('.wtSearchInput')
+      await searchInput.setValue('press') // filters to 2 rows
+
+      // Sanity: list is actually filtered before we try to drag.
+      expect(wrapper.findAll('.wtExerciseItem').length).toBe(2)
+
+      vi.useFakeTimers()
+      const items = wrapper.findAll('.wtExerciseItem')
+      dispatchTouch(items[0].element, 'touchstart', 20, 100)
+      vi.advanceTimersByTime(LONG_PRESS_MS + 100)
+      // Drive a drop gesture document-wide too, to make sure even if the
+      // timer somehow fired, no reorder call escapes the gate.
+      const end = new Event('touchend', { bubbles: true, cancelable: true })
+      Object.defineProperty(end, 'touches', { value: [] })
+      document.dispatchEvent(end)
+      dispatchTouch(items[0].element, 'touchend')
+
+      expect(mockReorderExercise).not.toHaveBeenCalled()
+    })
+
+    /**
+     * Visual affordance — handle must be rendered in the "disabled" state
+     * so users see why reorder doesn't respond. Parallel to the existing
+     * tag-filter visual test.
+     */
+    it('disables drag handles while a search query is active (#383)', async () => {
+      vi.useRealTimers()
+      exercises = [
+        { id: 'ex-1', name: 'Bench Press', tags: ['Chest'], sets: [] },
+        { id: 'ex-2', name: 'Squat', tags: ['Legs'], sets: [] },
+        { id: 'ex-3', name: 'Deadlift', tags: ['Back'], sets: [] },
+        { id: 'ex-4', name: 'Overhead Press', tags: ['Shoulders'], sets: [] },
+        { id: 'ex-5', name: 'Barbell Row', tags: ['Back'], sets: [] },
+      ]
+      const wrapper = mountTracker()
+      const searchInput = wrapper.find('.wtSearchInput')
+      await searchInput.setValue('press')
+
+      expect(wrapper.findAll('.wtDragHandleDisabled').length).toBeGreaterThan(0)
+    })
   })
 })

--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import {
   calculateSetXP,
   calculateBest1RM,
@@ -245,6 +245,19 @@ describe('calculateSetXP', () => {
 // --- calculateBest1RM ---
 
 describe('calculateBest1RM', () => {
+  // These tests use hardcoded 2026-01 … 2026-04 dates and rely on "now"
+  // being roughly mid-2026 for the 1- and 6-month windows to behave as
+  // written. Pin the clock so the suite doesn't silently start failing
+  // as wall-clock time drifts past those windows.
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-15T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('returns null for empty sets', () => {
     expect(calculateBest1RM([])).toBeNull()
   })


### PR DESCRIPTION
## Summary
- **Bug (P1, data corruption):** long-press drag-reorder on the exercise list used indices from `filteredExercises`, but `store.reorderExercise` splices the unfiltered `exercises` array. Under a **search query**, dropping filtered row 0 silently moved absolute row 0 — often an exercise the user couldn't even see. Tag-filter was already gated; search was not.
- **Fix:** extract `isFilteringActive` computed (`activeTagFilters.length > 0 || searchQuery.trim() !== ''`) and use it in the single press-ignore gate plus the three visual class bindings (`wtDragHandleDisabled`, `wt-dragging`, `wt-drag-over`).
- **Drive-by:** `calculateBest1RM` tests in `xp.test.ts` have been failing on master CI for ~2 days because of hardcoded 2026-03-20 dates against a 1-month window. Pin `vi.setSystemTime('2026-04-15')` for the whole `calculateBest1RM` describe so window-relative tests stop rotting. (See master run 24635485997 — failure is pre-existing, not from this PR.)

## Why Option A, not Option B
Issue #383 offered two fixes. Picked **A** (gate the gesture when filtered) over **B** (map filtered → absolute index):
- **Consistency** — tag-filter is already gated; the issue explicitly says to preserve that. Mixing gate-for-tag-filter with map-for-search would be worse.
- **Safety** — filtered→absolute mapping needs care (overIndex drift past the last visible row, drops on empty gaps between items, same-ID resolution). Reorder-while-filtering is a real feature that belongs behind its own issue + UX pass, not a P1 data-corruption fix.
- **UX match** — iOS Mail / Notes / Reminders all disable reorder during search. User's mental model while searching is "find", not "rearrange".

## Test plan
- [x] `npx vitest run` → 1279/1279 passing (+2 new regression tests)
- [x] `npm run typecheck` → clean
- [x] `npm run lint` → 0 errors
- [x] `npm run build` → clean, bundle size unchanged
- [x] New regression tests:
  - `does not arm a long-press while a search query is active (#383)` — mounts tracker with 5 exercises, types "press" to filter to 2 rows, long-press-drags, asserts `reorderExercise` is never called (also drives a document-level `touchend` to catch any gate-escape path).
  - `disables drag handles while a search query is active (#383)` — mirrors the existing tag-filter visual test.
- [x] No regressions on existing gestures: tag-filter gate still passes; long-press-drag in unfiltered mode still reorders (0 → 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)