### PR TITLE
fix(#389): sync input_mode to Supabase and enable plates for starter p

### DIFF
--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -443,7 +443,7 @@ function chooseStarter() {
   logEvent('onboarding_choice', { choice: 'starter' })
   emit('started')
   for (const ex of STARTER_EXERCISES) {
-    workoutStore.addExercise(ex.name, ex.tags)
+    workoutStore.addExercise(ex.name, ex.tags, ex.inputMode ? { inputMode: ex.inputMode } : undefined)
   }
   goToStarter(false)
 }

--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -83,6 +83,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
+import type { ExerciseInputMode } from '../stores/workout'
 import { useBodyweightStore } from '../stores/bodyweight'
 import { useProgressionStore } from '../stores/progression'
 import { useTheme, type ThemeId } from '../composables/useTheme'
@@ -98,12 +99,12 @@ const { logEvent } = useAnalytics()
 const step = ref<'setup' | 'starter-flow'>('setup')
 let pendingSampleData = false
 
-const STARTER_EXERCISES = [
-  { name: 'Bench Press', tags: ['Push', 'Chest'] },
-  { name: 'Squat', tags: ['Legs'] },
-  { name: 'Deadlift', tags: ['Pull', 'Legs'] },
-  { name: 'Overhead Press', tags: ['Push', 'Shoulders'] },
-  { name: 'Barbell Row', tags: ['Pull', 'Back'] },
+const STARTER_EXERCISES: Array<{ name: string; tags: string[]; inputMode?: ExerciseInputMode }> = [
+  { name: 'Bench Press', tags: ['Push', 'Chest'], inputMode: 'plates' },
+  { name: 'Squat', tags: ['Legs'], inputMode: 'plates' },
+  { name: 'Deadlift', tags: ['Pull', 'Legs'], inputMode: 'plates' },
+  { name: 'Overhead Press', tags: ['Push', 'Shoulders'], inputMode: 'plates' },
+  { name: 'Barbell Row', tags: ['Pull', 'Back'], inputMode: 'plates' },
   { name: 'Pull-ups', tags: ['Pull', 'Back'] },
 ]
 
@@ -455,7 +456,8 @@ function chooseExplore() {
   // Add exercises with sample sets — skip Supabase sync for sample data (MAS-197)
   for (const group of SAMPLE_SETS) {
     const starter = STARTER_EXERCISES.find(e => e.name === group.exercise)
-    const id = workoutStore.addExercise(group.exercise, starter?.tags || [], noSync)
+    const opts = { sync: false, ...(starter?.inputMode ? { inputMode: starter.inputMode } : {}) }
+    const id = workoutStore.addExercise(group.exercise, starter?.tags || [], opts)
     if (!id) continue
     for (const set of group.sets) {
       workoutStore.logSet(id, set.weight, set.reps, set.date, noSync)
@@ -464,7 +466,8 @@ function chooseExplore() {
   // Add remaining starter exercises without sets
   for (const ex of STARTER_EXERCISES) {
     if (!SAMPLE_SETS.find(g => g.exercise === ex.name)) {
-      workoutStore.addExercise(ex.name, ex.tags, noSync)
+      const opts = { sync: false, ...(ex.inputMode ? { inputMode: ex.inputMode } : {}) }
+      workoutStore.addExercise(ex.name, ex.tags, opts)
     }
   }
   // Add sample bodyweight entries

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -123,16 +123,16 @@ describe('OnboardingScreen', () => {
   })
 
   describe('Popular exercises', () => {
-    it('adds 6 starter exercises with tags', async () => {
+    it('adds 6 starter exercises with tags and plate mode for barbell exercises', async () => {
       // Popular is the featured / first option after the 01-auth.png restyle.
       await wrapper.findAll('.obOption')[0].trigger('click')
       expect(mockAddExercise).toHaveBeenCalledTimes(6)
-      expect(mockAddExercise).toHaveBeenCalledWith('Bench Press', ['Push', 'Chest'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Squat', ['Legs'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Deadlift', ['Pull', 'Legs'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Overhead Press', ['Push', 'Shoulders'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Barbell Row', ['Pull', 'Back'])
-      expect(mockAddExercise).toHaveBeenCalledWith('Pull-ups', ['Pull', 'Back'])
+      expect(mockAddExercise).toHaveBeenCalledWith('Bench Press', ['Push', 'Chest'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Squat', ['Legs'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Deadlift', ['Pull', 'Legs'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Overhead Press', ['Push', 'Shoulders'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Barbell Row', ['Pull', 'Back'], { inputMode: 'plates' })
+      expect(mockAddExercise).toHaveBeenCalledWith('Pull-ups', ['Pull', 'Back'], undefined)
     })
 
     it('emits complete event after skipping starter', async () => {
@@ -234,11 +234,15 @@ describe('OnboardingScreen', () => {
     })
 
     it('chooseStarter does NOT pass sync:false (starter data should sync)', async () => {
-      await wrapper.findAll('.obOption')[1].trigger('click')
+      // Popular exercises is the featured / first option (index 0)
+      await wrapper.findAll('.obOption')[0].trigger('click')
       const starterCalls = mockAddExercise.mock.calls
+      expect(starterCalls.length).toBeGreaterThan(0)
       for (const call of starterCalls) {
-        // Starter exercises only pass (name, tags) — no options object
-        expect(call.length).toBe(2)
+        // Starter exercises should not have sync: false
+        if (call[2]) {
+          expect(call[2]).not.toHaveProperty('sync', false)
+        }
       }
     })
 

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -204,11 +204,33 @@ describe('OnboardingScreen', () => {
     it('chooseExplore passes sync:false to addExercise for sample data', async () => {
       mockAddExercise.mockReturnValue('mock-id')
       await wrapper.findAll('.obOption')[2].trigger('click')
-      // Every addExercise call in chooseExplore should include { sync: false }
+      // Every addExercise call in chooseExplore should include sync: false
       const exploreCalls = mockAddExercise.mock.calls
       for (const call of exploreCalls) {
-        expect(call[2]).toEqual({ sync: false })
+        expect(call[2]).toHaveProperty('sync', false)
       }
+    })
+
+    it('chooseExplore enables plate calculator on barbell sample exercises', async () => {
+      mockAddExercise.mockReturnValue('mock-id')
+      await wrapper.findAll('.obOption')[2].trigger('click')
+      const exploreCalls = mockAddExercise.mock.calls
+      const barbellExercises = ['Bench Press', 'Squat', 'Deadlift', 'Overhead Press', 'Barbell Row']
+      for (const call of exploreCalls) {
+        const name = call[0] as string
+        if (barbellExercises.includes(name)) {
+          expect(call[2]).toHaveProperty('inputMode', 'plates')
+        }
+      }
+    })
+
+    it('chooseExplore does not enable plate calculator on bodyweight exercises', async () => {
+      mockAddExercise.mockReturnValue('mock-id')
+      await wrapper.findAll('.obOption')[2].trigger('click')
+      const exploreCalls = mockAddExercise.mock.calls
+      const pullUpsCall = exploreCalls.find((call: unknown[]) => call[0] === 'Pull-ups')
+      // Pull-ups should not have inputMode set
+      expect(pullUpsCall?.[2]).not.toHaveProperty('inputMode')
     })
 
     it('chooseStarter does NOT pass sync:false (starter data should sync)', async () => {

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -57,6 +57,19 @@ describe('workout store', () => {
       expect(store.exercises).toHaveLength(1)
     })
 
+    it('sets inputMode when provided in options', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Bench Press', ['Push'], { inputMode: 'plates' })
+      expect(id).toBeTruthy()
+      expect(store.exercises[0].inputMode).toBe('plates')
+    })
+
+    it('does not set inputMode when not provided', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Pull-ups', ['Pull'])
+      expect(store.exercises[0].inputMode).toBeUndefined()
+    })
+
     it('persists to localStorage', () => {
       const store = useWorkoutStore()
       store.addExercise('Deadlift')

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -406,7 +406,7 @@ export const useWorkoutStore = defineStore('workout', {
       }
     },
 
-    addExercise(name: string, tags: string[] = [], { sync = true }: { sync?: boolean } = {}): string | null {
+    addExercise(name: string, tags: string[] = [], { sync = true, inputMode }: { sync?: boolean; inputMode?: ExerciseInputMode } = {}): string | null {
       const trimmed = name.trim()
       if (!trimmed) return null
       const existing = this.exercises.find(
@@ -414,7 +414,7 @@ export const useWorkoutStore = defineStore('workout', {
       )
       if (existing) return existing.id
       const id = uuid()
-      const exercise: Exercise = { id, name: trimmed, tags: [...tags], sets: [], updated_at: new Date().toISOString(), ...(!sync ? { sample: true } : {}) }
+      const exercise: Exercise = { id, name: trimmed, tags: [...tags], sets: [], updated_at: new Date().toISOString(), ...(!sync ? { sample: true } : {}), ...(inputMode ? { inputMode } : {}) }
       this.exercises.push(exercise)
       this._persist()
 

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -422,7 +422,8 @@ export const useWorkoutStore = defineStore('workout', {
         const userId = this._userId
         syncQueue.enqueue(`exercise:${id}`, () =>
           supabase!.from('exercises').upsert({
-            id, user_id: userId, name: trimmed, tags: [...tags]
+            id, user_id: userId, name: trimmed, tags: [...tags],
+            ...(inputMode ? { input_mode: inputMode } : {})
           })
         )
       }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-389](https://github.com/aschung212/Lift/issues/389)

LIFT-389: The "Explore First" onboarding path creates sample exercises but none had the plate calculator enabled, hiding one of Lift's differentiating features from demo users. Rest timer was already on by default.

## Changes
- Extended `addExercise` store action to accept optional `inputMode` in its options parameter
- Configured all 5 barbell exercises (Bench Press, Squat, Deadlift, OHP, Barbell Row) with `inputMode: 'plates'` in `STARTER_EXERCISES`; Pull-ups remain as numpad (bodyweight)
- Applied plate mode to both "Explore First" (sample data) and "Popular Exercises" onboarding paths
- Fixed Supabase upsert to include `input_mode` when provided (prevents cross-device data loss)
- Fixed false-positive test that was clicking "Start Empty" instead of "Popular Exercises"
- Added 4 new regression tests: 2 for store `addExercise` inputMode, 2 for onboarding plate config

## Verification

### Steps to test
1. Clear app data (Settings > Clear Data or use incognito) to trigger onboarding
2. Select "Explore first" to load sample data
3. Navigate to the Workouts tab
4. Tap on "Bench Press" to open the set logger
5. Observe that the plate calculator input mode is active (shows plate buttons, not a numpad)
6. Go back and tap "Pull-ups" — should show the standard numpad input
7. Repeat steps 1-2 but choose "Popular exercises" instead
8. Tap Bench Press — should also show plate calculator mode

### Expected behavior
- All barbell exercises (Bench Press, Squat, Deadlift, OHP, Barbell Row) show the plate calculator input when opening the set logger
- Pull-ups shows the standard numpad input
- Rest timer is visible between sets (already was by default)
- Both "Explore First" and "Popular Exercises" paths apply plate mode

### What to watch for
- Plate calculator rendering correctly across all 10 themes
- Weight display showing correct plate breakdown for sample set weights
- Switching between exercises doesn't carry over input mode incorrectly
- The plate mode persists after closing and reopening the app
- Exercises created manually after onboarding should default to numpad (not plates)

### Risk assessment
- **Scope:** Narrow — onboarding flow and exercise creation only
- **Confidence:** High — the change is data-only (setting a config flag on exercise objects), no UI changes
- **Rollback:** Simple revert of the commit; exercises already created with plates mode can be toggled back manually

## Commits
- [`2f2a111`](https://github.com/aschung212/Lift/commit/2f2a111) fix(#389): sync input_mode to Supabase and enable plates for starter path
- [`6e7dd21`](https://github.com/aschung212/Lift/commit/6e7dd21) feat(#389): enable plate calculator on barbell sample exercises in onboarding

## Test Results
- Before: 1301 passing
- After: 1305 passing (4 delta)

---
_Automated by overnight pipeline — Sat Apr 25 00:06:32 PDT 2026_

## Preview
Test on your phone: https://lift-ibvigr5nc-aschung212-1101s-projects.vercel.app