### PR TITLE
chore(ci): add concurrency control to cancel superseded CI runs (close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-347](https://github.com/aschung212/Lift/issues/347)

Picked LIFT-347 — add concurrency control to cancel superseded CI runs. This saves GitHub Actions minutes by cancelling stale PR runs when new commits arrive, while preserving full validation on master merges.

## Changes
- Added `concurrency` block at workflow level in `.github/workflows/ci.yml`
- Group key: `ci-${{ github.ref }}` — groups runs by branch
- `cancel-in-progress: true` for PR branches, `false` for master

## Verification

### Steps to test
1. Open a PR against master with any small change
2. Push a second commit to the same PR branch before the first CI run completes
3. Check the Actions tab — the first run should show as "cancelled"
4. Push to master (merge a PR) — verify the run completes fully even if a second merge lands quickly

### Expected behavior
- PR branches: older CI runs cancelled when a newer push arrives on the same branch
- Master: all runs complete regardless of subsequent pushes

### What to watch for
- Ensure master runs are never cancelled (the `cancel-in-progress` expression must evaluate to `false` for `refs/heads/master`)
- Verify the concurrency group key correctly differentiates branches (e.g., two different PR branches should NOT cancel each other)

### Risk assessment
- **Scope:** CI workflow only — no app code changes
- **Confidence:** High — this is a standard GitHub Actions pattern documented in official docs
- **Rollback:** Revert the single commit to remove the concurrency block

## Commits
- [`56cef39`](https://github.com/aschung212/Lift/commit/56cef39) chore(ci): add concurrency control to cancel superseded CI runs (closes #347)

## Test Results
- Before: 1279 passing
- After: 1279 passing (0 delta)

---
_Automated by overnight pipeline — Fri Apr 24 00:57:54 PDT 2026_