### PR TITLE
feat(security): add Strict-Transport-Security header (closes #342)

### DIFF
--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -41,6 +41,7 @@ describe('vercel.json security headers', () => {
 
   describe('baseline headers still present', () => {
     it.each([
+      ['Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload'],
       ['X-Content-Type-Options', 'nosniff'],
       ['X-Frame-Options', 'DENY'],
       ['Referrer-Policy', 'strict-origin-when-cross-origin'],

--- a/vercel.json
+++ b/vercel.json
@@ -33,6 +33,7 @@
     {
       "source": "/(.*)",
       "headers": [
+        { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-342](https://github.com/aschung212/Lift/issues/342)

LIFT-342: Add `Strict-Transport-Security` header to `vercel.json` with `max-age=63072000; includeSubDomains; preload`. Zero-risk since the app is already HTTPS-only, and it future-proofs for custom domain migration.

## Changes
- Added HSTS header to the global `/(.*)`  header rule in `vercel.json`
- Added regression test pinning the HSTS value in `vercelHeadersRegression.test.ts`

## Verification

### Steps to test
1. Open the Vercel preview URL in Safari on iPhone
2. Open Safari Developer Tools (from Mac) → Network tab
3. Reload the page and inspect response headers on the HTML document
4. Verify `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` is present

### Expected behavior
The HSTS header should appear in the response headers for all resources. The app should behave identically to before — no visual or functional changes.

### What to watch for
- Verify the header doesn't conflict with Vercel's auto-served HSTS on `*.vercel.app` (it shouldn't — explicit headers take precedence)
- Ensure no other security headers were accidentally removed (the regression tests cover this)

### Risk assessment
- **Scope:** Narrow — only adds a response header via Vercel config, no app code changes
- **Confidence:** High — HSTS on an HTTPS-only site is a no-op that becomes useful on custom domain migration
- **Rollback:** Revert the single commit or remove the one line from `vercel.json`

## Commits
- [`6d6f962`](https://github.com/aschung212/Lift/commit/6d6f962) feat(security): add Strict-Transport-Security header (closes #342)

## Test Results
- Before: 1301 passing
- After: 1302 passing (1 delta)

---
_Automated by overnight pipeline — Fri Apr 24 23:49:09 PDT 2026_

## Preview
Test on your phone: https://lift-220u7zf9j-aschung212-1101s-projects.vercel.app