### PR TITLE
feat(manifest): add PWA shortcuts for quick tab navigation (closes #32

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1084,7 +1084,19 @@ function closeSettings() {
     settingsOpen.value = false
   }, { once: true })
 }
-const activeTab = ref(localStorage.getItem('active-tab') || 'workouts')
+// ── Tab initialization (supports PWA manifest shortcuts via ?tab= param) ──
+const VALID_TABS = ['workouts', 'calendar', 'weight'] as const
+const urlTab = new URLSearchParams(window.location.search).get('tab')
+const initialTab = urlTab && VALID_TABS.includes(urlTab as typeof VALID_TABS[number])
+  ? urlTab
+  : localStorage.getItem('active-tab') || 'workouts'
+const activeTab = ref(initialTab)
+// Clean up the query param so it doesn't persist on reload
+if (urlTab) {
+  const url = new URL(window.location.href)
+  url.searchParams.delete('tab')
+  window.history.replaceState({}, '', url.pathname)
+}
 
 // ── Keyboard shortcuts ─────────────────────────────────────────────
 const { helpOpen: shortcutsOpen, toggleHelp: toggleShortcuts, closeHelp: closeShortcuts } = useKeyboardShortcuts(() => [

--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -21,6 +21,29 @@ describe('PWA manifest regression tests', () => {
     })
   })
 
+  describe('manifest includes shortcuts for quick actions', () => {
+    it('has shortcuts array defined', () => {
+      expect(viteConfig).toContain('shortcuts: [')
+    })
+
+    it('has a workout shortcut with ?tab=workouts URL', () => {
+      expect(viteConfig).toContain("url: '/?tab=workouts'")
+    })
+
+    it('has a calendar shortcut with ?tab=calendar URL', () => {
+      expect(viteConfig).toContain("url: '/?tab=calendar'")
+    })
+
+    it('has a weight shortcut with ?tab=weight URL', () => {
+      expect(viteConfig).toContain("url: '/?tab=weight'")
+    })
+
+    it('shortcuts reference existing icon files', () => {
+      // All shortcuts use icon-192.png
+      expect(existsSync(resolve(publicDir, 'icon-192.png'))).toBe(true)
+    })
+  })
+
   describe('manifest includes screenshots for richer install UI', () => {
     it('has narrow (mobile) screenshot entries', () => {
       expect(viteConfig).toContain("form_factor: 'narrow'")

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,6 +45,29 @@ export default defineConfig({
         orientation: 'portrait',
         start_url: '/',
         categories: ['health', 'fitness', 'sports'],
+        shortcuts: [
+          {
+            name: 'Log Workout',
+            short_name: 'Workouts',
+            description: 'Jump to your workout tracker',
+            url: '/?tab=workouts',
+            icons: [{ src: 'icon-192.png', sizes: '192x192', type: 'image/png' }],
+          },
+          {
+            name: 'View Calendar',
+            short_name: 'Calendar',
+            description: 'See your training calendar',
+            url: '/?tab=calendar',
+            icons: [{ src: 'icon-192.png', sizes: '192x192', type: 'image/png' }],
+          },
+          {
+            name: 'Track Weight',
+            short_name: 'Weight',
+            description: 'Log a bodyweight entry',
+            url: '/?tab=weight',
+            icons: [{ src: 'icon-192.png', sizes: '192x192', type: 'image/png' }],
+          },
+        ],
         icons: [
           {
             src: 'icon-192.png',


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-329](https://github.com/aschung212/Lift/issues/329)

Picked LIFT-329 (Add manifest shortcuts for quick workout actions). This is a high-impact PWA feature that lets users long-press the app icon on their home screen to jump directly to Workouts, Calendar, or Weight tabs — a native-feeling interaction that demonstrates PWA polish.

## Changes
- Added 3 manifest shortcuts (Log Workout, View Calendar, Track Weight) to `vite.config.js` with `?tab=` URLs
- Added URL query parameter handling in `App.vue` to read `?tab=` on launch, navigate to the correct tab, and clean up the URL via `history.replaceState`
- Added 5 regression tests to `manifestRegression.test.ts` pinning shortcut URLs and icon references
- All 1284 tests passing, build succeeds, lint clean (0 errors)

## Verification

### Steps to test
1. Navigate to the Workouts tab, long-press the Lift icon on your home screen (iOS) or app icon (Android)
2. You should see 3 shortcut options: "Log Workout", "View Calendar", "Track Weight"
3. Tap "View Calendar" — the app should open directly to the Calendar tab
4. Close the app, long-press again, tap "Track Weight" — should open to the Weight tab
5. After the app loads, check the URL bar (if visible) — there should be no `?tab=` parameter remaining
6. Alternatively, test by manually navigating to `/?tab=calendar` in the browser — should land on Calendar tab

### Expected behavior
- Long-press menu shows 3 shortcuts with the app icon
- Each shortcut opens the app to the correct tab
- URL is clean after navigation (no leftover query params)
- If an invalid `?tab=` value is provided, falls back to localStorage or default (workouts)

### What to watch for
- Shortcuts may not appear immediately after install — some browsers cache the manifest and need a reinstall
- On iOS, home screen shortcuts are more limited than Android — the long-press menu may not show PWA shortcuts (this is an iOS Safari limitation, not a bug)
- Verify the tab indicator pill animates to the correct position on shortcut launch
- Test with a tab disabled in settings — if user navigates via `?tab=weight` but Weight is disabled, the fallback logic should still work

### Risk assessment
- **Scope:** Narrow — manifest config + App.vue tab initialization only
- **Confidence:** High — manifest shortcuts are a well-documented PWA spec feature, and the query param handling is straightforward with cleanup
- **Rollback:** Revert single commit; shortcuts disappear from manifest, URL params ignored

## Commits
- [`f01bee8`](https://github.com/aschung212/Lift/commit/f01bee8) feat(manifest): add PWA shortcuts for quick tab navigation (closes #329)

## Test Results
- Before: 1279 passing
- After: 1284 passing (5 delta)

---
_Automated by overnight pipeline — Fri Apr 24 00:09:33 PDT 2026_

## Preview
Test on your phone: https://lift-prsn7sn4f-aschung212-1101s-projects.vercel.app