### PR TITLE
fix(rest-timer): use timestamp-based countdown to prevent drift (close

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2037,6 +2037,12 @@ const timerSeconds = ref(0)
 const timerAnnouncement = ref('')
 const restDuration = ref(parseInt(localStorage.getItem('rest-duration') ?? '90') || 90)
 let timerIntervalId: ReturnType<typeof setInterval> | null = null
+// Timestamp-based drift correction: store when the timer ends and
+// how many seconds remained when paused, so every tick recalculates
+// from wall-clock time instead of decrementing a counter.
+let timerEndTime = 0        // Date.now() ms when timer should reach 0
+let pausedRemaining = 0     // seconds left when paused
+let lastWarnedAt = -1       // last warning second we fired (avoid duplicate beeps)
 
 const DEFAULT_WARNING_OPTIONS = [3, 5, 10, 15, 30]
 const warningOptions = ref<number[]>(loadWarningOptions())
@@ -2108,12 +2114,19 @@ function formatTimerAnnouncement(seconds: number): string {
 
 function startInterval() {
   if (timerIntervalId !== null) clearInterval(timerIntervalId)
+  lastWarnedAt = -1
   timerIntervalId = setInterval(() => {
     if (!timerPaused.value) {
-      timerSeconds.value--
-      if (warningTimes.value.includes(timerSeconds.value)) {
-        playWarningBeep(timerSeconds.value)
-        timerAnnouncement.value = `${formatTimerAnnouncement(timerSeconds.value)} remaining`
+      const remaining = Math.ceil((timerEndTime - Date.now()) / 1000)
+      const prev = timerSeconds.value
+      timerSeconds.value = Math.max(remaining, 0)
+      // Fire warnings for any thresholds we crossed (handles skipped seconds)
+      for (const w of warningTimes.value) {
+        if (w < prev && w >= timerSeconds.value && w !== lastWarnedAt) {
+          lastWarnedAt = w
+          playWarningBeep(w)
+          timerAnnouncement.value = `${formatTimerAnnouncement(w)} remaining`
+        }
       }
       if (timerSeconds.value <= 0) {
         playGoBeep()
@@ -2126,7 +2139,7 @@ function startInterval() {
         }
       }
     }
-  }, 1000)
+  }, 250)
 }
 
 function startRestTimer() {
@@ -2134,13 +2147,22 @@ function startRestTimer() {
   timerActive.value = true
   timerPaused.value = false
   timerSeconds.value = restDuration.value
+  timerEndTime = Date.now() + restDuration.value * 1000
   timerAnnouncement.value = `Rest timer started, ${formatTimerAnnouncement(restDuration.value)}`
   startInterval()
 }
 
 function togglePause() {
   ensureAudioCtx()
-  timerPaused.value = !timerPaused.value
+  if (!timerPaused.value) {
+    // Pausing: snapshot remaining seconds
+    pausedRemaining = Math.max(Math.ceil((timerEndTime - Date.now()) / 1000), 0)
+    timerPaused.value = true
+  } else {
+    // Resuming: recalculate end time from snapshot
+    timerEndTime = Date.now() + pausedRemaining * 1000
+    timerPaused.value = false
+  }
 }
 
 const timerStopping = ref(false)
@@ -2160,6 +2182,7 @@ function stopTimer() {
 function restartTimer() {
   ensureAudioCtx()
   timerSeconds.value = restDuration.value
+  timerEndTime = Date.now() + restDuration.value * 1000
   timerPaused.value = false
   startInterval()
 }
@@ -2235,6 +2258,7 @@ function setRestDuration(val: number) {
   restDuration.value = val
   localStorage.setItem('rest-duration', String(val))
   timerSeconds.value = val
+  timerEndTime = Date.now() + val * 1000
   timerPaused.value = false
   startInterval()
 }
@@ -2301,7 +2325,14 @@ function disableRestTimer() {
       timerActive.value = true
       timerPaused.value = wasPaused
       showModal.value = true
-      if (previousSeconds > 0) startInterval()
+      if (previousSeconds > 0) {
+        if (wasPaused) {
+          pausedRemaining = previousSeconds
+        } else {
+          timerEndTime = Date.now() + previousSeconds * 1000
+        }
+        startInterval()
+      }
     }
   }, () => { /* already disabled — no-op on commit */ })
 }

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -1024,6 +1024,73 @@ describe('WorkoutTracker', () => {
     })
   })
 
