### PR TITLE
feat(ci): post coverage summary as PR comment (closes #348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
 
       - run: npx vitest run --coverage
 
+      - name: Coverage report
+        if: always() && github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json
+
   # Push unapplied Supabase migrations on merge to master.
   # Runs before Vercel deploys so the DB schema is ready for the new code.
   migrate-db:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
     exclude: ['e2e/**', 'node_modules/**', 'dist/**', '.claude/**', '**/node_modules/**'],
     coverage: {
       provider: 'v8',
+      reporter: ['text', 'json-summary', 'json'],
       include: ['src/**/*.{ts,vue}'],
       exclude: ['src/**/__tests__/**', 'src/main.ts', 'src/App.vue'],
       thresholds: {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-348](https://github.com/aschung212/Lift/issues/348)

Picked LIFT-348 — post coverage summary as PR comment. The CI already runs `--coverage` but results are buried in logs. Adding the coverage report action makes coverage regressions immediately visible on every PR, which is high-value for a portfolio project demonstrating engineering rigor.

## Changes
- Added `json-summary` and `json` reporters to vitest coverage config (alongside existing `text`) so the action has structured data to work with
- Added `davelosert/vitest-coverage-report-action@v2` step to the `build-and-test` job, gated to PRs only, with `if: always()` so it posts even if tests fail

## Verification

### Steps to test
1. Open any PR against master on the Lift repo
2. Wait for CI to complete the `build-and-test` job
3. Check the PR conversation tab for a coverage summary comment

### Expected behavior
- A bot comment appears with a coverage summary table showing statements, branches, functions, and lines percentages
- The comment updates on subsequent pushes to the same PR
- On master pushes, no coverage comment is posted (action is gated to PRs)

### What to watch for
- The action requires `json-summary-path` and `json-final-path` to match the actual output paths — verified locally that `coverage/coverage-summary.json` and `coverage/coverage-final.json` are generated
- The `if: always()` condition means the coverage comment posts even when tests fail — this is intentional so you can see what coverage looks like even on a broken run
- If the action version `v2` introduces breaking changes, pin to a specific SHA

### Risk assessment
- **Scope:** CI workflow only — no app code changes except adding reporters to vitest config (no runtime impact)
- **Confidence:** High — the action is well-established, the reporter config is standard vitest, and JSON files were verified locally
- **Rollback:** Remove the coverage report step from ci.yml and the extra reporters from vitest.config.js

## Commits
- [`d54c2bf`](https://github.com/aschung212/Lift/commit/d54c2bf) feat(ci): post coverage summary as PR comment (closes #348)

## Test Results
- Before: 1301 passing
- After: 1301 passing (0 delta)

---
_Automated by overnight pipeline — Fri Apr 24 23:13:37 PDT 2026_