### PR TITLE
chore(ci): automate dependabot patch/minor merges and group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    groups:
+      npm-patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # Major version bumps need manual review
       - dependency-name: "vue"
@@ -21,3 +26,8 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      actions-patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- New workflow auto-enables `--auto` merge on dependabot PRs for patch/minor updates. Major bumps still require manual review.
- Group npm and github-actions patch/minor updates into one PR per ecosystem per week instead of one per dep.

## Why
Just cleared a 7-PR dependabot backlog by hand. Six of them had stale CI failures from 22 days ago because master had moved (the Epley refactor in #400 fixed the test that was breaking them) — they needed manual `@dependabot rebase` comments before merging.

With this in place:
- Patch/minor PRs merge themselves once `build-and-test` passes (branch protection already requires it).
- One grouped PR per ecosystem per week instead of N per ecosystem.
- Stale CI self-corrects: when master moves, the next weekly run rebases and re-runs CI.

Aaron only sees PRs that need eyes (major bumps, ecosystem-wide breakage).

## Test plan
- [ ] CI passes
- [ ] Next dependabot run produces grouped PRs (visible Monday mornings)
- [ ] Patch/minor PR auto-merges without manual `gh pr merge`
- [ ] Major version bump (when one comes along) does NOT auto-merge