### PR TITLE
fix(test): use relative dates in calculateBest1RM custom window test

### DIFF
--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="obScreen">
     <div class="obCard">
+      <!-- Step indicator dots -->
+      <div class="obDots" role="progressbar" :aria-valuenow="currentStep" aria-valuemin="1" aria-valuemax="4" :aria-label="`Step ${currentStep} of 4`">
+        <span v-for="i in 4" :key="i" :class="['obDot', { obDotActive: i === currentStep }]" />
+      </div>
+
       <!-- Step 1: Setup path -->
       <template v-if="step === 'setup'">
         <div class="obHero">
@@ -74,6 +79,7 @@
           @skip="handleStarterSkip"
           @preview="handleStarterPreview"
           @revert-preview="handleStarterRevertPreview"
+          @step-change="onStarterStepChange"
         />
       </template>
     </div>
@@ -81,7 +87,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
 import { useBodyweightStore } from '../stores/bodyweight'
 import { useProgressionStore } from '../stores/progression'
@@ -96,7 +102,17 @@ const progressionStore = useProgressionStore()
 const { logEvent } = useAnalytics()
 
 const step = ref<'setup' | 'starter-flow'>('setup')
+const starterStep = ref<'explainer' | 'pick' | 'goal'>('explainer')
 let pendingSampleData = false
