### PR TITLE
fix(#388): preserve entered weight when enabling plate mode from setti

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2961,7 +2961,13 @@ function confirmEditExercise() {
     }
   }
   editTarget.value = null
-  syncPlateWeight()
+  // When switching to plate mode, reverse-sync the current weight into
+  // plates so the user's entered value is preserved (LIFT-388 review fix).
+  if (editPlateMode.value && weight.value) {
+    syncPlatesFromWeight()
+  } else {
+    syncPlateWeight()
+  }
   logEvent('exercise_edit')
 }
 

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -687,6 +687,20 @@
             </div>
           </div>
 
+          <!-- One-time hint: plate calculator discoverability (LIFT-388) -->
+          <div
+            v-if="showPlateHint"
+            class="wtPlateHint"
+            role="button"
+            tabindex="0"
+            @click="openSettingsFromHint"
+            @keydown.enter="openSettingsFromHint"
+          >
+            <svg class="wtPlateHintIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+            <span class="wtPlateHintText">Tip: Enable the plate calculator in exercise settings</span>
+            <button class="wtPlateHintDismiss" @click.stop="dismissPlateHint" aria-label="Dismiss hint">×</button>
+          </div>
+
           <!--
             Plate calculator (shown when exercise is in plates mode).
             Matches screens/05-logset-platecalc.png:
@@ -1705,6 +1719,28 @@ const plateMode = computed(() => {
   return ex?.inputMode === 'plates'
 })
 const plateNumpadOverride = ref(false)
+
+// ── Plate calculator hint (LIFT-388) ────────────────────────────
+const PLATE_HINT_KEY = 'plate-calc-hint-dismissed'
+const plateHintDismissed = ref(!!localStorage.getItem(PLATE_HINT_KEY))
+
+const showPlateHint = computed(() =>
+  !plateHintDismissed.value &&
+  !plateMode.value &&
+  !isEditMode.value &&
+  isLogForExercise.value
+)
+
+function dismissPlateHint() {
+  plateHintDismissed.value = true
+  localStorage.setItem(PLATE_HINT_KEY, 'true')
+}
+
+function openSettingsFromHint() {
+  dismissPlateHint()
+  const ex = store.exercises.find(e => e.id === selectedExerciseId.value)
+  if (ex) openEditExerciseModal(ex)
+}
 
 function adjustReps(delta: number) {
   const current = reps.value ?? 0

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -716,6 +716,54 @@ describe('WorkoutTracker', () => {
       // and is now gone — the REPS card covers it.
       expect(wrapper.find('.wtRepsStepperFull').exists()).toBe(false)
     })
+
+    it('shows plate calculator hint for numpad-mode exercises (LIFT-388)', async () => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      // ex-1 is in default numpad mode (no inputMode set)
+      const wrapper = mountTracker()
+      const logBtns = wrapper.findAll('.wtExerciseLogBtn')
+      await logBtns[0].trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.wtPlateHint').exists()).toBe(true)
+      expect(wrapper.find('.wtPlateHintText').text()).toContain('plate calculator')
+    })
+
+    it('hides plate calculator hint when exercise is in plate mode (LIFT-388)', async () => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      exercises[0].inputMode = 'plates'
+      const wrapper = mountTracker()
+      const logBtns = wrapper.findAll('.wtExerciseLogBtn')
+      await logBtns[0].trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.wtPlateHint').exists()).toBe(false)
+    })
+
+    it('hides plate calculator hint after dismissal via localStorage (LIFT-388)', async () => {
+      localStorageMock.setItem('plate-calc-hint-dismissed', 'true')
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      const wrapper = mountTracker()
+      const logBtns = wrapper.findAll('.wtExerciseLogBtn')
+      await logBtns[0].trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.wtPlateHint').exists()).toBe(false)
+    })
+
+    it('dismiss button persists hint dismissal to localStorage (LIFT-388)', async () => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      const wrapper = mountTracker()
+      const logBtns = wrapper.findAll('.wtExerciseLogBtn')
+      await logBtns[0].trigger('click')
+      await wrapper.vm.$nextTick()
+
+      await wrapper.find('.wtPlateHintDismiss').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(localStorageMock.getItem('plate-calc-hint-dismissed')).toBe('true')
+      expect(wrapper.find('.wtPlateHint').exists()).toBe(false)
+    })
   })
 
   describe('exercise search', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -3919,6 +3919,52 @@ html.theme-fading .settingsSheet {
    loaded). The weight value itself is rendered by the WEIGHT card above
    the plate calc — this card is purely the picker chrome. */
 
+/* Plate calculator first-use hint (LIFT-388) */
+.wtPlateHint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin: 8px 0;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: opacity 0.2s;
+  text-align: left;
+  font-family: inherit;
+}
+
+.wtPlateHintIcon {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.wtPlateHintText {
+  flex: 1;
+  min-width: 0;
+  line-height: 1.3;
+}
+
+.wtPlateHintDismiss {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  cursor: pointer;
+  margin: -12px -8px -12px 0;
+  border-radius: 8px;
+}
+
 .wtPlateCalc {
   padding: 0;
 }


### PR DESCRIPTION
## Summary



## Changes




## Commits
- [`c4ca947`](https://github.com/aschung212/Lift/commit/c4ca947) fix(#388): preserve entered weight when enabling plate mode from settings
- [`ff04d33`](https://github.com/aschung212/Lift/commit/ff04d33) feat(#388): add contextual first-use hint for plate calculator discoverability

## Test Results
- Before: 1301 passing
- After: 1305 passing (4 delta)

---
_Automated by overnight pipeline — Sat Apr 25 00:20:09 PDT 2026_

## Preview
Test on your phone: https://lift-opgib4y7n-aschung212-1101s-projects.vercel.app