### PR TITLE
docs(comments): remove stale LIFT-XXX ticket refs and legal dates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -551,7 +551,6 @@
             <div class="legalBody">
               <!-- Privacy Policy -->
               <template v-if="legalView === 'privacy'">
-                <p class="legalUpdated">Last updated: March 31, 2026</p>
                 <h4 class="legalH4">What We Collect</h4>
                 <p>Lift collects only the data you explicitly enter: exercises, sets, reps, weights, and bodyweight entries. If you create an account, we store your email address for authentication.</p>
                 <h4 class="legalH4">How Data Is Stored</h4>
@@ -570,7 +569,6 @@
               </template>
               <!-- Terms of Service -->
               <template v-else>
-                <p class="legalUpdated">Last updated: March 31, 2026</p>
                 <h4 class="legalH4">Acceptance</h4>
                 <p>By using Lift, you agree to these terms. If you do not agree, please do not use the app.</p>
                 <h4 class="legalH4">Description</h4>

--- a/src/__tests__/progressionIntegration.test.ts
+++ b/src/__tests__/progressionIntegration.test.ts
@@ -445,7 +445,7 @@ describe('Progression Integration', () => {
     })
   })
 
-  // ── Startup streak evaluation (LIFT-142) ──────────────────────
+  // ── Startup streak evaluation ──────────────────────────────────
   describe('startup streak evaluation', () => {
     it('evaluatePendingWeeks catches up missed weeks on startup', () => {
       const store = useProgressionStore()

--- a/src/components/__tests__/CalendarView.test.ts
+++ b/src/components/__tests__/CalendarView.test.ts
@@ -482,7 +482,7 @@ describe('CalendarView', () => {
       expect(wrapper.find('#exercise-picker-title').text()).toBe('Choose Exercise')
     })
 
-    it('week view log buttons have aria-labels (LIFT-93)', async () => {
+    it('week view log buttons have aria-labels', async () => {
       const wrapper = mountCalendar()
       await wrapper.findAll('.calToggleBtn')[1].trigger('click')
 

--- a/src/index.css
+++ b/src/index.css
@@ -6350,12 +6350,6 @@ html.theme-fading .settingsSheet {
   margin: 0 0 12px;
 }
 
-.legalUpdated {
-  font-size: var(--font-caption1);
-  color: var(--text-secondary);
-  margin-bottom: 16px !important;
-}
-
 .legalH4 {
   font-size: var(--font-subhead);
   font-weight: 600;

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -188,7 +188,7 @@ describe('CSS regression tests', () => {
       })
     })
 
-    describe('.mgRow in MuscleGroupChart (LIFT-97)', () => {
+    describe('.mgRow in MuscleGroupChart', () => {
       const style = getVueStyleBlock('MuscleGroupChart.vue')
       const lines = getRuleLines('.mgRow', style)
 
@@ -198,7 +198,7 @@ describe('CSS regression tests', () => {
     })
   })
 
-  describe('.wtTimerEditResetBtn touch target (LIFT-79)', () => {
+  describe('.wtTimerEditResetBtn touch target', () => {
     const lines = getRuleLines('.wtTimerEditResetBtn')
 
     it('has min-height: 44px for iOS HIG compliance', () => {
@@ -213,7 +213,7 @@ describe('CSS regression tests', () => {
     })
   })
 
-  describe('.wtTimerPresetSm touch target (LIFT-79)', () => {
+  describe('.wtTimerPresetSm touch target', () => {
     const lines = getRuleLines('.wtTimerPresetSm')
 
     it('has min-height: 44px for iOS HIG compliance', () => {
@@ -221,7 +221,7 @@ describe('CSS regression tests', () => {
     })
   })
 
-  describe('.wtTimerEditCountdown touch target (LIFT-79)', () => {
+  describe('.wtTimerEditCountdown touch target', () => {
     const lines = getRuleLines('.wtTimerEditCountdown')
 
     it('has min-height: 44px for iOS HIG compliance', () => {
@@ -229,7 +229,7 @@ describe('CSS regression tests', () => {
     })
   })
 
-  describe('brace balance (LIFT-252)', () => {
+  describe('brace balance', () => {
     // Regression: an extra closing brace in index.css caused a CSS minifier
     // warning ("unexpected }") that could silently drop rules in production.
     it('index.css has balanced braces', () => {
@@ -271,7 +271,7 @@ describe('CSS regression tests', () => {
     })
   })
 
-  describe('.srOnly screen-reader utility (LIFT-77)', () => {
+  describe('.srOnly screen-reader utility', () => {
     it('has position: absolute and clip to hide visually', () => {
       const lines = getRuleLines('.srOnly')
       expect(lines.length).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary

Part 2 of the doc/comment audit. Cleans up two small classes of stale text.

- **Stale Linear ticket IDs in test descriptions.** Linear was decommissioned for career tracking on 2026-04-23 (per global CLAUDE.md) and Lift migrated issue tracking to GitHub Issues on 2026-04-03. The `LIFT-XX` IDs in test-describe blocks are dangling references that only create grep noise now.
  - [src/__tests__/progressionIntegration.test.ts:448](src/__tests__/progressionIntegration.test.ts#L448) — drop `(LIFT-142)`
  - [src/components/__tests__/CalendarView.test.ts:485](src/components/__tests__/CalendarView.test.ts#L485) — drop `(LIFT-93)`
  - [src/lib/__tests__/cssRegression.test.ts](src/lib/__tests__/cssRegression.test.ts) — drop `(LIFT-97)`, `(LIFT-79)` (×3), `(LIFT-252)`, `(LIFT-77)` from 6 describe blocks

- **Stale "Last updated" date in legal modals.** `src/App.vue` Privacy Policy and Terms of Service templates showed `Last updated: March 31, 2026`. Neither body has actually been revised in that window, so the timestamp was misleading. Removed both `<p class=\"legalUpdated\">` lines and the now-orphaned `.legalUpdated` CSS rule in `src/index.css`. Re-introducing an accurate update cadence is tracked as a follow-up.

## Verification

- Dev preview confirmed both Privacy and Terms modals still open, render cleanly, and close without console errors. Screenshots show \"What We Collect\" / \"Acceptance\" now sit immediately under the modal title, with no layout glitch.
- Grep for `LIFT-\d+` across `src/` returns zero matches after this PR.
- Grep for `legalUpdated` / `Last updated` across the repo returns zero matches after this PR.
- No tests assert on the removed strings (verified via grep).

## Follow-ups

- Part 3 of the audit: centralize the duplicated Epley 1RM formula and consolidate `makeSet` / `makeExercise` test fixtures.
- Establish a real legal-doc review cadence before reintroducing an \"Updated\" timestamp.

## Test plan

- [x] Dev server loads without errors
- [x] Privacy modal renders correctly (verified via screenshot)
- [x] Terms modal renders correctly (verified via screenshot)
- [x] No tests reference `LIFT-XXX` or `legalUpdated` strings
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)