+
+const STEP_MAP = { explainer: 2, pick: 3, goal: 4 } as const
+const currentStep = computed(() =>
+  step.value === 'setup' ? 1 : STEP_MAP[starterStep.value]
+)
+
+function onStarterStepChange(s: 'explainer' | 'pick' | 'goal') {
+  starterStep.value = s
+}
 
 const STARTER_EXERCISES = [
   { name: 'Bench Press', tags: ['Push', 'Chest'] },
@@ -476,6 +492,26 @@ function chooseExplore() {
 </script>
 
 <style scoped>
+.obDots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 24px;
+}
+
+.obDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-muted, rgba(255,255,255,0.2));
+  transition: background 0.2s, transform 0.2s;
+}
+
+.obDotActive {
+  background: var(--accent);
+  transform: scale(1.25);
+}
+
 .obScreen {
   display: flex;
   align-items: center;

--- a/src/components/StarterPickerFlow.vue
+++ b/src/components/StarterPickerFlow.vue
@@ -60,7 +60,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { THEME_PREVIEWS, type ThemeId } from '../composables/useTheme'
 
 const props = withDefaults(defineProps<{
@@ -76,11 +76,14 @@ const emit = defineEmits<{
   skip: []
   preview: [themeId: ThemeId]
   'revert-preview': []
+  'step-change': [step: 'explainer' | 'pick' | 'goal']
 }>()
 
 const step = ref<'explainer' | 'pick' | 'goal'>('explainer')
 const selection = ref<ThemeId | null>(null)
 const goal = ref(3)
+
+watch(step, (s) => emit('step-change', s))
 
 const STARTERS: { id: ThemeId; label: string }[] = [
   { id: 'fire', label: 'Intensity' },

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -230,6 +230,60 @@ describe('OnboardingScreen', () => {
     })
   })
 
+  describe('step indicator dots', () => {
+    it('renders 4 step dots', () => {
+      const dots = wrapper.findAll('.obDot')
+      expect(dots.length).toBe(4)
+    })
+
+    it('first dot is active on setup step', () => {
+      const dots = wrapper.findAll('.obDot')
+      expect(dots[0].classes()).toContain('obDotActive')
+      expect(dots[1].classes()).not.toContain('obDotActive')
+      expect(dots[2].classes()).not.toContain('obDotActive')
+      expect(dots[3].classes()).not.toContain('obDotActive')
+    })
+
+    it('second dot is active on explainer step', async () => {
+      await wrapper.findAll('.obOption')[0].trigger('click') // → explainer
+      const dots = wrapper.findAll('.obDot')
+      expect(dots[0].classes()).not.toContain('obDotActive')
+      expect(dots[1].classes()).toContain('obDotActive')
+    })
+
+    it('third dot is active on starter pick step', async () => {
+      await wrapper.findAll('.obOption')[0].trigger('click') // → explainer
+      await wrapper.find('.spfPrimary').trigger('click') // → pick
+      const dots = wrapper.findAll('.obDot')
+      expect(dots[2].classes()).toContain('obDotActive')
+    })
+
+    it('fourth dot is active on weekly goal step', async () => {
+      await wrapper.findAll('.obOption')[0].trigger('click') // → explainer
+      await wrapper.find('.spfPrimary').trigger('click') // → pick
+      await wrapper.findAll('.spfCard')[0].trigger('click') // select Fire
+      await wrapper.findAll('.spfPrimary').at(-1)!.trigger('click') // → goal
+      const dots = wrapper.findAll('.obDot')
+      expect(dots[3].classes()).toContain('obDotActive')
+    })
+
+    it('has progressbar role with correct aria attributes', () => {
+      const dotsContainer = wrapper.find('.obDots')
+      expect(dotsContainer.attributes('role')).toBe('progressbar')
+      expect(dotsContainer.attributes('aria-valuenow')).toBe('1')
+      expect(dotsContainer.attributes('aria-valuemin')).toBe('1')
+      expect(dotsContainer.attributes('aria-valuemax')).toBe('4')
+      expect(dotsContainer.attributes('aria-label')).toBe('Step 1 of 4')
+    })
+
+    it('aria-label updates as steps progress', async () => {
+      await wrapper.findAll('.obOption')[0].trigger('click') // → explainer
+      const dotsContainer = wrapper.find('.obDots')
+      expect(dotsContainer.attributes('aria-valuenow')).toBe('2')
+      expect(dotsContainer.attributes('aria-label')).toBe('Step 2 of 4')
+    })
+  })
+
   describe('starter theme picker', () => {
     async function goToStarterPicker() {
       await wrapper.findAll('.obOption')[0].trigger('click') // → explainer

--- a/src/lib/__tests__/xp.test.ts
+++ b/src/lib/__tests__/xp.test.ts
@@ -274,9 +274,14 @@ describe('calculateBest1RM', () => {
   })
 
   it('respects custom window', () => {
+    const now = new Date()
+    // 15 days ago — inside a 1-month window
+    const recent = new Date(now.getTime() - 15 * 24 * 60 * 60 * 1000).toISOString()
+    // 60 days ago — outside a 1-month window
+    const old = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString()
     const sets = [
-      makeSet({ estimated1RM: 150, date: '2026-02-01T10:00:00Z' }),
-      makeSet({ estimated1RM: 100, date: '2026-03-20T10:00:00Z' }),
+      makeSet({ estimated1RM: 150, date: old }),
+      makeSet({ estimated1RM: 100, date: recent }),
     ]
     expect(calculateBest1RM(sets, { windowMonths: 1 })).toBe(100)
   })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-385](https://github.com/aschung212/Lift/issues/385)

Picked LIFT-385 (Add step indicator dots to onboarding flow). The onboarding has 4 steps with no progress indication — this adds iOS-style pagination dots following Apple HIG.

## Changes
- **StarterPickerFlow.vue**: Added `step-change` emit declaration and a watcher that emits the current step name whenever it changes
- **OnboardingScreen.vue**: Added `starterStep` ref to track StarterPickerFlow's internal step, `currentStep` computed (1-4 mapping), and renders 4 dots with `.obDots` container above all content. Active dot gets accent color + 1.25x scale.
- **OnboardingScreen.test.ts**: Added 7 regression tests covering dot count, active state at each step, progressbar ARIA role, and aria-label updates

## Verification

### Steps to test
1. Go to Settings → scroll to Dev Tools → tap "Reset Onboarding"
2. Observe the onboarding screen — 4 small dots should appear centered above the "Lift" logo
3. The first dot should be highlighted (accent color, slightly larger)
4. Tap "Popular exercises" (or any option) to advance to the progression explainer
5. The second dot should now be highlighted, first dot muted
6. Tap "Pick a Starter Theme" button to advance to theme picker
7. Third dot should be highlighted
8. Select a theme (e.g. Fire), tap "Next" to advance to weekly goal
9. Fourth dot should be highlighted

### Expected behavior
- 4 dots always visible, centered horizontally, with consistent position across all steps
- Active dot uses the theme's accent color and is 25% larger than inactive dots
- Inactive dots use muted color (subtle but visible)
- Smooth transition when switching between steps (0.2s CSS transition)
- Dots are present on all 4 screens including the initial setup choice

### What to watch for
- **Theme rendering**: Check dots in multiple themes (Void dark, Origin light, Fire) — accent color should be visible against the background
- **Light mode**: Muted dots should still be visible (using `--text-muted`)
- **Dot alignment**: Should stay centered and not shift position between steps
- **Skip path**: Tapping "Skip" from the explainer should work correctly (dots shouldn't cause issues)
- **Back button**: On the goal step, tapping "Back" should return to step 3 and dot should update

### Risk assessment
- **Scope:** Narrow — only affects OnboardingScreen and StarterPickerFlow. No changes to stores, routing, or other views.
- **Confidence:** High — 38 tests pass (31 existing + 7 new), Gemini review found no issues, and the implementation is purely additive (no existing DOM/logic modified).
- **Rollback:** Revert single commit `22236bd`.

## Commits
- [`40ad268`](https://github.com/aschung212/Lift/commit/40ad268) fix(test): use relative dates in calculateBest1RM custom window test
- [`22236bd`](https://github.com/aschung212/Lift/commit/22236bd) feat(LIFT-385): add step indicator dots to onboarding flow

## Test Results
- Before: 0 passing
- After: 1284 passing (1284 delta)

---
_Automated by overnight pipeline — Wed Apr 22 23:13:08 PDT 2026_

## Preview
Test on your phone: https://lift-k5vfqm8y2-aschung212-1101s-projects.vercel.app