### PR TITLE
refactor(onboarding): pass inputMode through addExercise to ensure per

### DIFF
--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -442,11 +442,7 @@ function chooseStarter() {
   logEvent('onboarding_choice', { choice: 'starter' })
   emit('started')
   for (const ex of STARTER_EXERCISES) {
-    const id = workoutStore.addExercise(ex.name, ex.tags)
-    if (id && ex.inputMode) {
-      const exercise = workoutStore.exercises.find(e => e.id === id)
-      if (exercise) exercise.inputMode = ex.inputMode
-    }
+    workoutStore.addExercise(ex.name, ex.tags, ex.inputMode ? { inputMode: ex.inputMode } : undefined)
   }
   goToStarter(false)
 }
@@ -459,13 +455,9 @@ function chooseExplore() {
   // Add exercises with sample sets — skip Supabase sync for sample data (MAS-197)
   for (const group of SAMPLE_SETS) {
     const starter = STARTER_EXERCISES.find(e => e.name === group.exercise)
-    const id = workoutStore.addExercise(group.exercise, starter?.tags || [], noSync)
+    const opts = starter?.inputMode ? { sync: false, inputMode: starter.inputMode } as const : noSync
+    const id = workoutStore.addExercise(group.exercise, starter?.tags || [], opts)
     if (!id) continue
-    // Enable plate calculator on barbell exercises so users see the feature during exploration
-    if (starter?.inputMode) {
-      const exercise = workoutStore.exercises.find(e => e.id === id)
-      if (exercise) exercise.inputMode = starter.inputMode
-    }
     for (const set of group.sets) {
       workoutStore.logSet(id, set.weight, set.reps, set.date, noSync)
     }
@@ -473,11 +465,8 @@ function chooseExplore() {
   // Add remaining starter exercises without sets
   for (const ex of STARTER_EXERCISES) {
     if (!SAMPLE_SETS.find(g => g.exercise === ex.name)) {
-      const id = workoutStore.addExercise(ex.name, ex.tags, noSync)
-      if (id && ex.inputMode) {
-        const exercise = workoutStore.exercises.find(e => e.id === id)
-        if (exercise) exercise.inputMode = ex.inputMode
-      }
+      const opts = ex.inputMode ? { sync: false, inputMode: ex.inputMode } as const : noSync
+      workoutStore.addExercise(ex.name, ex.tags, opts)
     }
   }
   // Add sample bodyweight entries

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -82,7 +82,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useWorkoutStore } from '../stores/workout'
+import { useWorkoutStore, type ExerciseInputMode } from '../stores/workout'
 import { useBodyweightStore } from '../stores/bodyweight'
 import { useProgressionStore } from '../stores/progression'
 import { useTheme, type ThemeId } from '../composables/useTheme'
@@ -98,12 +98,12 @@ const { logEvent } = useAnalytics()
 const step = ref<'setup' | 'starter-flow'>('setup')
 let pendingSampleData = false
 
-const STARTER_EXERCISES = [
-  { name: 'Bench Press', tags: ['Push', 'Chest'] },
-  { name: 'Squat', tags: ['Legs'] },
-  { name: 'Deadlift', tags: ['Pull', 'Legs'] },
-  { name: 'Overhead Press', tags: ['Push', 'Shoulders'] },
-  { name: 'Barbell Row', tags: ['Pull', 'Back'] },
+const STARTER_EXERCISES: { name: string; tags: string[]; inputMode?: ExerciseInputMode }[] = [
+  { name: 'Bench Press', tags: ['Push', 'Chest'], inputMode: 'plates' },
+  { name: 'Squat', tags: ['Legs'], inputMode: 'plates' },
+  { name: 'Deadlift', tags: ['Pull', 'Legs'], inputMode: 'plates' },
+  { name: 'Overhead Press', tags: ['Push', 'Shoulders'], inputMode: 'plates' },
+  { name: 'Barbell Row', tags: ['Pull', 'Back'], inputMode: 'plates' },
   { name: 'Pull-ups', tags: ['Pull', 'Back'] },
 ]
 
@@ -442,7 +442,11 @@ function chooseStarter() {
   logEvent('onboarding_choice', { choice: 'starter' })
   emit('started')
   for (const ex of STARTER_EXERCISES) {
-    workoutStore.addExercise(ex.name, ex.tags)
+    const id = workoutStore.addExercise(ex.name, ex.tags)
+    if (id && ex.inputMode) {
+      const exercise = workoutStore.exercises.find(e => e.id === id)
+      if (exercise) exercise.inputMode = ex.inputMode
+    }
   }
   goToStarter(false)
 }
@@ -457,6 +461,11 @@ function chooseExplore() {
     const starter = STARTER_EXERCISES.find(e => e.name === group.exercise)
     const id = workoutStore.addExercise(group.exercise, starter?.tags || [], noSync)
     if (!id) continue
+    // Enable plate calculator on barbell exercises so users see the feature during exploration
+    if (starter?.inputMode) {
+      const exercise = workoutStore.exercises.find(e => e.id === id)
+      if (exercise) exercise.inputMode = starter.inputMode
+    }
     for (const set of group.sets) {
       workoutStore.logSet(id, set.weight, set.reps, set.date, noSync)
     }
@@ -464,7 +473,11 @@ function chooseExplore() {
   // Add remaining starter exercises without sets
   for (const ex of STARTER_EXERCISES) {
     if (!SAMPLE_SETS.find(g => g.exercise === ex.name)) {
-      workoutStore.addExercise(ex.name, ex.tags, noSync)
+      const id = workoutStore.addExercise(ex.name, ex.tags, noSync)
+      if (id && ex.inputMode) {
+        const exercise = workoutStore.exercises.find(e => e.id === id)
+        if (exercise) exercise.inputMode = ex.inputMode
+      }
     }
   }
   // Add sample bodyweight entries

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -4,16 +4,23 @@ import { setActivePinia, createPinia } from 'pinia'
 import OnboardingScreen from '../OnboardingScreen.vue'
 
 // Mock stores
-const mockAddExercise = vi.fn().mockReturnValue('mock-id')
+let mockIdCounter = 0
+const mockAddExercise = vi.fn().mockImplementation(() => `mock-id-${++mockIdCounter}`)
 const mockLogSet = vi.fn()
 const mockAddEntry = vi.fn()
 
 const mockSetStarterTheme = vi.fn()
 
+const mockExercises: { id: string; inputMode?: string }[] = []
 vi.mock('../../stores/workout', () => ({
   useWorkoutStore: () => ({
-    addExercise: mockAddExercise,
+    addExercise: (...args: unknown[]) => {
+      const id = mockAddExercise(...args)
+      if (id) mockExercises.push({ id })
+      return id
+    },
     logSet: mockLogSet,
+    exercises: mockExercises,
   })
 }))
 
@@ -43,6 +50,8 @@ describe('OnboardingScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.clear()
+    mockExercises.length = 0
+    mockIdCounter = 0
     setActivePinia(createPinia())
     wrapper = mount(OnboardingScreen)
   })
@@ -145,6 +154,12 @@ describe('OnboardingScreen', () => {
       await wrapper.findAll('.obOption')[0].trigger('click')
       expect(mockLogSet).not.toHaveBeenCalled()
     })
+
+    it('enables plate calculator on barbell starter exercises', async () => {
+      await wrapper.findAll('.obOption')[0].trigger('click')
+      const platesExercises = mockExercises.filter(e => e.inputMode === 'plates')
+      expect(platesExercises.length).toBe(5) // all barbell exercises
+    })
   })
 
   describe('Explore first (sample data)', () => {
@@ -177,6 +192,17 @@ describe('OnboardingScreen', () => {
       await wrapper.findAll('.obOption')[2].trigger('click')
       // Extended sample data: ~365 days across 5 exercises (multiple sets per session)
       expect(mockLogSet.mock.calls.length).toBe(367)
+    })
+
+    it('enables plate calculator on barbell sample exercises', async () => {
+      await wrapper.findAll('.obOption')[2].trigger('click')
+      // All barbell exercises (Bench, Squat, Deadlift, OHP, Row) should have plates mode
+      const platesExercises = mockExercises.filter(e => e.inputMode === 'plates')
+      expect(platesExercises.length).toBe(5)
+      // Pull-ups (bodyweight) should NOT have plate calculator
+      expect(mockExercises.length).toBe(6)
+      const pullUps = mockExercises.find(e => !e.inputMode)
+      expect(pullUps).toBeDefined()
     })
   })
 

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -4,23 +4,16 @@ import { setActivePinia, createPinia } from 'pinia'
 import OnboardingScreen from '../OnboardingScreen.vue'
 
 // Mock stores
-let mockIdCounter = 0
-const mockAddExercise = vi.fn().mockImplementation(() => `mock-id-${++mockIdCounter}`)
+const mockAddExercise = vi.fn().mockReturnValue('mock-id')
 const mockLogSet = vi.fn()
 const mockAddEntry = vi.fn()
 
 const mockSetStarterTheme = vi.fn()
 
-const mockExercises: { id: string; inputMode?: string }[] = []
 vi.mock('../../stores/workout', () => ({
   useWorkoutStore: () => ({
-    addExercise: (...args: unknown[]) => {
-      const id = mockAddExercise(...args)
-      if (id) mockExercises.push({ id })
-      return id
-    },
+    addExercise: mockAddExercise,
     logSet: mockLogSet,
-    exercises: mockExercises,
   })
 }))
 
@@ -50,8 +43,6 @@ describe('OnboardingScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorageMock.clear()
-    mockExercises.length = 0
-    mockIdCounter = 0
     setActivePinia(createPinia())
     wrapper = mount(OnboardingScreen)
   })
@@ -136,12 +127,12 @@ describe('OnboardingScreen', () => {
       // Popular is the featured / first option after the 01-auth.png restyle.
       await wrapper.findAll('.obOption')[0].trigger('click')
       expect(mockAddExercise).toHaveBeenCalledTimes(6)
-      expect(mockAddExercise).toHaveBeenCalledWith('Bench Press', ['Push', 'Chest'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Squat', ['Legs'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Deadlift', ['Pull', 'Legs'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Overhead Press', ['Push', 'Shoulders'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Barbell Row', ['Pull', 'Back'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Pull-ups', ['Pull', 'Back'])
+      expect(mockAddExercise).toHaveBeenCalledWith('Bench Press', ['Push', 'Chest'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Squat', ['Legs'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Deadlift', ['Pull', 'Legs'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Overhead Press', ['Push', 'Shoulders'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Barbell Row', ['Pull', 'Back'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Pull-ups', ['Pull', 'Back'], undefined)
     })
 
     it('emits complete event after skipping starter', async () => {
@@ -157,8 +148,15 @@ describe('OnboardingScreen', () => {
 
     it('enables plate calculator on barbell starter exercises', async () => {
       await wrapper.findAll('.obOption')[0].trigger('click')
-      const platesExercises = mockExercises.filter(e => e.inputMode === 'plates')
-      expect(platesExercises.length).toBe(5) // all barbell exercises
+      const calls = mockAddExercise.mock.calls
+      // Barbell exercises pass inputMode: 'plates'
+      expect(calls.find((c: unknown[]) => c[0] === 'Bench Press')?.[2]).toEqual({ inputMode: 'plates' })
+      expect(calls.find((c: unknown[]) => c[0] === 'Squat')?.[2]).toEqual({ inputMode: 'plates' })
+      expect(calls.find((c: unknown[]) => c[0] === 'Deadlift')?.[2]).toEqual({ inputMode: 'plates' })
+      expect(calls.find((c: unknown[]) => c[0] === 'Overhead Press')?.[2]).toEqual({ inputMode: 'plates' })
+      expect(calls.find((c: unknown[]) => c[0] === 'Barbell Row')?.[2]).toEqual({ inputMode: 'plates' })
+      // Pull-ups (bodyweight) should NOT have inputMode
+      expect(calls.find((c: unknown[]) => c[0] === 'Pull-ups')?.[2]).toBeUndefined()
     })
   })
 
@@ -196,13 +194,13 @@ describe('OnboardingScreen', () => {
 
     it('enables plate calculator on barbell sample exercises', async () => {
       await wrapper.findAll('.obOption')[2].trigger('click')
-      // All barbell exercises (Bench, Squat, Deadlift, OHP, Row) should have plates mode
-      const platesExercises = mockExercises.filter(e => e.inputMode === 'plates')
-      expect(platesExercises.length).toBe(5)
-      // Pull-ups (bodyweight) should NOT have plate calculator
-      expect(mockExercises.length).toBe(6)
-      const pullUps = mockExercises.find(e => !e.inputMode)
-      expect(pullUps).toBeDefined()
+      const calls = mockAddExercise.mock.calls
+      // Barbell exercises pass inputMode: 'plates' alongside sync: false
+      expect(calls.find((c: unknown[]) => c[0] === 'Bench Press')?.[2]).toEqual({ sync: false, inputMode: 'plates' })
+      expect(calls.find((c: unknown[]) => c[0] === 'Squat')?.[2]).toEqual({ sync: false, inputMode: 'plates' })
+      expect(calls.find((c: unknown[]) => c[0] === 'Deadlift')?.[2]).toEqual({ sync: false, inputMode: 'plates' })
+      // Pull-ups has no plate calculator — just sync: false
+      expect(calls.find((c: unknown[]) => c[0] === 'Pull-ups')?.[2]).toEqual({ sync: false })
     })
   })
 
@@ -230,10 +228,10 @@ describe('OnboardingScreen', () => {
     it('chooseExplore passes sync:false to addExercise for sample data', async () => {
       mockAddExercise.mockReturnValue('mock-id')
       await wrapper.findAll('.obOption')[2].trigger('click')
-      // Every addExercise call in chooseExplore should include { sync: false }
+      // Every addExercise call in chooseExplore should include sync: false
       const exploreCalls = mockAddExercise.mock.calls
       for (const call of exploreCalls) {
-        expect(call[2]).toEqual({ sync: false })
+        expect(call[2]).toHaveProperty('sync', false)
       }
     })
 
@@ -241,8 +239,10 @@ describe('OnboardingScreen', () => {
       await wrapper.findAll('.obOption')[1].trigger('click')
       const starterCalls = mockAddExercise.mock.calls
       for (const call of starterCalls) {
-        // Starter exercises only pass (name, tags) — no options object
-        expect(call.length).toBe(2)
+        // Starter exercises should not have sync: false
+        if (call[2]) {
+          expect(call[2]).not.toHaveProperty('sync', false)
+        }
       }
     })
 

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -406,7 +406,7 @@ export const useWorkoutStore = defineStore('workout', {
       }
     },
 
-    addExercise(name: string, tags: string[] = [], { sync = true }: { sync?: boolean } = {}): string | null {
+    addExercise(name: string, tags: string[] = [], { sync = true, inputMode }: { sync?: boolean; inputMode?: ExerciseInputMode } = {}): string | null {
       const trimmed = name.trim()
       if (!trimmed) return null
       const existing = this.exercises.find(
@@ -414,7 +414,7 @@ export const useWorkoutStore = defineStore('workout', {
       )
       if (existing) return existing.id
       const id = uuid()
-      const exercise: Exercise = { id, name: trimmed, tags: [...tags], sets: [], updated_at: new Date().toISOString(), ...(!sync ? { sample: true } : {}) }
+      const exercise: Exercise = { id, name: trimmed, tags: [...tags], sets: [], updated_at: new Date().toISOString(), ...(!sync ? { sample: true } : {}), ...(inputMode ? { inputMode } : {}) }
       this.exercises.push(exercise)
       this._persist()
 


### PR DESCRIPTION
## Summary



## Changes




## Commits
- [`c52211b`](https://github.com/aschung212/Lift/commit/c52211b) refactor(onboarding): pass inputMode through addExercise to ensure persistence
- [`e31057d`](https://github.com/aschung212/Lift/commit/e31057d) feat(onboarding): enable plate calculator on barbell sample exercises (closes #389)

## Test Results
- Before: 1301 passing
- After: 1303 passing (2 delta)

---
_Automated by overnight pipeline — Fri Apr 24 23:43:56 PDT 2026_

## Preview
Test on your phone: https://lift-30wjwivyt-aschung212-1101s-projects.vercel.app