### PR TITLE
docs: sync README, CLAUDE.md, CONTRIBUTING.md with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Before committing any UI change, verify all of the following:
 - [ ] Spacing uses the 4/8/12/16/24/32 scale — no arbitrary pixel values
 - [ ] Modals use existing bottom-sheet or centered-modal pattern — no new modal paradigms
 - [ ] No new navigation patterns introduced — stay consistent with existing tab/modal structure
-- [ ] Component renders correctly in all 9 themes, both light and dark mode
+- [ ] Component renders correctly in all 10 themes, both light and dark mode
 - [ ] New interactive elements have appropriate aria attributes
 - [ ] Animations use CSS transitions/animations, not JavaScript timers
 - [ ] No layout shift when showing/hiding conditional elements — reserve space or position at end of row
@@ -61,13 +61,13 @@ This app targets iOS App Store via Capacitor. Every UI element must meet Apple's
 
 - **44pt minimum touch targets.** Buttons, toggles, tappable rows, icon buttons — all must be at least 44x44pt. Existing regression tests enforce this for known violations. When adding new interactive elements, verify and add a test.
 - **Safe area insets.** All fixed/sticky elements must use `env(safe-area-inset-*)`. The Dynamic Island on newer iPhones hides content at the top. Test in PWA standalone mode — browser mode hides this issue.
-- **WCAG 2.1 AA contrast.** All 9 themes (18 variants) are tested via `themeContrast.test.ts`. When adding or modifying theme colors, run the contrast audit. Normal text needs 4.5:1, large text needs 3:1.
+- **WCAG 2.1 AA contrast.** All 10 themes (20 variants) are tested via `themeContrast.test.ts`. When adding or modifying theme colors, run the contrast audit. Normal text needs 4.5:1, large text needs 3:1.
 - **No hover-gated interactions.** Touch-only. Hover can enhance but must never be the only way to access functionality.
 
 ## Code Standards
 
 - **TypeScript strict mode.** All new files must be `.ts` or `.vue` with `lang="ts"`. No `any` types unless absolutely necessary.
-- **Conventional commits.** Format: `type: description (LIFT-XXX)`. Types: feat, fix, test, chore, docs, perf, refactor.
+- **Conventional commits.** Format: `type: description (closes #NNN)` or `type(scope): description (#PR)`. Types: feat, fix, test, chore, docs, perf, refactor. (Project migrated from Linear to GitHub Issues on 2026-04-03; the old `LIFT-XXX` prefix is no longer used.)
 - **ESLint clean.** Run `npm run lint` before committing. Zero errors allowed, warnings should be addressed.
 - **No app-breaking changes.** Always run `npm test` and `npm run build` after changes. If tests fail, fix them before moving on.
 
@@ -95,7 +95,7 @@ These patterns were reached through multiple iterations of user testing. Do not 
 ## Architecture Notes
 
 - **Local-first.** Pinia + localStorage is the source of truth. Supabase syncs in the background. The UI never waits on the network.
-- **Theme system.** 9 elemental themes (Fire, Water, Luck, Air, Void, Amethyst, Sun, Moon, Love) with CSS custom properties, custom SVG icons, and gradient previews. Light/dark/auto modes. Glass morphism is opt-in. Void (black + gold) is the default.
+- **Theme system.** 10 elemental themes (Eternal, Origin, Fortitude, Intensity, Flow, Stability, Luck, Focus, Energy, Love; internal IDs: `eternal`, `pearl`, `midnight`, `fire`, `water`, `earth`, `luck`, `amethyst`, `air`, `love`) with CSS custom properties, custom SVG icons, and gradient previews. Light/dark/auto modes. Glass morphism is always on. Eternal (black + gold) is the default. Legacy IDs (`void`, `sun`, `moon`, `graphite`, `arctic`, `forge`, `aaron`, `tina`, `bloom`, `metal`, `oak`) are mapped to current IDs by a migration table in `useTheme.ts`.
 - **Hand-rolled SVGs.** No chart libraries. Polyline + polygon with computed point arrays.
 - **Debounced sync.** Rapid store mutations are batched before hitting Supabase.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,10 @@ src/
    npm run build       # Vite production build
    ```
 
-4. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+4. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/). Reference the GitHub issue being closed in the subject:
    ```
