### PR TITLE
refactor(lib): centralize Epley 1RM formula and share test fixtures

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -6,6 +6,8 @@
  */
 import { vi } from 'vitest'
 import { ref } from 'vue'
+import { epley } from '../lib/epley'
+import type { Exercise, WorkoutSet } from '../stores/workout'
 
 // ── localStorage helpers ─────────────────────────────────────────
 
@@ -58,5 +60,41 @@ export function mockAuth() {
       signInWithEmail: vi.fn().mockResolvedValue({ error: null }),
       signUp: vi.fn().mockResolvedValue({ error: null }),
     })
+  }
+}
+
+// ── Fixture factories ────────────────────────────────────────────
+
+/**
+ * Build a WorkoutSet with sensible defaults. `weight` and `reps` are
+ * required; `estimated1RM` is auto-computed via `epley()` unless
+ * overridden. Used across progression, xp, theme-stats, and migration
+ * tests so the fixture shape stays in lockstep with the production
+ * WorkoutSet type.
+ */
+export function makeSet(overrides: Partial<WorkoutSet> & { weight: number; reps: number }): WorkoutSet {
+  const { weight, reps } = overrides
+  return {
+    id: overrides.id ?? `set-${Math.random().toString(36).slice(2)}`,
+    date: overrides.date ?? '2026-04-01T12:00:00Z',
+    weight,
+    reps,
+    estimated1RM: overrides.estimated1RM ?? epley(weight, reps),
+  }
+}
+
+/**
+ * Build an Exercise with the given name and a pre-built list of sets.
+ * Tags default to empty; pass overrides to change id, tags, or other
+ * fields. Compose with `makeSet()` at the call site when test data
+ * cares about specific weight/rep values.
+ */
+export function makeExercise(name: string, sets: WorkoutSet[] = [], overrides: Partial<Exercise> = {}): Exercise {
+  return {
+    id: overrides.id ?? `ex-${name}`,
+    name,
+    tags: [],
+    sets,
+    ...overrides,
   }
 }

--- a/src/__tests__/progressionIntegration.test.ts
+++ b/src/__tests__/progressionIntegration.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { getLocalStorageMock } from './helpers'
+import { getLocalStorageMock, makeSet, makeExercise } from './helpers'
 
 const localStorageMock = getLocalStorageMock()
 
@@ -34,26 +34,7 @@ import {
   type StreakHistoryEntry,
 } from '../lib/xp'
 import { computeRetroactiveXP, isMigrated, markMigrated, clearMigrationFlag } from '../lib/xpMigration'
-import type { Exercise, WorkoutSet } from '../stores/workout'
 import type { BodyweightEntry } from '../stores/bodyweight'
-
-// ── Helpers ─────────────────────────────────────────────────────
-
-function makeSet(overrides: Partial<WorkoutSet> & { weight: number; reps: number }): WorkoutSet {
-  const w = overrides.weight
-  const r = overrides.reps
-  return {
-    id: overrides.id || `set-${Math.random().toString(36).slice(2)}`,
-    date: overrides.date || '2026-04-01T12:00:00Z',
-    weight: w,
-    reps: r,
-    estimated1RM: overrides.estimated1RM ?? (r === 1 ? Math.round(w) : Math.round(w * (1 + r / 30))),
-  }
-}
-
-function makeExercise(name: string, sets: WorkoutSet[]): Exercise {
-  return { id: `ex-${name}`, name, tags: [], sets }
-}
 
 // ── Happy path ──────────────────────────────────────────────────
 

--- a/src/components/__tests__/prTarget.test.ts
+++ b/src/components/__tests__/prTarget.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { epley } from '../../lib/epley'
 
 /**
  * Tests for the inverse Epley formulas used in PR target calculations.
@@ -7,11 +8,6 @@ import { describe, it, expect } from 'vitest'
  * Inverse for weight: weight = e1RM / (1 + reps / 30)
  * Inverse for reps: reps = 30 * (e1RM / weight - 1)
  */
