### PR TITLE
feat(calendar): add first-use empty state guidance (closes #387)

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -71,6 +71,11 @@
         </div>
       </div>
 
+      <!-- First-use empty state (no workout data at all) -->
+      <p v-if="!hasAnyData && !selectedDay" class="wtEmpty calEmptyState">
+        Log your first workout on the Workouts tab to see it here.
+      </p>
+
       <!-- Selected day detail -->
       <div v-if="selectedDay" class="calDetail">
         <div class="calDetailHeader">
@@ -189,6 +194,11 @@
           </div>
         </div>
       </div>
+
+      <!-- First-use empty state (no workout data at all) -->
+      <p v-if="!hasAnyData" class="wtEmpty calEmptyState">
+        Log your first workout on the Workouts tab to see it here.
+      </p>
 
       <MuscleGroupRecovery
         v-if="hasRecoveryData"
@@ -346,6 +356,11 @@ function toLocalDateStr(d: Date) {
 }
 
 const todayStr = toLocalDateStr(new Date())
+
+// True when the user has zero sets across all exercises (brand-new account)
+const hasAnyData = computed(() =>
+  store.exercises.some(e => e.sets.length > 0)
+)
 
 // Map YYYY-MM-DD → unique exercise names (respects tag filter)
 const trainingMap = computed(() => {

--- a/src/components/__tests__/CalendarView.test.ts
+++ b/src/components/__tests__/CalendarView.test.ts
@@ -45,6 +45,8 @@ vi.mock('../../stores/workout', () => ({
     getExercisePR,
     logSet: vi.fn(),
     addExercise: vi.fn(),
+    tagRecoveryDays: {},
+    tagRecoveryExcluded: [],
   })
 }))
 
@@ -201,6 +203,33 @@ describe('CalendarView', () => {
       expect(wrapper.find('.calDetailEmpty').text()).toContain('No sets logged')
     })
 
+    it('shows first-use empty state when no exercises have sets (month view)', () => {
+      exercises = []
+      const wrapper = mountCalendar()
+      const emptyState = wrapper.find('.calEmptyState')
+      expect(emptyState.exists()).toBe(true)
+      expect(emptyState.text()).toContain('Log your first workout')
+      expect(emptyState.text()).toContain('Workouts tab')
+    })
+
+    it('hides first-use empty state when exercises have sets', () => {
+      const today = new Date()
+      const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+      exercises = makeExercises([dateStr])
+      const wrapper = mountCalendar()
+      expect(wrapper.find('.calEmptyState').exists()).toBe(false)
+    })
+
+    it('hides first-use empty state when a day is selected', async () => {
+      exercises = []
+      const wrapper = mountCalendar()
+      expect(wrapper.find('.calEmptyState').exists()).toBe(true)
+      const inMonthCells = wrapper.findAll('.calCell:not(.calCellOtherMonth)')
+      await inMonthCells[0].trigger('click')
+      // When a day is selected, the per-day detail takes over
+      expect(wrapper.find('.calEmptyState').exists()).toBe(false)
+    })
+
     it('deselects day when clicked again', async () => {
       const wrapper = mountCalendar()
       const inMonthCells = wrapper.findAll('.calCell:not(.calCellOtherMonth)')
@@ -332,6 +361,26 @@ describe('CalendarView', () => {
       const initialLabel = wrapper.find('.calNavLabel').text()
       await wrapper.findAll('.calNavBtn')[0].trigger('click')
       expect(wrapper.find('.calNavLabel').text()).not.toBe(initialLabel)
+    })
+
+    it('shows first-use empty state when no exercises have sets (week view)', async () => {
+      exercises = []
+      const wrapper = mountCalendar()
+      await wrapper.findAll('.calToggleBtn')[1].trigger('click')
+
+      const emptyState = wrapper.find('.calEmptyState')
+      expect(emptyState.exists()).toBe(true)
+      expect(emptyState.text()).toContain('Log your first workout')
+    })
+
+    it('hides first-use empty state in week view when exercises have sets', async () => {
+      const today = new Date()
+      const dateStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+      exercises = makeExercises([dateStr])
+      const wrapper = mountCalendar()
+      await wrapper.findAll('.calToggleBtn')[1].trigger('click')
+
+      expect(wrapper.find('.calEmptyState').exists()).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-387](https://github.com/aschung212/Lift/issues/387)

Picked LIFT-387 — Calendar tab empty state needs richer first-use guidance. The calendar is the second tab users see, but with no data it just shows empty "Rest" labels with no guidance. Other views (WorkoutTracker, BodyweightTracker) both have actionable empty states.

## Changes
- Added `hasAnyData` computed that checks if any exercises have sets
- Added first-use empty state message in month view (hidden when a day is selected, so per-day "No sets logged" still works)
- Added first-use empty state message in week view (below the week rows)
- Message: "Log your first workout on the Workouts tab to see it here." — consistent with the `.wtEmpty` pattern
- Fixed mock store in CalendarView tests (missing `tagRecoveryDays` and `tagRecoveryExcluded`)
- Added 5 new tests covering empty state in both views

## Verification

### Steps to test
1. Navigate to the Calendar tab
2. If you have workout data, clear localStorage to simulate a new user (or test from an incognito window without signing in)
3. In month view, observe the empty state message below the calendar grid
4. Tap a day — the empty state disappears and the per-day "No sets logged." message appears
5. Deselect the day — empty state reappears
6. Switch to Week view — empty state appears below the week rows
7. Log a workout from the Workouts tab, return to Calendar — empty state is gone

### Expected behavior
- New users see "Log your first workout on the Workouts tab to see it here." centered below the calendar grid
- The message uses muted text, matching the empty state style in Workouts and Body Weight tabs
- Once any workout data exists, the message disappears permanently

### What to watch for
- Verify the empty state message renders in all 10 themes (light + dark)
- Check that the message doesn't appear when the user has data but is viewing an empty month (only triggers on zero global data)
- Verify the per-day "No sets logged." still works correctly when selecting a day

### Risk assessment
- **Scope:** Narrow — only CalendarView.vue template and existing CSS
- **Confidence:** High — simple conditional rendering, 5 targeted tests, all 1284 tests pass
- **Rollback:** Revert single commit

## Commits
- [`0ad77ad`](https://github.com/aschung212/Lift/commit/0ad77ad) feat(calendar): add first-use empty state guidance (closes #387)

## Test Results
- Before: 1279 passing
- After: 1284 passing (5 delta)

---
_Automated by overnight pipeline — Fri Apr 24 00:53:31 PDT 2026_

## Preview
Test on your phone: https://lift-c2caglpg2-aschung212-1101s-projects.vercel.app