-   feat: add rest timer presets (MAS-XXX)
-   fix: correct 1RM calculation for single-rep sets
+   feat: add rest timer presets (closes #123)
+   fix: correct 1RM calculation for single-rep sets (closes #456)
    test: add CalendarView navigation tests
    ```
 
@@ -75,8 +75,8 @@ src/
 Tests live next to the code they test in `__tests__/` directories:
 
 ```
-src/stores/__tests__/workout.test.js
-src/components/__tests__/WorkoutTracker.test.js
+src/stores/__tests__/workout.test.ts
+src/components/__tests__/WorkoutTracker.test.ts
 ```
 
 We use **Vitest** with **happy-dom** and **@vue/test-utils**. Mock Supabase in every test file:
@@ -94,7 +94,7 @@ npx vitest --watch    # Watch mode
 ## Architecture Decisions
 
 - **Hand-rolled SVGs** for charts — no chart libraries. This keeps the bundle small and the rendering fast.
-- **CSS custom properties** for theming (6 themes, light/dark/auto, optional glass morphism).
+- **CSS custom properties** for theming (10 themes, light/dark/auto, always-on glass morphism).
 - **Debounced sync queue** batches rapid Supabase mutations to avoid rate limits.
 - **Last-write-wins conflict resolution** for multi-device sync.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A **mobile-first Progressive Web App** for tracking strength training, bodyweigh
 
 ![Vue 3](https://img.shields.io/badge/Vue-3.4-42b883?logo=vue.js&logoColor=white)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6?logo=typescript&logoColor=white)
-![Vite](https://img.shields.io/badge/Vite-5-646cff?logo=vite&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-6-646cff?logo=vite&logoColor=white)
 ![Supabase](https://img.shields.io/badge/Supabase-cloud--sync-3ecf8e?logo=supabase&logoColor=white)
 ![PWA](https://img.shields.io/badge/PWA-installable-5a0fc8)
-![Tests](https://img.shields.io/badge/tests-299_passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-1279_passing-brightgreen)
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
 <p align="center">
@@ -110,7 +110,7 @@ Lift lets you track any strength exercise over time. Log a set (weight + reps + 
 ### UI & Experience
 - Bottom tab bar with sliding liquid glass indicator (when glass mode is on)
 - Tab animation on switch
-- 6 themes with visual preview dots: Midnight, Graphite, Arctic, Forge, Aaron, Tina
+- 10 themes with visual preview dots: Eternal, Origin, Fortitude, Intensity, Flow, Stability, Luck, Focus, Energy, Love
 - Light / Auto / Dark mode — auto follows system `prefers-color-scheme`
 - Liquid Glass mode — frosted glass cards, tab bar, and modals with per-theme ambient mesh gradients
 - Settings bottom sheet — iOS-style grouped sections for Appearance, Features, and Account
@@ -137,7 +137,7 @@ Lift lets you track any strength exercise over time. Log a set (weight + reps + 
 | **UI framework** | Vue 3 (`<script setup>`) | Fine-grained reactivity; single-file components |
 | **State** | Pinia | Lightweight store; syncs to localStorage on every mutation |
 | **Backend / Auth** | Supabase | Postgres with RLS, Google OAuth, email auth |
-| **Build** | Vite 5 | Sub-second HMR, native ESM |
+| **Build** | Vite 6 | Sub-second HMR, native ESM |
 | **PWA** | `vite-plugin-pwa` + Workbox | Pre-caches all static assets; installable on iOS & Android |
 | **Charts** | Hand-rolled SVG | `<polyline>` + `<polygon>` computed from normalized data — no chart library |
 | **Styling** | CSS custom properties | All themes + glass tokens are a single `data-theme` attribute swap |
@@ -174,14 +174,14 @@ All interactive elements meet Apple's 44pt minimum touch target. Font sizes are 
 
 ### Unit & Component Tests (Vitest)
 
-299 tests across 18 test files, covering stores, composables, library modules, and Vue components:
+1279 tests across 54 test files, covering stores, composables, library modules, and Vue components:
 
-| Layer | Tests | What's covered |
-|---|---|---|
-| **Stores** | 76 | Exercise/set CRUD, Epley 1RM, PR detection, bodyweight stats, preference toggles, template save/load, persistence |
-| **Composables** | 43 | Theme switching, color modes, auth flows (OAuth, email, sign-up with duplicate detection), keyboard shortcuts, undo toast |
-| **Library** | 21 | Sync queue debouncing/coalescing, conflict resolver (last-write-wins, merge strategies) |
-| **Components** | 159 | WorkoutTracker (exercise list, tag filtering, detail modal, PR history, set actions, progressive overload), BodyweightTracker (entry list, stats, SVG chart, period selection, modal), AuthScreen (sign-in/sign-up flows, OAuth, errors), ExerciseGraph (SVG rendering, PR detection, edge cases), OnboardingScreen (all 3 paths), CalendarView (month/week navigation, day selection, workout summary, PR badges), ErrorBoundary, accessibility attributes |
+| Layer | What's covered |
+|---|---|
+| **Stores** | Exercise/set CRUD, Epley 1RM, PR detection, bodyweight stats, preference toggles, progression XP and theme unlocks, sync fuzzing |
+| **Composables** | Theme switching, color modes, auth flows (OAuth, email, sign-up with duplicate detection), keyboard shortcuts, undo toast, swipe-to-dismiss, focus trap, haptics, PR burst, tag recovery/volume |
+| **Library** | Sync queue debouncing/coalescing, conflict resolver (last-write-wins, merge strategies), CSS/meta/manifest/SEO/theme-contrast/vercel-headers regression suites, CSV import, data export, plate calculator, XP migration |
+| **Components** | WorkoutTracker, BodyweightTracker, AuthScreen, ExerciseGraph, OnboardingScreen, CalendarView, ErrorBoundary, StarterPickerFlow, SkeletonLoader, MuscleGroupChart/Recovery, PR target, accessibility attributes |
 
 ```bash
 npm test           # run all tests


### PR DESCRIPTION
## Summary

Documentation audit surfaced drift between the repo-root docs and the actual source of truth. This PR brings them back in sync with zero runtime-visible changes.

- **Theme count and names** — README said "6 themes: Midnight, Graphite, Arctic, Forge, Aaron, Tina" and CLAUDE.md said "9 themes (Fire, Water, Luck, Air, Void, Amethyst, Sun, Moon, Love)". Ground truth in [`useTheme.ts`](src/composables/useTheme.ts#L20-L31) is **10 themes**: Eternal, Origin, Fortitude, Intensity, Flow, Stability, Luck, Focus, Energy, Love. Legacy IDs (`void`, `sun`, `moon`, etc.) are mapped via the migration table in `useTheme.ts:60-72`.
- **Vite version** — README badge and tech-stack table referenced Vite 5; `package.json` is on `^6.4.2`.
- **Test counts** — README claimed "299 tests across 18 test files"; latest master CI run reports **1279 tests across 54 test files**. Replaced the drift-prone per-layer test-count column with a coverage-only column.
- **Commit convention** — CLAUDE.md prescribed `(LIFT-XXX)` Linear IDs and CONTRIBUTING.md's example used a stale `MAS-XXX` prefix. Project migrated from Linear to GitHub Issues on 2026-04-03; recent commits use `(closes #NNN)` / `(#PR)`. Both docs now match.
- **Test file extensions** — CONTRIBUTING.md showed `.test.js` examples; the project is strict TypeScript and all tests are `.ts`.
- **Glass morphism** — CLAUDE.md said glass is "opt-in", but [`useTheme.ts:129`](src/composables/useTheme.ts#L129) hardcodes `data-glass="on"` and the opt-out toggle was removed. Note now reads "always on".

Items explicitly **not** changed because they were verified accurate: `index.html` canonical and OG URLs (pinned by `metaRegression.test.ts`), the `VALID_THEMES` guard in `index.html`, all four regression-test filenames referenced by CLAUDE.md.

## Follow-ups (separate PRs)

This is part 1 of a three-part doc/comment audit:
- **Part 2** — remove stale `LIFT-XXX` ticket refs from test-file comments and the stale "Last updated: March 31, 2026" strings in the Privacy/Terms modals
- **Part 3** — refactor: centralize the duplicated Epley 1RM formula and consolidate `makeSet`/`makeExercise` test fixtures

## Test plan

- [x] Diff is text-only (3 files, 21/21 lines changed)
- [x] Theme list in README matches `THEMES` array in `useTheme.ts:20-31` verbatim
- [x] Test count sourced from last successful master CI run (#24843784093)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)