+  describe('rest timer drift correction', () => {
+    beforeEach(() => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      localStorage.setItem('rest-timer', 'on')
+      localStorage.setItem('rest-duration', '90')
+      const mockOsc = { connect: vi.fn(), frequency: { value: 0, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() }, start: vi.fn(), stop: vi.fn() }
+      const mockGain = { connect: vi.fn(), gain: { value: 0, setValueAtTime: vi.fn(), exponentialRampToValueAtTime: vi.fn() } }
+      vi.stubGlobal('AudioContext', class {
+        state = 'running'
+        currentTime = 0
+        destination = {}
+        resume = vi.fn()
+        createOscillator = vi.fn(() => mockOsc)
+        createGain = vi.fn(() => mockGain)
+      })
+      vi.useFakeTimers({ shouldAdvanceTime: false })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('uses wall-clock time so backgrounding the app does not cause drift', async () => {
+      const wrapper = mountTracker()
+      const vm = wrapper.vm as unknown as {
+        startRestTimer: () => void
+        timerSeconds: number
+        timerActive: boolean
+      }
+      // Start the timer with 90s duration
+      const startTime = Date.now()
+      vi.setSystemTime(startTime)
+      vm.startRestTimer()
+      expect(vm.timerSeconds).toBe(90)
+
+      // Simulate 30 real seconds passing (as if phone was backgrounded)
+      vi.setSystemTime(startTime + 30_000)
+      vi.advanceTimersByTime(250) // one tick
+      await wrapper.vm.$nextTick()
+      expect(vm.timerSeconds).toBe(60)
+
+      // Simulate 55 more seconds — only 5s should remain
+      vi.setSystemTime(startTime + 85_000)
+      vi.advanceTimersByTime(250)
+      await wrapper.vm.$nextTick()
+      expect(vm.timerSeconds).toBe(5)
+    })
+
+    it('timer reaches zero even if intervals were throttled', async () => {
+      const wrapper = mountTracker()
+      const vm = wrapper.vm as unknown as {
+        startRestTimer: () => void
+        timerSeconds: number
+        timerActive: boolean
+      }
+      const startTime = Date.now()
+      vi.setSystemTime(startTime)
+      vm.startRestTimer()
+
+      // Jump past the full duration in one step
+      vi.setSystemTime(startTime + 91_000)
+      vi.advanceTimersByTime(250)
+      await wrapper.vm.$nextTick()
+      expect(vm.timerSeconds).toBe(0)
+    })
+  })
+
   describe('view toggle', () => {
     beforeEach(() => {
       exercises = JSON.parse(JSON.stringify(EXERCISES))


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-326](https://github.com/aschung212/Lift/issues/326)

Picked LIFT-326 (Rest timer drift fix — use timestamp-based countdown instead of setInterval). This is a real correctness bug affecting every workout session. When iOS throttles setInterval during screen lock or backgrounding, the timer falls behind real time. Fixed by anchoring the countdown to `Date.now()` wall-clock timestamps.

## Changes
- Replaced `setInterval` decrement-by-1 approach with `Date.now()`-anchored calculation: each tick computes `Math.ceil((timerEndTime - Date.now()) / 1000)`
- Added `timerEndTime`, `pausedRemaining`, and `lastWarnedAt` state variables for timestamp tracking
- Updated `startRestTimer`, `restartTimer`, `setRestDuration` to set `timerEndTime`
- Updated `togglePause` to snapshot remaining seconds on pause and recalculate endTime on resume
- Updated `disableRestTimer` undo handler to restore timestamp state correctly
- Reduced tick interval from 1000ms to 250ms for faster catch-up after backgrounding
- Warning beep logic now detects crossed thresholds (handles skipped ticks when multiple seconds pass in one tick)
- Added 2 regression tests verifying drift-free behavior

## Verification

### Steps to test
1. Navigate to the Workouts tab
2. Tap any exercise to open its detail view
3. Log a set (enter weight/reps and tap Save) — the rest timer should auto-start if auto-start is enabled, or tap the timer icon
4. With the timer running (~90s), lock your phone screen for 15-20 seconds
5. Unlock the phone and check the timer display
6. Verify the timer shows the correct remaining time (should have lost ~15-20s, not be stuck near where you left it)
7. Test pause/resume: tap pause, wait 5 seconds, tap resume — timer should continue from where it was paused, not skip ahead
8. Test preset switching: while timer is running, tap a different duration preset (e.g., 60s) — timer should restart at the new duration
9. Let a timer count down to 0 and verify the completion beep fires and the timer shows "Done"

### Expected behavior
- Timer display always matches real elapsed time, even after phone sleep/background
- Pause freezes the countdown; resume continues from the paused value
- Warning beeps fire at the correct thresholds (default: 5 seconds remaining)
- Completion beep fires when timer reaches 0
- Progress ring animates smoothly with the countdown

### What to watch for
- Timer jumping erratically after unlocking (should smoothly catch up)
- Missed warning beeps when phone was locked through the warning threshold
- Timer showing negative values (clamped to 0)
- Pause/resume losing time (paused seconds should be preserved exactly)
- Any theme where the timer ring or text is invisible (test in light mode Eternal and at least one other theme)

### Risk assessment
- **Scope:** Narrow — only the rest timer countdown logic in WorkoutTracker.vue
- **Confidence:** High — the timestamp approach is a well-established pattern, and the two regression tests verify the core invariant
- **Rollback:** Simple revert of one commit; no schema or data changes

## Commits
- [`06c2c3b`](https://github.com/aschung212/Lift/commit/06c2c3b) fix(rest-timer): use timestamp-based countdown to prevent drift (closes #326)

## Test Results
- Before: 1279 passing
- After: 1281 passing (2 delta)

---
_Automated by overnight pipeline — Thu Apr 23 23:28:08 PDT 2026_

## Preview
Test on your phone: https://lift-ameu90hre-aschung212-1101s-projects.vercel.app