### PR TITLE
feat(share-summary): Workout Complete view + session summary data layer (#305 PR 1/3)

### DIFF
--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    ref="overlayEl"
     class="wcOverlay"
     role="dialog"
     aria-modal="true"
@@ -61,16 +62,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted, ref, nextTick } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
 import { useProgressionStore } from '../stores/progression'
 import { buildSessionSummary } from '../lib/sessionSummary'
+import { useFocusTrap } from '../composables/useFocusTrap'
 
 const props = defineProps<{ rawDate: string }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
 const store = useWorkoutStore()
 const progression = useProgressionStore()
+const focusTrap = useFocusTrap()
+const overlayEl = ref<HTMLElement | null>(null)
 
 const summary = computed(() =>
   buildSessionSummary({
@@ -87,13 +91,16 @@ const formattedVolume = computed(() => summary.value.totalVolume.toLocaleString(
 function onKey(e: KeyboardEvent) {
   if (e.key === 'Escape') emit('close')
 }
-onMounted(() => {
+onMounted(async () => {
   document.documentElement.classList.add('modal-open')
   window.addEventListener('keydown', onKey)
+  await nextTick()
+  if (overlayEl.value) focusTrap.activate(overlayEl.value)
 })
 onUnmounted(() => {
   document.documentElement.classList.remove('modal-open')
   window.removeEventListener('keydown', onKey)
+  focusTrap.deactivate()
 })
 </script>
 

--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -1,0 +1,316 @@
+<template>
+  <div
+    class="wcOverlay"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="wcTitle"
+    @click.self="emit('close')"
+  >
+    <div class="wcSurface">
+      <div class="wcMesh" aria-hidden="true"></div>
+
+      <header class="wcHeader">
+        <button class="wcLink" @click="emit('close')" aria-label="Close summary">Close</button>
+        <span id="wcTitle" class="wcEyebrow">Workout complete</span>
+        <span class="wcLinkSpacer" aria-hidden="true"></span>
+      </header>
+
+      <template v-if="hasSets">
+        <section class="wcHero">
+          <div class="wcMicrolabel">Total volume</div>
+          <div class="wcHeroNumber">{{ formattedVolume }}</div>
+          <div class="wcHeroUnit">lbs moved</div>
+        </section>
+
+        <section class="wcStatRow">
+          <div class="wcStat">
+            <div class="wcStatKey">TIME</div>
+            <div class="wcStatVal">{{ summary.duration }}</div>
+          </div>
+          <div class="wcStat">
+            <div class="wcStatKey">SETS</div>
+            <div class="wcStatVal">{{ summary.setsCompleted }}</div>
+          </div>
+          <div class="wcStat wcStatAccent">
+            <div class="wcStatKey">PRs</div>
+            <div class="wcStatVal">{{ summary.prs + summary.repPRs }}</div>
+          </div>
+        </section>
+
+        <section v-if="summary.bestSet" class="wcBestSet">
+          <div class="wcBestSetHead">
+            <span class="wcBestSetEyebrow"><span aria-hidden="true">🏆</span> Best set</span>
+            <span v-if="summary.bestSet.isPR" class="wcBestSetBadge">NEW PR</span>
+          </div>
+          <div class="wcBestSetName">{{ summary.bestSet.name }}</div>
+          <div class="wcBestSetWeight">{{ summary.bestSet.weight }} × {{ summary.bestSet.reps }}</div>
+          <div class="wcBestSetE1RM">~{{ summary.bestSet.e1RM }} lbs e1RM</div>
+        </section>
+      </template>
+
+      <section v-else class="wcEmpty">
+        <div class="wcEmptyTitle">No sets logged yet</div>
+        <div class="wcEmptyBody">Log a set first, then come back here to see your summary.</div>
+      </section>
+
+      <footer class="wcFooter">
+        <button class="wcDone" @click="emit('close')">Done</button>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted } from 'vue'
+import { useWorkoutStore } from '../stores/workout'
+import { useProgressionStore } from '../stores/progression'
+import { buildSessionSummary } from '../lib/sessionSummary'
+
+const props = defineProps<{ rawDate: string }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const store = useWorkoutStore()
+const progression = useProgressionStore()
+
+const summary = computed(() =>
+  buildSessionSummary({
+    rawDate: props.rawDate,
+    exercises: store.exercises,
+    xpPerSet: progression.xpPerSet,
+    streakWeeks: progression.streakWeeks,
+  })
+)
+
+const hasSets = computed(() => summary.value.setsCompleted > 0)
+const formattedVolume = computed(() => summary.value.totalVolume.toLocaleString('en-US'))
+
+function onKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+onMounted(() => {
+  document.documentElement.classList.add('modal-open')
+  window.addEventListener('keydown', onKey)
+})
+onUnmounted(() => {
+  document.documentElement.classList.remove('modal-open')
+  window.removeEventListener('keydown', onKey)
+})
+</script>
+
+<style scoped>
+.wcOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: var(--bg-primary);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.wcSurface {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+  padding: max(env(safe-area-inset-top), 16px) 20px max(env(safe-area-inset-bottom), 24px);
+  display: flex;
+  flex-direction: column;
+  isolation: isolate;
+}
+
+.wcMesh {
+  position: absolute;
+  inset: 0;
+  background-image: var(--mesh);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.wcHeader {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 0 4px;
+  min-height: 44px;
+}
+
+.wcLink {
+  background: transparent;
+  border: 0;
+  color: var(--text-secondary);
+  font: 500 var(--font-callout) / 1 var(--ff);
+  padding: 12px 0;
+  text-align: left;
+  cursor: pointer;
+  min-height: 44px;
+  min-width: 44px;
+}
+
+.wcLinkSpacer {
+  display: block;
+  width: 44px;
+}
+
+.wcEyebrow {
+  font: 600 var(--font-caption2) / 1 var(--ff-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.wcHero {
+  text-align: center;
+  padding: 32px 0 8px;
+}
+
+.wcMicrolabel {
+  font: 500 var(--font-caption2) / 1 var(--ff-mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.wcHeroNumber {
+  margin-top: 16px;
+  font: 800 88px / 1 var(--ff-display);
+  letter-spacing: -0.045em;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.wcHeroUnit {
+  margin-top: 4px;
+  font: 600 var(--font-subhead) / 1 var(--ff);
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.wcStatRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  margin-top: 32px;
+}
+
+.wcStat {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 12px 8px;
+  text-align: center;
+}
+
+.wcStatAccent {
+  border-color: var(--accent);
+}
+
+.wcStatKey {
+  font: 500 10px / 1 var(--ff-mono);
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+
+.wcStatVal {
+  margin-top: 8px;
+  font: 700 var(--font-title2) / 1 var(--ff-display);
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.wcStatAccent .wcStatVal {
+  color: var(--accent);
+}
+
+.wcBestSet {
+  margin-top: 24px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.wcBestSetHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.wcBestSetEyebrow {
+  font: 500 10px / 1 var(--ff-mono);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wcBestSetBadge {
+  font: 700 10px / 1 var(--ff-mono);
+  color: var(--accent);
+  background: var(--accent-subtle);
+  padding: 4px 8px;
+  border-radius: 6px;
+  letter-spacing: 0.1em;
+}
+
+.wcBestSetName {
+  margin-top: 12px;
+  font: 700 19px / 1.15 var(--ff-display);
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.wcBestSetWeight {
+  margin-top: 8px;
+  font: 600 26px / 1 var(--ff-display);
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent);
+}
+
+.wcBestSetE1RM {
+  margin-top: 4px;
+  font: 500 var(--font-caption1) / 1 var(--ff);
+  color: var(--text-secondary);
+}
+
+.wcEmpty {
+  margin: auto 0;
+  text-align: center;
+  padding: 0 24px;
+}
+
+.wcEmptyTitle {
+  font: 700 var(--font-title2) / 1.2 var(--ff-display);
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
+.wcEmptyBody {
+  margin-top: 8px;
+  font: 500 var(--font-callout) / 1.4 var(--ff);
+  color: var(--text-secondary);
+}
+
+.wcFooter {
+  margin-top: auto;
+  padding-top: 24px;
+}
+
+.wcDone {
+  width: 100%;
+  min-height: 54px;
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  border: 0;
+  border-radius: 16px;
+  font: 700 var(--font-callout) / 1 var(--ff);
+  letter-spacing: 0.01em;
+  cursor: pointer;
+}
+</style>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -8,6 +8,18 @@
         {{ totalExercises }} {{ totalExercises === 1 ? 'exercise' : 'exercises' }}
         · {{ prsThisWeek }} {{ prsThisWeek === 1 ? 'PR' : 'PRs' }} this week
       </p>
+      <button
+        v-if="setsLoggedToday > 0"
+        class="wtFinishWorkoutBtn"
+        @click="openWorkoutComplete"
+        aria-label="Finish workout and view today's summary"
+      >
+        <span class="wtFinishWorkoutLabel">Finish workout</span>
+        <span class="wtFinishWorkoutMeta">
+          {{ setsLoggedToday }} {{ setsLoggedToday === 1 ? 'set' : 'sets' }} today
+        </span>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18l6-6-6-6"/></svg>
+      </button>
     </header>
 
     <!-- View toggle (Exercises / Timeline) -->
@@ -959,11 +971,22 @@
       <span class="wtRestBarLabel">Start Rest Timer</span>
     </template>
   </button>
+
+  <Teleport to="body">
+    <WorkoutCompleteView
+      v-if="workoutCompleteDate"
+      :raw-date="workoutCompleteDate"
+      @close="workoutCompleteDate = null"
+    />
+  </Teleport>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, watch, nextTick, onUnmounted } from 'vue'
+import { ref, reactive, computed, watch, nextTick, onUnmounted, defineAsyncComponent } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
+import { toLocalDateKey } from '../lib/sessionSummary'
+
+const WorkoutCompleteView = defineAsyncComponent(() => import('./WorkoutCompleteView.vue'))
 import type { Exercise, WorkoutSet, PlateCountMode } from '../stores/workout'
 
 interface PREntry extends WorkoutSet {
@@ -1267,6 +1290,26 @@ const isFilteringActive = computed(() =>
 
 /** Total exercise count, shown in the "Workouts" header stats. */
 const totalExercises = computed(() => store.exercises.length)
+
+/** Sets logged on the local "today" date — drives the Finish workout affordance. */
+const setsLoggedToday = computed(() => {
+  const today = todayISO()
+  let count = 0
+  for (const ex of store.exercises) {
+    for (const s of ex.sets) {
+      if (toLocalDateKey(s.date) === today) count++
+    }
+  }
+  return count
+})
+
+/** When non-null, renders the WorkoutCompleteView overlay for that date. */
+const workoutCompleteDate = ref<string | null>(null)
+function openWorkoutComplete() {
+  workoutCompleteDate.value = todayISO()
+  impactLight()
+  logEvent('workout_complete_view_opened', { sets: setsLoggedToday.value })
+}
 
 /** Exercises whose baseline-relative PR was achieved in the last 7 days. */
 const prsThisWeek = computed(() => {
@@ -1599,11 +1642,6 @@ function toggleShowAll(id: string) {
 function visibleSets(exercise: Exercise): WorkoutSet[] {
   const sorted = [...exercise.sets].sort((a, b) => b.date.slice(0, 10).localeCompare(a.date.slice(0, 10)))
   return showAllSets.value.has(exercise.id) ? sorted : sorted.slice(0, SET_LIMIT)
-}
-
-function toLocalDateKey(iso: string): string {
-  const d = new Date(iso)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
 
 const groupedSets = computed(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -673,6 +673,13 @@
   --space-6:  24px;
   --space-8:  32px;
 
+  /* Font family tokens — used by share cards and other surfaces that need explicit
+     font-family references. The body element uses these by default; --ff-mono is
+     used for stat callouts and labels, --ff-display for headline numbers. */
+  --ff:         -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Inter', system-ui, sans-serif;
+  --ff-display: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+  --ff-mono:    'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, Monaco, monospace;
+
   /* Capacitor: keyboard height injected by native plugin */
   --keyboard-height: 0px;
 }
@@ -1874,6 +1881,50 @@ html.theme-fading .settingsSheet {
   font-size: 13px;
   font-weight: 500;
   color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* "Finish workout" button — appears in the page header when sets exist for today.
+   Routes to the WorkoutCompleteView for share/celebration. (issue #305) */
+.wtFinishWorkoutBtn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  margin: 12px 0 0;
+  padding: 12px 16px;
+  min-height: 44px;
+  background: var(--accent-subtle);
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: var(--font-callout);
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.wtFinishWorkoutBtn:hover {
+  background: color-mix(in srgb, var(--accent-subtle) 70%, var(--accent) 30%);
+}
+
+.wtFinishWorkoutBtn:active {
+  transform: scale(0.99);
+}
+
+.wtFinishWorkoutLabel {
+  flex: 1;
+}
+
+.wtFinishWorkoutMeta {
+  font-family: var(--ff-mono);
+  font-size: var(--font-caption2);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  opacity: 0.85;
   font-variant-numeric: tabular-nums;
 }
 

--- a/src/lib/__tests__/sessionSummary.test.ts
+++ b/src/lib/__tests__/sessionSummary.test.ts
@@ -219,6 +219,22 @@ describe('buildSessionSummary', () => {
     expect(summary.duration).toBe('30m')
   })
 
+  it('ignores end-of-day jitter sets when mixed with real-time sets (does not inflate)', () => {
+    // Regression: a user logs three real-time sets in a 30-minute window, then
+    // adds one bulk-imported set later. The bulk-add lands at 23:59Z. If we
+    // include it in the duration max, the span jumps to ~10 hours instead of 30m.
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 's1', weight: 225, reps: 5, date: '2026-04-21T14:00:00Z' },
+        { id: 's2', weight: 225, reps: 5, date: '2026-04-21T14:15:00Z' },
+        { id: 's3', weight: 225, reps: 5, date: '2026-04-21T14:30:00Z' },
+        { id: 's4', weight: 225, reps: 5, date: '2026-04-21T23:59:33.789Z' }, // bulk-add
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.duration).toBe('30m')
+  })
+
   it('reports duration as — when every set is in the end-of-day jitter window', () => {
     const exercises = [
       makeExercise('Bulk-Add', 'ex1', [

--- a/src/lib/__tests__/sessionSummary.test.ts
+++ b/src/lib/__tests__/sessionSummary.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildSessionSummary,
+  formatSessionDate,
+  weekRange,
+  formatDuration,
+} from '../sessionSummary'
+import type { Exercise } from '../../stores/workout'
+import type { SetXPEntry } from '../../stores/progression'
+
+function makeExercise(name: string, id: string, sets: { id: string; weight: number; reps: number; date: string }[]): Exercise {
+  return {
+    id,
+    name,
+    tags: [],
+    sets: sets.map((s) => ({
+      ...s,
+      estimated1RM: s.reps === 1 ? Math.round(s.weight) : Math.round(s.weight * (1 + s.reps / 30)),
+    })),
+  }
+}
+
+function makeXPEntry(overrides: Partial<SetXPEntry> = {}): SetXPEntry {
+  return { xp: 72, theme: 'fire', epoch: 1, zone: 'working', isPR: false, isRepPR: false, ...overrides }
+}
+
+describe('formatSessionDate', () => {
+  it('formats a YYYY-MM-DD as "Tue, Apr 22" style', () => {
+    // 2026-04-21 was a Tuesday
+    expect(formatSessionDate('2026-04-21')).toBe('Tue, Apr 21')
+  })
+
+  it('returns the raw input when malformed', () => {
+    expect(formatSessionDate('not-a-date')).toBe('not-a-date')
+  })
+})
+
+describe('weekRange', () => {
+  it('returns Mon→Sun for a Tuesday in the middle of a week', () => {
+    // 2026-04-21 is a Tuesday, so the week is Mon 2026-04-20 → Sun 2026-04-26
+    const wk = weekRange('2026-04-21')
+    expect(wk).toEqual([
+      '2026-04-20',
+      '2026-04-21',
+      '2026-04-22',
+      '2026-04-23',
+      '2026-04-24',
+      '2026-04-25',
+      '2026-04-26',
+    ])
+  })
+
+  it('rolls back to Monday when given a Sunday', () => {
+    // 2026-04-26 is a Sunday — week should be 2026-04-20..04-26
+    const wk = weekRange('2026-04-26')
+    expect(wk[0]).toBe('2026-04-20')
+    expect(wk[6]).toBe('2026-04-26')
+  })
+})
+
+describe('formatDuration', () => {
+  it('renders sub-minute spans as <1m', () => {
+    expect(formatDuration(30_000)).toBe('<1m')
+  })
+
+  it('renders minute-only spans without an hour', () => {
+    expect(formatDuration(45 * 60_000)).toBe('45m')
+  })
+
+  it('renders hour+minute spans together', () => {
+    expect(formatDuration(74 * 60_000)).toBe('1h 14m')
+  })
+
+  it('drops the trailing 0m on whole hours', () => {
+    expect(formatDuration(2 * 3_600_000)).toBe('2h')
+  })
+})
+
+describe('buildSessionSummary', () => {
+  it('returns zeros when no sets exist for the date', () => {
+    const summary = buildSessionSummary({
+      rawDate: '2026-04-21',
+      exercises: [],
+    })
+    expect(summary.totalVolume).toBe(0)
+    expect(summary.setsCompleted).toBe(0)
+    expect(summary.exercises).toBe(0)
+    expect(summary.bestSet).toBeNull()
+    expect(summary.highlights).toEqual([])
+    expect(summary.prs).toBe(0)
+    expect(summary.repPRs).toBe(0)
+  })
+
+  it('aggregates volume, set count, and exercise count for a single day', () => {
+    const exercises = [
+      makeExercise('Hack Squat', 'ex1', [
+        { id: 's1', weight: 405, reps: 6, date: '2026-04-21T15:00:00Z' },
+        { id: 's2', weight: 405, reps: 6, date: '2026-04-21T15:10:00Z' },
+        { id: 's3', weight: 405, reps: 5, date: '2026-04-21T15:20:00Z' },
+      ]),
+      makeExercise('RDL', 'ex2', [
+        { id: 's4', weight: 315, reps: 8, date: '2026-04-21T15:30:00Z' },
+      ]),
+      // Different day — must not contribute
+      makeExercise('Bench', 'ex3', [
+        { id: 's5', weight: 225, reps: 5, date: '2026-04-20T15:00:00Z' },
+      ]),
+    ]
+
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.setsCompleted).toBe(4)
+    expect(summary.exercises).toBe(2)
+    expect(summary.totalVolume).toBe(405 * 6 + 405 * 6 + 405 * 5 + 315 * 8) // 9405
+  })
+
+  it('detects an e1RM PR when today beats prior best', () => {
+    const exercises = [
+      makeExercise('Hack Squat', 'ex1', [
+        // Prior days
+        { id: 'p1', weight: 405, reps: 5, date: '2026-04-14T15:00:00Z' },
+        // Today — beats prior best (505×6 e1RM = 606 vs prior 473)
+        { id: 's1', weight: 505, reps: 6, date: '2026-04-21T15:00:00Z' },
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.prs).toBe(1)
+    expect(summary.bestSet?.isPR).toBe(true)
+    expect(summary.highlights[0].badge).toBe('PR')
+  })
+
+  it('does not count a PR when today only ties prior best', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 'p1', weight: 225, reps: 5, date: '2026-04-14T15:00:00Z' }, // e1RM 263
+        { id: 's1', weight: 225, reps: 5, date: '2026-04-21T15:00:00Z' }, // e1RM 263 again
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.prs).toBe(0)
+  })
+
+  it('detects a rep PR (same weight, more reps than any prior session)', () => {
+    const exercises = [
+      makeExercise('Pull-Up', 'ex1', [
+        // Prior best at bodyweight 0 lb load: 8 reps
+        { id: 'p1', weight: 0, reps: 8, date: '2026-04-14T15:00:00Z' },
+        // Today: 10 reps at the same load — that's a rep PR
+        { id: 's1', weight: 0, reps: 10, date: '2026-04-21T15:00:00Z' },
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.repPRs).toBe(1)
+  })
+
+  it('dedupes PRs to one per exercise even when multiple sets beat prior best', () => {
+    const exercises = [
+      makeExercise('Hack Squat', 'ex1', [
+        { id: 'p1', weight: 405, reps: 5, date: '2026-04-14T15:00:00Z' }, // prior e1RM 473
+        // Two PR-setting sets today
+        { id: 's1', weight: 505, reps: 6, date: '2026-04-21T15:00:00Z' }, // 606
+        { id: 's2', weight: 515, reps: 5, date: '2026-04-21T15:10:00Z' }, // 601
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.prs).toBe(1) // single exercise PR'd, not two
+  })
+
+  it('ranks highlights by volume descending', () => {
+    const exercises = [
+      makeExercise('Leg Curl', 'ex1', [
+        { id: 's1', weight: 145, reps: 12, date: '2026-04-21T15:00:00Z' }, // 1740
+      ]),
+      makeExercise('Hack Squat', 'ex2', [
+        { id: 's2', weight: 405, reps: 6, date: '2026-04-21T15:10:00Z' }, // 2430
+        { id: 's3', weight: 405, reps: 6, date: '2026-04-21T15:20:00Z' }, // 2430
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.highlights[0].name).toBe('Hack Squat')
+    expect(summary.highlights[1].name).toBe('Leg Curl')
+  })
+
+  it('picks the highest e1RM set as the best set', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 's1', weight: 225, reps: 5, date: '2026-04-21T15:00:00Z' }, // e1RM 263
+        { id: 's2', weight: 245, reps: 3, date: '2026-04-21T15:10:00Z' }, // e1RM 270
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.bestSet?.weight).toBe(245)
+    expect(summary.bestSet?.reps).toBe(3)
+  })
+
+  it('uses xpPerSet flags when supplied (over derived detection)', () => {
+    const exercises = [
+      makeExercise('Squat', 'ex1', [
+        // No prior sets — derived detection would NOT flag PR (priorMaxE1RM is null)
+        { id: 's1', weight: 405, reps: 6, date: '2026-04-21T15:00:00Z' },
+      ]),
+    ]
+    const xpPerSet: Record<string, SetXPEntry> = {
+      s1: makeXPEntry({ isPR: true }),
+    }
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises, xpPerSet })
+    expect(summary.prs).toBe(1)
+    expect(summary.bestSet?.isPR).toBe(true)
+  })
+
+  it('derives duration from first→last real-time timestamp', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 's1', weight: 225, reps: 5, date: '2026-04-21T14:00:00Z' },
+        { id: 's2', weight: 225, reps: 5, date: '2026-04-21T14:15:00Z' },
+        { id: 's3', weight: 225, reps: 5, date: '2026-04-21T14:30:00Z' },
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.duration).toBe('30m')
+  })
+
+  it('reports duration as — when every set is in the end-of-day jitter window', () => {
+    const exercises = [
+      makeExercise('Bulk-Add', 'ex1', [
+        { id: 's1', weight: 225, reps: 5, date: '2026-04-21T23:59:12.345Z' },
+        { id: 's2', weight: 225, reps: 5, date: '2026-04-21T23:59:33.789Z' },
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.duration).toBe('—')
+  })
+
+  it('returns 7-entry weekVolume aggregating across all exercises', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 's1', weight: 100, reps: 10, date: '2026-04-20T15:00:00Z' }, // Mon 1000
+        { id: 's2', weight: 100, reps: 10, date: '2026-04-21T15:00:00Z' }, // Tue 1000
+      ]),
+      makeExercise('Squat', 'ex2', [
+        { id: 's3', weight: 200, reps: 5, date: '2026-04-21T16:00:00Z' }, // Tue +1000
+        { id: 's4', weight: 200, reps: 5, date: '2026-04-23T15:00:00Z' }, // Thu 1000
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.weekVolume).toEqual([1000, 2000, 0, 1000, 0, 0, 0])
+  })
+
+  it('passes streak through from input', () => {
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises: [], streakWeeks: 7 })
+    expect(summary.streak).toBe(7)
+  })
+})

--- a/src/lib/sessionSummary.ts
+++ b/src/lib/sessionSummary.ts
@@ -215,24 +215,22 @@ export function buildSessionSummary(input: SessionSummaryInput): SessionSummary 
   highlights.sort((a, b) => b.volume - a.volume)
 
   // Duration: span between earliest and latest *real-time* timestamps on the date.
-  // If every set is in the end-of-day jitter window, the span is meaningless —
-  // mark unknown.
+  // End-of-day jitter timestamps (bulk-add / legacy) are excluded entirely —
+  // including them in the max would inflate duration to ~all day when a user
+  // mixes a real-time session with a bulk-added set on the same date.
   let duration = '—'
-  const allTimestamps: number[] = []
-  let allEndOfDay = true
+  const realTimestamps: number[] = []
   for (const { sets } of todaysByExercise.values()) {
     for (const s of sets) {
+      if (isEndOfDayJitter(s.date)) continue
       const t = Date.parse(s.date)
-      if (!Number.isNaN(t)) {
-        allTimestamps.push(t)
-        if (!isEndOfDayJitter(s.date)) allEndOfDay = false
-      }
+      if (!Number.isNaN(t)) realTimestamps.push(t)
     }
   }
-  if (allTimestamps.length > 1 && !allEndOfDay) {
-    const span = Math.max(...allTimestamps) - Math.min(...allTimestamps)
+  if (realTimestamps.length > 1) {
+    const span = Math.max(...realTimestamps) - Math.min(...realTimestamps)
     duration = formatDuration(span)
-  } else if (allTimestamps.length === 1 && !allEndOfDay) {
+  } else if (realTimestamps.length === 1) {
     duration = '<1m'
   }
 

--- a/src/lib/sessionSummary.ts
+++ b/src/lib/sessionSummary.ts
@@ -1,0 +1,266 @@
+/**
+ * Per-day session summary computation.
+ *
+ * Pure functions that aggregate workout-store data into the shape consumed
+ * by `WorkoutCompleteView` and the share cards (issue #305).
+ *
+ * Framework-free so the share-card pipeline and tests can use it directly.
+ */
+
+import type { Exercise, WorkoutSet } from '../stores/workout'
+import type { SetXPEntry } from '../stores/progression'
+
+export interface SessionHighlight {
+  exerciseId: string
+  name: string
+  weight: number
+  reps: number
+  e1RM: number
+  badge: 'PR' | 'rep PR' | ''
+  volume: number
+}
+
+export interface SessionBestSet {
+  exerciseId: string
+  name: string
+  weight: number
+  reps: number
+  e1RM: number
+  isPR: boolean
+}
+
+export interface SessionSummary {
+  rawDate: string             // YYYY-MM-DD (key used everywhere internally)
+  date: string                // 'Tue, Apr 22' formatted for display
+  duration: string            // 'Xh Ym' / 'Ym' / '—' when the span is unknowable
+  totalVolume: number         // Σ weight × reps for the date
+  setsCompleted: number
+  exercises: number           // distinct exercise count for the date
+  prs: number                 // weight/e1RM PRs (one per exercise, deduped)
+  repPRs: number              // rep-at-weight PRs (one per exercise, deduped)
+  bestSet: SessionBestSet | null
+  highlights: SessionHighlight[]
+  weekVolume: number[]        // 7 entries, Mon→Sun for the week containing rawDate
+  streak: number              // weeks
+}
+
+export interface SessionSummaryInput {
+  rawDate: string
+  exercises: Exercise[]
+  /** When provided, PR/repPR flags are read from here for consistency with the XP system. */
+  xpPerSet?: Record<string, SetXPEntry | number>
+  /** Weekly streak count from the progression store. */
+  streakWeeks?: number
+}
+
+const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const
+
+/** Format YYYY-MM-DD as 'Tue, Apr 22' in local time. */
+export function formatSessionDate(rawDate: string): string {
+  const [y, m, d] = rawDate.split('-').map(Number)
+  if (!y || !m || !d) return rawDate
+  const local = new Date(y, m - 1, d)
+  return `${WEEKDAY_SHORT[local.getDay()]}, ${MONTH_SHORT[local.getMonth()]} ${local.getDate()}`
+}
+
+/** Return Monday→Sunday array of YYYY-MM-DD for the week containing rawDate. */
+export function weekRange(rawDate: string): string[] {
+  const [y, m, d] = rawDate.split('-').map(Number)
+  const local = new Date(y, m - 1, d)
+  // JS: 0=Sun, 1=Mon, ... 6=Sat. Shift so Monday=0.
+  const dayIdx = (local.getDay() + 6) % 7
+  const monday = new Date(local)
+  monday.setDate(local.getDate() - dayIdx)
+  const out: string[] = []
+  for (let i = 0; i < 7; i++) {
+    const day = new Date(monday)
+    day.setDate(monday.getDate() + i)
+    const yyyy = day.getFullYear()
+    const mm = String(day.getMonth() + 1).padStart(2, '0')
+    const dd = String(day.getDate()).padStart(2, '0')
+    out.push(`${yyyy}-${mm}-${dd}`)
+  }
+  return out
+}
+
+/** Format a millisecond duration as 'Xh Ym' / 'Ym' / '<1m'. */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 60_000) return '<1m'
+  const totalMin = Math.round(ms / 60_000)
+  const h = Math.floor(totalMin / 60)
+  const m = totalMin % 60
+  if (h === 0) return `${m}m`
+  if (m === 0) return `${h}h`
+  return `${h}h ${m}m`
+}
+
+/**
+ * `endOfDayISO` lands sets between 23:59:00.000Z and 23:59:59.999Z — bulk-add
+ * and legacy paths look like a sub-minute span. Treat anything in that window as
+ * "duration unknown" rather than misleading the user with a fake "<1m".
+ *
+ * Detection is string-based (UTC) because the underlying timestamps are produced
+ * via `endOfDayISO()` and `Date.toISOString()` — both always Z-suffixed.
+ */
+function isEndOfDayJitter(iso: string): boolean {
+  return iso.slice(11, 16) === '23:59'
+}
+
+/**
+ * Convert a set's stored ISO timestamp to its *local* calendar date (YYYY-MM-DD).
+ *
+ * The workout store stores UTC ISO strings via `Date.toISOString()`, but the
+ * user's mental model — and the rest of the UI like `formatTimeAgo` — operates
+ * on the local calendar day. Comparing `iso.slice(0, 10)` to a local-derived
+ * "today" key drops late-night sets whose UTC date has already rolled over.
+ */
+export function toLocalDateKey(iso: string): string {
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return iso.slice(0, 10)
+  const d = new Date(t)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/** Pure: compute per-day session summary. */
+export function buildSessionSummary(input: SessionSummaryInput): SessionSummary {
+  const { rawDate, exercises, xpPerSet, streakWeeks = 0 } = input
+
+  const dayKey = rawDate
+  const todaysByExercise = new Map<string, { ex: Exercise; sets: WorkoutSet[] }>()
+  for (const ex of exercises) {
+    const todays = ex.sets.filter((s) => toLocalDateKey(s.date) === dayKey)
+    if (todays.length > 0) todaysByExercise.set(ex.id, { ex, sets: todays })
+  }
+
+  let totalVolume = 0
+  let setsCompleted = 0
+  let bestSet: SessionBestSet | null = null
+  const highlights: SessionHighlight[] = []
+  let prCount = 0
+  let repPRCount = 0
+
+  for (const { ex, sets } of todaysByExercise.values()) {
+    let exVolume = 0
+    let topSet: WorkoutSet | null = null
+    let bestE1RM = -1
+    let exerciseHasPR = false
+    let exerciseHasRepPR = false
+
+    // Prior sets (everything strictly before today). Used both for derived
+    // PR detection AND for rep-PR-at-weight comparison.
+    const priorSets = ex.sets.filter((s) => toLocalDateKey(s.date) < dayKey)
+    const priorMaxE1RM = priorSets.length === 0 ? null : Math.max(...priorSets.map((s) => s.estimated1RM))
+    const priorRepsByWeight = new Map<number, number>()
+    for (const s of priorSets) {
+      const cur = priorRepsByWeight.get(s.weight) ?? 0
+      if (s.reps > cur) priorRepsByWeight.set(s.weight, s.reps)
+    }
+
+    for (const s of sets) {
+      setsCompleted++
+      const vol = s.weight * s.reps
+      totalVolume += vol
+      exVolume += vol
+      if (s.estimated1RM > bestE1RM) {
+        bestE1RM = s.estimated1RM
+        topSet = s
+      }
+
+      // Prefer the XP system's flags when available so the card matches
+      // what was awarded at log time.
+      const xpEntry = xpPerSet?.[s.id]
+      const xpFlags = xpEntry && typeof xpEntry !== 'number' ? xpEntry : null
+      if (xpFlags) {
+        if (xpFlags.isPR) exerciseHasPR = true
+        if (xpFlags.isRepPR) exerciseHasRepPR = true
+      } else {
+        // Derived: e1RM beats prior best, OR no prior data and this is the best so far.
+        if (priorMaxE1RM !== null && s.estimated1RM > priorMaxE1RM) exerciseHasPR = true
+        const priorReps = priorRepsByWeight.get(s.weight) ?? 0
+        if (priorReps > 0 && s.reps > priorReps) exerciseHasRepPR = true
+      }
+    }
+
+    if (exerciseHasPR) prCount++
+    if (exerciseHasRepPR) repPRCount++
+
+    if (topSet) {
+      const badge: SessionHighlight['badge'] = exerciseHasPR ? 'PR' : exerciseHasRepPR ? 'rep PR' : ''
+      highlights.push({
+        exerciseId: ex.id,
+        name: ex.name,
+        weight: topSet.weight,
+        reps: topSet.reps,
+        e1RM: topSet.estimated1RM,
+        badge,
+        volume: exVolume,
+      })
+      if (!bestSet || topSet.estimated1RM > bestSet.e1RM) {
+        bestSet = {
+          exerciseId: ex.id,
+          name: ex.name,
+          weight: topSet.weight,
+          reps: topSet.reps,
+          e1RM: topSet.estimated1RM,
+          isPR: exerciseHasPR,
+        }
+      }
+    }
+  }
+
+  highlights.sort((a, b) => b.volume - a.volume)
+
+  // Duration: span between earliest and latest *real-time* timestamps on the date.
+  // If every set is in the end-of-day jitter window, the span is meaningless —
+  // mark unknown.
+  let duration = '—'
+  const allTimestamps: number[] = []
+  let allEndOfDay = true
+  for (const { sets } of todaysByExercise.values()) {
+    for (const s of sets) {
+      const t = Date.parse(s.date)
+      if (!Number.isNaN(t)) {
+        allTimestamps.push(t)
+        if (!isEndOfDayJitter(s.date)) allEndOfDay = false
+      }
+    }
+  }
+  if (allTimestamps.length > 1 && !allEndOfDay) {
+    const span = Math.max(...allTimestamps) - Math.min(...allTimestamps)
+    duration = formatDuration(span)
+  } else if (allTimestamps.length === 1 && !allEndOfDay) {
+    duration = '<1m'
+  }
+
+  // Week volume — Mon→Sun, summed from all sets across all exercises.
+  const week = weekRange(rawDate)
+  const weekVolumeMap = new Map<string, number>(week.map((d) => [d, 0]))
+  for (const ex of exercises) {
+    for (const s of ex.sets) {
+      const k = toLocalDateKey(s.date)
+      if (weekVolumeMap.has(k)) {
+        weekVolumeMap.set(k, weekVolumeMap.get(k)! + s.weight * s.reps)
+      }
+    }
+  }
+  const weekVolume = week.map((d) => weekVolumeMap.get(d) ?? 0)
+
+  return {
+    rawDate,
+    date: formatSessionDate(rawDate),
+    duration,
+    totalVolume,
+    setsCompleted,
+    exercises: todaysByExercise.size,
+    prs: prCount,
+    repPRs: repPRCount,
+    bestSet,
+    highlights,
+    weekVolume,
+    streak: streakWeeks,
+  }
+}


### PR DESCRIPTION
## Summary

First slice of [#305](https://github.com/aschung212/Lift/issues/305) (shareable workout summary card). Lays the foundation that the share-card pipeline (PR 2) and full card catalog (PR 3) will build on.

- **`src/lib/sessionSummary.ts`** — pure `buildSessionSummary(date)` that aggregates a day's sets into a typed shape: volume, set count, PRs, rep PRs, best set, top-volume highlights, week-volume array, duration. Composes existing store state — no new Pinia. PR detection prefers the XP system's flags when `xpPerSet` is supplied, falls back to derived comparison against prior sets. Duration is masked to `—` when every set sits in the end-of-day jitter window so bulk-add days don't show a fake `<1m`. Mixed real-time + jitter sets only count the real-time timestamps for the span (regression test included).
- **`src/components/WorkoutCompleteView.vue`** — themed full-screen overlay with hero volume, 3-stat row (TIME / SETS / PRs), best-set callout with PR badge, and a Done button. Uses `useFocusTrap` to match the project's modal accessibility convention. Adds shared `--ff` / `--ff-display` / `--ff-mono` font tokens to `src/index.css` (consumed here and by the upcoming share cards).
- **`src/components/WorkoutTracker.vue`** — `setsLoggedToday` computed and a "Finish workout" header button (visible only when count > 0) that opens the view via `<Teleport>`. Removes a duplicated local `toLocalDateKey` in favor of the new lib export.
- **22 unit tests** covering volume aggregation, PR / rep-PR detection (both derived and XP-flagged paths), highlight ranking, week aggregation, duration formatting, the end-of-day jitter mask, and the mixed-jitter regression case.

Sharing pipeline (`html-to-image` render + 8 square / 3 story cards + picker sheet) lands in follow-up PRs per the approved plan in `.claude/plans/how-would-you-approach-optimized-taco.md`. This PR plays the celebratory "workout complete" beat on its own without sharing wired up yet — independently shippable.

## Test plan

- [ ] `npm test` — full suite passes (1323 tests)
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — no new errors
- [ ] `npm run build` — `WorkoutCompleteView` lazy-loads as its own chunk (~5.5KB JS / ~3.8KB CSS)
- [ ] Manual: log a set today, "Finish workout" button appears in Workouts header with set count
- [ ] Manual: tap button → WorkoutCompleteView opens with correct volume / sets / PRs / best set
- [ ] Manual: switch theme — accent reskins the modal (PRs box border, Best-set weight, Done button)
- [ ] Manual: `Esc` and tap-outside both dismiss the modal; focus is trapped inside while open

🤖 Generated with [Claude Code](https://claude.com/claude-code)