### PR TITLE
fix(security): gate source maps on Sentry and remove .map redirect (cl

### DIFF
--- a/src/lib/__tests__/sourcemapRegression.test.ts
+++ b/src/lib/__tests__/sourcemapRegression.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Regression test for LIFT-341: source maps must never be generated
+ * unconditionally. They should only be built when Sentry is configured
+ * (SENTRY_AUTH_TOKEN is set), because the Sentry plugin uploads them
+ * and then deletes them from the build output.
+ *
+ * Generating source maps without Sentry means they ship to production,
+ * exposing the full source code to anyone who requests .map files.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('vite.config.js sourcemap setting (LIFT-341)', () => {
+  const configPath = resolve(__dirname, '../../../vite.config.js')
+  const configSource = readFileSync(configPath, 'utf8')
+
+  it('does not unconditionally enable sourcemaps', () => {
+    // sourcemap: true would generate maps even without Sentry
+    expect(configSource).not.toMatch(/sourcemap:\s*true/)
+  })
+
+  it('gates sourcemap generation on SENTRY_AUTH_TOKEN', () => {
+    expect(configSource).toMatch(/sourcemap:.*SENTRY_AUTH_TOKEN/)
+  })
+})

--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -15,8 +15,15 @@ interface HeaderRule {
   headers: Array<{ key: string; value: string }>
 }
 
+interface RedirectRule {
+  source: string
+  destination: string
+  statusCode?: number
+}
+
 interface VercelConfig {
   headers?: HeaderRule[]
+  redirects?: RedirectRule[]
 }
 
 function loadVercelConfig(): VercelConfig {
@@ -113,6 +120,22 @@ describe('vercel.json security headers', () => {
       expect(csp).toMatch(/img-src\s+[^;]*'self'/)
       expect(csp).toMatch(/img-src\s+[^;]*data:/)
       expect(csp).toMatch(/img-src\s+[^;]*blob:/)
+    })
+  })
+
+  describe('source map exposure prevention (LIFT-341)', () => {
+    it('does not redirect .map requests with a 404 (leaks bundler info)', () => {
+      const mapRedirect = (config.redirects || []).find(
+        r => r.source.includes('.map') && r.statusCode === 404
+      )
+      expect(mapRedirect).toBeUndefined()
+    })
+
+    it('does not serve .map files via any redirect rule', () => {
+      const mapRedirects = (config.redirects || []).filter(r =>
+        r.source.includes('.map')
+      )
+      expect(mapRedirects).toHaveLength(0)
     })
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -41,11 +41,5 @@
       ]
     }
   ],
-  "redirects": [
-    {
-      "source": "/(.*).map",
-      "destination": "/",
-      "statusCode": 404
-    }
-  ]
+  "redirects": []
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   build: {
     target: 'es2022',
-    sourcemap: true,
+    sourcemap: !!process.env.SENTRY_AUTH_TOKEN,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-341](https://github.com/aschung212/Lift/issues/341)

LIFT-341: Source maps were unconditionally generated and deployed, then blocked by a `.map` → 404 redirect that leaked bundler information. Fix by gating sourcemap generation on `SENTRY_AUTH_TOKEN` (Sentry uploads + deletes them) and removing the redirect entirely.

## Changes
- **vite.config.js**: Changed `sourcemap: true` to `sourcemap: !!process.env.SENTRY_AUTH_TOKEN` — maps only generated when Sentry will upload and delete them
- **vercel.json**: Removed the `/(.*).map` → 404 redirect — no maps deployed means no redirect needed, and no information leakage
- **vercelHeadersRegression.test.ts**: Added 2 tests ensuring no `.map` redirect rules exist
- **sourcemapRegression.test.ts**: New file with 2 tests pinning sourcemap to be conditional on `SENTRY_AUTH_TOKEN`

## Verification

### Steps to test
1. Open the Vercel preview deployment in a browser
2. Open DevTools → Network tab
3. Navigate to the app — observe that JS bundles load normally
4. Try requesting any JS bundle URL with `.map` appended (e.g., append `.map` to any `/assets/*.js` URL)
5. Verify the request returns the SPA fallback (index.html) with a 200, not a 404

### Expected behavior
- The app loads and functions identically to production
- `.map` file requests return the SPA fallback (200) since the rewrite catches all routes — no special 404 that reveals "we know about source maps"
- No `.map` files exist in the deployed assets

### What to watch for
- Sentry error tracking still works in production (source maps should still be uploaded via the Sentry plugin when SENTRY_AUTH_TOKEN is set in Vercel env vars)
- No regressions in the build output (bundle sizes should be the same or slightly smaller without maps)
- DevTools "Sources" tab should not show original source files

### Risk assessment
- **Scope:** Narrow — build config and Vercel routing only, no runtime code changes
- **Confidence:** High — the Sentry plugin's `filesToDeleteAfterUpload` already handles cleanup when configured; we're just preventing generation when it's not
- **Rollback:** Revert one commit to restore `sourcemap: true` and the redirect

## Commits
- [`aedc58c`](https://github.com/aschung212/Lift/commit/aedc58c) fix(security): gate source maps on Sentry and remove .map redirect (closes #341)

## Test Results
- Before: 1301 passing
- After: 1305 passing (4 delta)

---
_Automated by overnight pipeline — Fri Apr 24 23:55:33 PDT 2026_

## Preview
Test on your phone: https://lift-6qcksrzwy-aschung212-1101s-projects.vercel.app