-
-function epley(weight: number, reps: number): number {
-  if (reps === 1) return Math.round(weight)
-  return Math.round(weight * (1 + reps / 30))
-}
 
 function prTargetWeight(currentPR: number, reps: number): number {
   const target = currentPR + 1

--- a/src/lib/epley.ts
+++ b/src/lib/epley.ts
@@ -1,0 +1,18 @@
+/**
+ * Epley 1RM estimation, rounded to the nearest integer.
+ *
+ *   e1RM = weight * (1 + reps / 30)
+ *
+ * For a single-rep set we return the weight itself (still rounded) — at 1 rep
+ * the formula collapses to weight * (1 + 1/30), but the working definition
+ * of a one-rep max is literally the lifted weight, so we special-case it.
+ *
+ * Input assumed valid (reps > 0, weight > 0). Callers that need to accept
+ * user-provided or CSV-imported values should guard their inputs before
+ * calling — see `csvImport.ts` for an example that also returns 0 for bad
+ * input.
+ */
+export function epley(weight: number, reps: number): number {
+  if (reps === 1) return Math.round(weight)
+  return Math.round(weight * (1 + reps / 30))
+}

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -6,6 +6,7 @@ import { mergeEntities } from '../lib/conflictResolver'
 import { uuid, endOfDayISO } from '../lib/uuid'
 import { logError, logWarn } from '../lib/logger'
 import { addTombstone, removeTombstone, isTombstoned, cleanupTombstones } from '../lib/tombstones'
+import { epley } from '../lib/epley'
 
 const TOMBSTONE_STORE = 'exercises'
 
@@ -40,11 +41,6 @@ export interface OverloadSuggestion {
   weight: number
   reps: number
   reason: string
-}
-
-function epley(weight: number, reps: number): number {
-  if (reps === 1) return Math.round(weight)
-  return Math.round(weight * (1 + reps / 30))
 }
 
 /**


### PR DESCRIPTION
## Summary

Part 3 of the doc/comment audit — the only one that touches runtime code. Removes true duplicates without changing behavior.

### Epley 1RM centralization
The formula `weight × (1 + reps / 30)` was duplicated across three identical implementations:
- [`src/stores/workout.ts:45`](src/stores/workout.ts#L45) (production path)
- [`src/components/__tests__/prTarget.test.ts:11`](src/components/__tests__/prTarget.test.ts#L11) (test-only copy)
- Inline computations in several test fixture helpers

Introduced [`src/lib/epley.ts`](src/lib/epley.ts) exporting a single canonical `epley(weight, reps)`. Byte-for-byte identical to the workout.ts implementation — including the `reps === 1` short-circuit that returns `Math.round(weight)`. `workout.ts` and `prTarget.test.ts` now import it.

### Shared test fixtures
Extended [`src/__tests__/helpers.ts`](src/__tests__/helpers.ts) with `makeSet()` and `makeExercise()` factories so tests stop redefining fixture shape. [`progressionIntegration.test.ts`](src/__tests__/progressionIntegration.test.ts) migrates to the shared factories; call sites unchanged.

### Deliberately NOT centralized
Three sites have **divergent behavior** — consolidating them would be a breaking change, not a refactor:

| File | Divergence |
|---|---|
| [`src/lib/csvImport.ts:12`](src/lib/csvImport.ts#L12) `estimated1RM` | Guards `reps <= 0` / `weight <= 0` → returns 0. Also returns **unrounded** `weight` at `reps === 1` (vs. shared `epley` which rounds). CSV inputs can be malformed — this is the right behavior for that context. |
| [`src/stores/__tests__/workout.test.ts:719`](src/stores/__tests__/workout.test.ts#L719) `makeSet` | Positional signature `(id, date, weight, reps)` used only by `deduplicateSets` tests. |
| [`src/lib/__tests__/xp.test.ts:14`](src/lib/__tests__/xp.test.ts#L14) `makeSet` | Requires explicit `estimated1RM`, defaults weight/reps to 100/5. Different contract than shared helper. |
| [`src/lib/__tests__/themeStats.test.ts:6`](src/lib/__tests__/themeStats.test.ts#L6), [`src/lib/__tests__/xpMigration.test.ts:14`](src/lib/__tests__/xpMigration.test.ts#L14) `makeExercise` | Accept partial set specs with generated ids that downstream tests assert on (e.g. `Bench-set-0`). Rewriting those tests to use the shared factory would be a caller-visible change. |

Each is noted in the commit body so future readers know it's intentional.

## Verification

- `npm test` — **54 test files / 1279 tests pass** (matches the last successful master CI run exactly). No new failures.
- `npm run typecheck` — clean.
- `npm run lint` — 0 errors, 9 warnings (pre-existing; unchanged).
- Behavior of `epley()` is identical to the previous local implementation — verified by inspection (same function body) and by the full test suite still passing.

## Follow-ups (out of scope)

- Time-dependent test flake: [`xp.test.ts:289`](src/lib/__tests__/xp.test.ts#L289) `calculateBest1RM > respects custom window` uses hardcoded dates (`2026-02-01`, `2026-03-20`) compared against `Date.now()` with a 1-month window. It fails whenever the wall clock is more than ~30 days past the latest fixture date. Needs a fixed-clock pattern (`vi.setSystemTime` / relative date helpers) — separate PR.
- Establish a style guide doc-check script so CLAUDE.md / README.md theme counts can't silently drift from `useTheme.ts` (from part 1 follow-ups).

## Test plan

- [x] Full test suite green (1279/1279)
- [x] Typecheck green
- [x] Lint green (no new warnings)
- [x] Epley formula byte-identical to pre-refactor behavior
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)