### PR TITLE
feat(manifest): add display_override fallback chain for future-proof d

### DIFF
--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -21,6 +21,12 @@ describe('PWA manifest regression tests', () => {
     })
   })
 
+  describe('manifest includes display_override for fallback chain', () => {
+    it('has display_override array with standalone and minimal-ui', () => {
+      expect(viteConfig).toContain("display_override: ['standalone', 'minimal-ui']")
+    })
+  })
+
   describe('manifest includes shortcuts for quick actions', () => {
     it('has shortcuts array defined', () => {
       expect(viteConfig).toContain('shortcuts: [')

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,7 @@ export default defineConfig({
         theme_color: '#0f0f0f',
         background_color: '#0f0f0f',
         display: 'standalone',
+        display_override: ['standalone', 'minimal-ui'],
         orientation: 'portrait',
         start_url: '/',
         categories: ['health', 'fitness', 'sports'],


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-328](https://github.com/aschung212/Lift/issues/328)

LIFT-328: Add `display_override` to the PWA manifest. This is a low-effort, zero-risk improvement that future-proofs the app for newer display modes and provides a proper fallback chain per the W3C spec.

## Changes
- Added `display_override: ['standalone', 'minimal-ui']` to the VitePWA manifest config in `vite.config.js`
- Added regression test in `manifestRegression.test.ts` pinning the `display_override` array

## Verification

### Steps to test
1. Open the Vercel preview URL on your iPhone
2. Check the generated manifest by navigating to `<preview-url>/manifest.webmanifest`
3. Verify the `display_override` field is present with `["standalone", "minimal-ui"]`
4. Add the app to Home Screen — verify it still launches in standalone mode (no browser chrome)

### Expected behavior
- Manifest contains both `display: "standalone"` and `display_override: ["standalone", "minimal-ui"]`
- App installs and runs identically to before — standalone mode with no browser chrome
- No visual or behavioral changes to the existing PWA experience

### What to watch for
- The manifest file should be valid JSON — check that no syntax errors were introduced
- Standalone mode should still work exactly as before on iOS Safari
- No regressions in PWA install flow

### Risk assessment
- **Scope:** Narrow — only the PWA manifest configuration
- **Confidence:** High — this is a declarative manifest field with no runtime code changes
- **Rollback:** Revert the single commit to remove `display_override`

## Commits
- [`e5f584e`](https://github.com/aschung212/Lift/commit/e5f584e) feat(manifest): add display_override fallback chain for future-proof display modes (closes #328)

## Test Results
- Before: 1301 passing
- After: 1302 passing (1 delta)

---
_Automated by overnight pipeline — Sat Apr 25 00:24:48 PDT 2026_

## Preview
Test on your phone: https://lift-lqjmsjmwz-aschung212-1101s-projects.vercel.app