### PR TITLE
feat(settings): add user-facing "Replay intro" option (closes #386)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -234,6 +234,11 @@
                   <span class="glassToggleThumb"></span>
                 </button>
               </div>
+              <div class="settingsRow">
+                <button class="settingsRevealBtn" @click="confirmReplayIntro">
+                  Replay intro
+                </button>
+              </div>
             </div>
 
             <div class="settingsGroup">
@@ -1217,6 +1222,17 @@ const resetConfirmVisible = ref(false)
 
 function confirmResetProgress() {
   resetConfirmVisible.value = true
+}
+
+function confirmReplayIntro() {
+  showConfirm(
+    'Replay the onboarding intro? Your exercises, data, and progression are kept.',
+    () => {
+      localStorage.removeItem('onboarding-complete')
+      logEvent('replay_intro')
+      location.reload()
+    }
+  )
 }
 
 const starterPickerVisible = ref(false)


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-386](https://github.com/aschung212/Lift/issues/386)

Picked LIFT-386 (Add user-facing "Reset Onboarding" option in Settings) — the most impactful UX gap among the medium-priority issues. Users currently have no way to replay the intro or recalibrate their weekly goal without dev tools access.

## Changes
- Added "Replay intro" button in the Experience section of Settings, using the existing `settingsRevealBtn` style (matches "Start new training block" pattern)
- Added `confirmReplayIntro()` function using the existing `showConfirm` dialog pattern
- The production version only clears `onboarding-complete` from localStorage — unlike the dev version, it preserves progression data (XP, streaks, unlocked themes)
- Analytics event `replay_intro` is logged when confirmed

## Verification

### Steps to test
1. Navigate to Settings (gear icon in top bar)
2. Scroll to the **Experience** section (below Appearance, contains Haptics/PR celebration/Rest Timer)
3. Tap **Replay intro** at the bottom of the Experience section
4. A confirmation dialog appears: "Replay the onboarding intro? Your exercises, data, and progression are kept."
5. Tap **Cancel** — nothing happens, settings stay open
6. Tap **Replay intro** again, then tap **Confirm**
7. The page reloads and the onboarding screen appears with the three options (Popular Exercises, Start Empty, Explore First)
8. Choose any path to complete onboarding — verify all existing exercises and data are still present afterward

### Expected behavior
- The "Replay intro" button appears as a text button at the bottom of the Experience section
- Confirmation dialog follows the same style as "Start new training block" and "Reset Progress" confirmations
- After replay, all workout data, bodyweight entries, progression XP, streaks, and unlocked themes are preserved
- Completing onboarding again returns user to the app with all data intact

### What to watch for
- Verify the button renders correctly in all themes (light and dark)
- Check that progression data (XP count, streak, unlocked themes) is unchanged after replaying
- If user has sample data active, verify the "Explore First" flow doesn't double-populate
- The onboarding auto-skip watcher (fires if user has any exercises) may immediately complete onboarding — this is expected behavior for users with existing data; they'll see the setup screen briefly then get forwarded to starter picker flow

### Risk assessment
- **Scope:** Narrow — only adds a button and confirmation handler to App.vue's settings
- **Confidence:** High — uses two battle-tested patterns (settingsRevealBtn, showConfirm) with no new UI paradigms
- **Rollback:** Single commit revert (`git revert 0e3dbe7`)

## Commits
- [`0e3dbe7`](https://github.com/aschung212/Lift/commit/0e3dbe7) feat(settings): add user-facing "Replay intro" option (closes #386)

## Test Results
- Before: 1279 passing
- After: 1279 passing (0 delta)

---
_Automated by overnight pipeline — Thu Apr 23 23:17:40 PDT 2026_

## Preview
Test on your phone: https://lift-xh4ys8a4v-aschung212-1101s-projects.vercel.app