### PR TITLE
feat(share-summary): rasterize + share pipeline + first 2 cards (#305 PR 2/3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,13 @@
         "@capacitor/haptics": "^8.0.2",
         "@capacitor/keyboard": "^8.0.3",
         "@capacitor/preferences": "^8.0.1",
+        "@capacitor/share": "^8.0.1",
         "@capacitor/status-bar": "^8.0.2",
         "@sentry/vue": "^10.50.0",
         "@supabase/supabase-js": "^2.104.1",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
+        "html-to-image": "^1.11.13",
         "pinia": "^3.0.4",
         "vue": "^3.5.33"
       },
@@ -1688,6 +1690,15 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/preferences/-/preferences-8.0.1.tgz",
       "integrity": "sha512-T6no3ebi79XJCk91U3Jp/liJUwgBdvHR+s6vhvPkPxSuch7z3zx5Rv1bdWM6sWruNx+pViuEGqZvbfCdyBvcHQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/share": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
+      "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
@@ -6491,6 +6502,12 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
       "license": "MIT"
     },
     "node_modules/https-proxy-agent": {

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "@capacitor/haptics": "^8.0.2",
     "@capacitor/keyboard": "^8.0.3",
     "@capacitor/preferences": "^8.0.1",
+    "@capacitor/share": "^8.0.1",
     "@capacitor/status-bar": "^8.0.2",
     "@sentry/vue": "^10.50.0",
     "@supabase/supabase-js": "^2.104.1",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
+    "html-to-image": "^1.11.13",
     "pinia": "^3.0.4",
     "vue": "^3.5.33"
   },

--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -20,7 +20,7 @@
         <section class="wcHero">
           <div class="wcMicrolabel">Total volume</div>
           <div class="wcHeroNumber">{{ formattedVolume }}</div>
-          <div class="wcHeroUnit">lbs moved</div>
+          <div class="wcHeroUnit">{{ summary.unitLabel }} moved</div>
         </section>
 
         <section class="wcStatRow">
@@ -45,7 +45,7 @@
           </div>
           <div class="wcBestSetName">{{ summary.bestSet.name }}</div>
           <div class="wcBestSetWeight">{{ summary.bestSet.weight }} × {{ summary.bestSet.reps }}</div>
-          <div class="wcBestSetE1RM">~{{ summary.bestSet.e1RM }} lbs e1RM</div>
+          <div class="wcBestSetE1RM">~{{ summary.bestSet.e1RM }} {{ summary.unitLabel }} e1RM</div>
         </section>
       </template>
 
@@ -77,6 +77,7 @@ import { useWorkoutStore } from '../stores/workout'
 import { useProgressionStore } from '../stores/progression'
 import { buildSessionSummary } from '../lib/sessionSummary'
 import { useFocusTrap } from '../composables/useFocusTrap'
+import { useTheme } from '../composables/useTheme'
 
 const SharePickerSheet = defineAsyncComponent(() => import('./share/SharePickerSheet.vue'))
 
@@ -92,6 +93,7 @@ const store = useWorkoutStore()
 const progression = useProgressionStore()
 const focusTrap = useFocusTrap()
 const overlayEl = ref<HTMLElement | null>(null)
+const { displayWeight, weightUnit } = useTheme()
 
 const summary = computed(() =>
   buildSessionSummary({
@@ -99,6 +101,8 @@ const summary = computed(() =>
     exercises: store.exercises,
     xpPerSet: progression.xpPerSet,
     streakWeeks: progression.streakWeeks,
+    toDisplayUnits: displayWeight,
+    unitLabel: weightUnit.value,
   })
 )
 
@@ -106,7 +110,13 @@ const hasSets = computed(() => summary.value.setsCompleted > 0)
 const formattedVolume = computed(() => summary.value.totalVolume.toLocaleString('en-US'))
 
 function onKey(e: KeyboardEvent) {
-  if (e.key === 'Escape') emit('close')
+  if (e.key !== 'Escape') return
+  // Single Escape owner for both layers — close the topmost open thing.
+  if (pickerOpen.value) {
+    pickerOpen.value = false
+    return
+  }
+  emit('close')
 }
 onMounted(async () => {
   document.documentElement.classList.add('modal-open')

--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -55,21 +55,38 @@
       </section>
 
       <footer class="wcFooter">
-        <button class="wcDone" @click="emit('close')">Done</button>
+        <button v-if="hasSets" class="wcShare" @click="openPicker">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7"/><path d="m16 6-4-4-4 4"/><path d="M12 2v13"/></svg>
+          Share summary
+        </button>
+        <button class="wcDone" :class="{ wcDoneSecondary: hasSets }" @click="emit('close')">Done</button>
       </footer>
     </div>
+
+    <SharePickerSheet
+      v-if="pickerOpen"
+      :summary="summary"
+      @close="pickerOpen = false"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, nextTick } from 'vue'
+import { computed, onMounted, onUnmounted, ref, nextTick, defineAsyncComponent } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
 import { useProgressionStore } from '../stores/progression'
 import { buildSessionSummary } from '../lib/sessionSummary'
 import { useFocusTrap } from '../composables/useFocusTrap'
 
+const SharePickerSheet = defineAsyncComponent(() => import('./share/SharePickerSheet.vue'))
+
 const props = defineProps<{ rawDate: string }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
+
+const pickerOpen = ref(false)
+function openPicker() {
+  pickerOpen.value = true
+}
 
 const store = useWorkoutStore()
 const progression = useProgressionStore()
@@ -307,6 +324,25 @@ onUnmounted(() => {
 .wcFooter {
   margin-top: auto;
   padding-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.wcShare {
+  width: 100%;
+  min-height: 54px;
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  border: 0;
+  border-radius: 16px;
+  font: 700 var(--font-callout) / 1 var(--ff);
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
 }
 
 .wcDone {
@@ -319,5 +355,13 @@ onUnmounted(() => {
   font: 700 var(--font-callout) / 1 var(--ff);
   letter-spacing: 0.01em;
   cursor: pointer;
+}
+
+.wcDoneSecondary {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-strong);
+  font-weight: 600;
+  min-height: 48px;
 }
 </style>

--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -109,18 +109,20 @@ async function onSave() {
   else if (res.kind === 'error') lastResult.value = 'Save failed — try again'
 }
 
-function onKey(e: KeyboardEvent) {
-  if (e.key === 'Escape') emit('close')
-}
+// Escape is owned by the parent (WorkoutCompleteView) — its single
+// listener routes Escape to either close-picker or close-view based on
+// whether the picker is open. Two listeners on window racing each other
+// to handle the same key is fragile with stopImmediatePropagation; one
+// owner is simpler and avoids closing the underlying summary by accident.
+//
+// `modal-open` is also owned by the parent. The picker doesn't toggle
+// it — doing so would re-enable background scroll the moment the picker
+// closes even though the parent is still up.
 onMounted(async () => {
-  document.documentElement.classList.add('modal-open')
-  window.addEventListener('keydown', onKey)
   await nextTick()
   if (overlayEl.value) focusTrap.activate(overlayEl.value)
 })
 onUnmounted(() => {
-  document.documentElement.classList.remove('modal-open')
-  window.removeEventListener('keydown', onKey)
   focusTrap.deactivate()
 })
 </script>

--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -1,0 +1,303 @@
+<template>
+  <div
+    ref="overlayEl"
+    class="spOverlay"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="spTitle"
+    @click.self="emit('close')"
+  >
+    <div class="spSheet" :style="{ paddingBottom: `max(env(safe-area-inset-bottom), 24px)` }">
+      <div class="spHandle" aria-hidden="true"></div>
+
+      <header class="spHeader">
+        <div class="spTitleBlock">
+          <h2 id="spTitle" class="spTitle">Pick a card</h2>
+          <p class="spSub">Same data, different vibe</p>
+        </div>
+        <span class="spCount">{{ activeIndex + 1 }} / {{ cards.length }}</span>
+      </header>
+
+      <div class="spThumbRow">
+        <button
+          v-for="(card, i) in cards"
+          :key="card.id"
+          :class="['spThumb', { spThumbActive: i === activeIndex }]"
+          :aria-pressed="i === activeIndex"
+          :aria-label="`Select ${card.label} card`"
+          @click="activeIndex = i"
+        >
+          <div class="spThumbCard">
+            <div class="spThumbInner">
+              <component :is="card.component" :summary="summary" />
+            </div>
+          </div>
+          <span class="spThumbLabel">{{ card.label }}</span>
+        </button>
+      </div>
+
+      <footer class="spActions">
+        <button
+          class="spActionPrimary"
+          :disabled="isSharing || !activeCard"
+          @click="onShare"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7"/><path d="m16 6-4-4-4 4"/><path d="M12 2v13"/></svg>
+          {{ isSharing ? 'Working…' : 'Share' }}
+        </button>
+        <button
+          class="spActionSecondary"
+          :disabled="isSharing || !activeCard"
+          @click="onSave"
+        >
+          Save image
+        </button>
+      </footer>
+
+      <p v-if="lastResult" class="spStatus" role="status">{{ lastResult }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, nextTick } from 'vue'
+import type { SessionSummary } from '../../lib/sessionSummary'
+import { eligibleSquareCards } from './cardRegistry'
+import { useWorkoutShare } from '../../composables/useWorkoutShare'
+import { useTheme } from '../../composables/useTheme'
+import { useFocusTrap } from '../../composables/useFocusTrap'
+
+const props = defineProps<{ summary: SessionSummary }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const overlayEl = ref<HTMLElement | null>(null)
+const focusTrap = useFocusTrap()
+const { currentTheme, resolvedMode } = useTheme()
+const { shareCard, downloadCard, isSharing } = useWorkoutShare()
+
+const cards = computed(() => eligibleSquareCards(props.summary))
+const activeIndex = ref(0)
+const activeCard = computed(() => cards.value[activeIndex.value] ?? null)
+const lastResult = ref<string | null>(null)
+
+async function onShare() {
+  if (!activeCard.value) return
+  lastResult.value = null
+  const res = await shareCard({
+    component: activeCard.value.component,
+    format: activeCard.value.format,
+    summary: props.summary,
+    theme: currentTheme.value,
+    mode: resolvedMode.value,
+  })
+  if (res.kind === 'downloaded') lastResult.value = `Saved ${res.filename}`
+  else if (res.kind === 'shared') emit('close')
+  else if (res.kind === 'error') lastResult.value = 'Share failed — try again'
+}
+
+async function onSave() {
+  if (!activeCard.value) return
+  lastResult.value = null
+  const res = await downloadCard({
+    component: activeCard.value.component,
+    format: activeCard.value.format,
+    summary: props.summary,
+    theme: currentTheme.value,
+    mode: resolvedMode.value,
+  })
+  if (res.kind === 'downloaded') lastResult.value = `Saved ${res.filename}`
+  else if (res.kind === 'error') lastResult.value = 'Save failed — try again'
+}
+
+function onKey(e: KeyboardEvent) {
+  if (e.key === 'Escape') emit('close')
+}
+onMounted(async () => {
+  document.documentElement.classList.add('modal-open')
+  window.addEventListener('keydown', onKey)
+  await nextTick()
+  if (overlayEl.value) focusTrap.activate(overlayEl.value)
+})
+onUnmounted(() => {
+  document.documentElement.classList.remove('modal-open')
+  window.removeEventListener('keydown', onKey)
+  focusTrap.deactivate()
+})
+</script>
+
+<style scoped>
+.spOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.spSheet {
+  width: 100%;
+  max-width: 520px;
+  background: var(--bg-secondary);
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
+  border-top: 1px solid var(--border-strong);
+  padding: 8px 0 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.spHandle {
+  margin: 8px auto 16px;
+  width: 36px;
+  height: 4px;
+  background: var(--border-strong);
+  border-radius: 4px;
+}
+
+.spHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0 20px 4px;
+}
+
+.spTitle {
+  margin: 0;
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-size: var(--font-title2);
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.spSub {
+  margin: 8px 0 0;
+  font-family: var(--ff);
+  font-weight: 500;
+  font-size: var(--font-footnote);
+  color: var(--text-secondary);
+}
+
+.spCount {
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.spThumbRow {
+  margin-top: 16px;
+  padding: 8px 16px 16px;
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+
+.spThumb {
+  flex: 0 0 auto;
+  scroll-snap-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.spThumbCard {
+  position: relative;
+  width: 220px;
+  height: 220px;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 2px solid transparent;
+  box-shadow: 0 8px 24px -8px rgba(0, 0, 0, 0.6);
+  transition: border-color 120ms ease;
+}
+
+.spThumbActive .spThumbCard {
+  border-color: var(--accent);
+}
+
+/* Cards are designed at 360x360 — render at full size and scale down for the
+   thumbnail. Same DOM the export pipeline uses, so what you see is what shares. */
+.spThumbInner {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 360px;
+  height: 360px;
+  transform: scale(0.6111);
+  transform-origin: top left;
+}
+
+.spThumbLabel {
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.spThumbActive .spThumbLabel {
+  color: var(--accent);
+}
+
+.spActions {
+  padding: 8px 20px 0;
+  display: flex;
+  gap: 12px;
+}
+
+.spActionPrimary,
+.spActionSecondary {
+  flex: 1;
+  min-height: 48px;
+  border-radius: 12px;
+  font-family: var(--ff);
+  font-weight: 600;
+  font-size: var(--font-callout);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.spActionPrimary {
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  border: 0;
+  font-weight: 700;
+}
+
+.spActionSecondary {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  border: 1px solid var(--border-strong);
+}
+
+.spActionPrimary:disabled,
+.spActionSecondary:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.spStatus {
+  margin: 12px 20px 0;
+  font-family: var(--ff);
+  font-size: var(--font-footnote);
+  color: var(--text-secondary);
+  text-align: center;
+}
+</style>

--- a/src/components/share/cardRegistry.ts
+++ b/src/components/share/cardRegistry.ts
@@ -1,0 +1,41 @@
+/**
+ * Catalog of share-card variants for issue #305.
+ *
+ * The picker UI iterates this registry to render thumbnails. The share flow
+ * looks up the component by id. New cards land here in subsequent PRs.
+ */
+
+import type { Component } from 'vue'
+import type { CardFormat } from '../../lib/shareImage'
+import type { SessionSummary } from '../../lib/sessionSummary'
+
+import BoldFloodCard from './cards/BoldFloodCard.vue'
+import BestSetCard from './cards/BestSetCard.vue'
+
+export interface CardEntry {
+  id: string
+  /** Short display name shown under the thumbnail. */
+  label: string
+  /** Square (1080×1080) or story (1080×1920). */
+  format: CardFormat
+  /** Returns false to hide this card given the current summary. */
+  eligible?: (summary: SessionSummary) => boolean
+  component: Component
+}
+
+export const SQUARE_CARDS: CardEntry[] = [
+  { id: 'bold-flood', label: 'Bold', format: 'square', component: BoldFloodCard },
+  { id: 'best-set', label: 'Best set', format: 'square', component: BestSetCard },
+]
+
+export const STORY_CARDS: CardEntry[] = []
+
+/** Returns the cards that should appear in the picker for this summary. */
+export function eligibleSquareCards(summary: SessionSummary): CardEntry[] {
+  return SQUARE_CARDS.filter((c) => !c.eligible || c.eligible(summary))
+}
+
+/** Look up a card by id, regardless of format bucket. */
+export function findCard(id: string): CardEntry | null {
+  return SQUARE_CARDS.find((c) => c.id === id) || STORY_CARDS.find((c) => c.id === id) || null
+}

--- a/src/components/share/cards/BestSetCard.vue
+++ b/src/components/share/cards/BestSetCard.vue
@@ -13,14 +13,14 @@
       <div class="bsNumberRow">
         <div class="bsWeight">{{ summary.bestSet.weight }}</div>
         <div class="bsRepsBlock">
-          <div class="bsRepsLabel">LBS &times;</div>
+          <div class="bsRepsLabel">{{ summary.unitLabel.toUpperCase() }} &times;</div>
           <div class="bsReps">{{ summary.bestSet.reps }}</div>
         </div>
       </div>
     </div>
 
     <div class="bsFoot">
-      <div class="bsE1RM" v-if="summary.bestSet">~{{ summary.bestSet.e1RM }} lbs e1RM</div>
+      <div class="bsE1RM" v-if="summary.bestSet">~{{ summary.bestSet.e1RM }} {{ summary.unitLabel }} e1RM</div>
       <div class="bsBrand">LIFT</div>
     </div>
   </div>

--- a/src/components/share/cards/BestSetCard.vue
+++ b/src/components/share/cards/BestSetCard.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="bsRoot">
+    <div class="bsHead">
+      <div class="bsHeadLeft">
+        <div class="bsEyebrow">Best set</div>
+        <div class="bsPRLabel">{{ prLabel }}</div>
+      </div>
+      <div class="bsDate">{{ summary.date }}</div>
+    </div>
+
+    <div v-if="summary.bestSet" class="bsHero">
+      <div class="bsName">{{ summary.bestSet.name }}</div>
+      <div class="bsNumberRow">
+        <div class="bsWeight">{{ summary.bestSet.weight }}</div>
+        <div class="bsRepsBlock">
+          <div class="bsRepsLabel">LBS &times;</div>
+          <div class="bsReps">{{ summary.bestSet.reps }}</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="bsFoot">
+      <div class="bsE1RM" v-if="summary.bestSet">~{{ summary.bestSet.e1RM }} lbs e1RM</div>
+      <div class="bsBrand">LIFT</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { SessionSummary } from '../../../lib/sessionSummary'
+
+const props = defineProps<{ summary: SessionSummary }>()
+
+const prLabel = computed(() => (props.summary.bestSet?.isPR ? 'New personal record' : 'Top set'))
+</script>
+
+<style scoped>
+.bsRoot {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-primary);
+  background-image: var(--mesh);
+  color: var(--text-primary);
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-family: var(--ff);
+}
+
+.bsHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.bsEyebrow {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.bsPRLabel {
+  margin-top: 4px;
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.bsDate {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+
+.bsName {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 30px;
+  line-height: 1;
+  letter-spacing: -0.025em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bsNumberRow {
+  margin-top: 16px;
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.bsWeight {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 68px;
+  line-height: 1;
+  letter-spacing: -0.05em;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent);
+}
+
+.bsRepsBlock {
+  display: flex;
+  flex-direction: column;
+}
+
+.bsRepsLabel {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.bsReps {
+  margin-top: 8px;
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 36px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+.bsFoot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.bsE1RM {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.bsBrand {
+  font-family: var(--ff-mono);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+}
+</style>

--- a/src/components/share/cards/BoldFloodCard.vue
+++ b/src/components/share/cards/BoldFloodCard.vue
@@ -1,0 +1,132 @@
+<template>
+  <div class="bfRoot">
+    <div class="bfHead">
+      <div class="bfBrand">Lift</div>
+      <div class="bfDate">{{ summary.date }}</div>
+    </div>
+
+    <div class="bfHero">
+      <div class="bfNumber">{{ formattedVolume }}</div>
+      <div class="bfUnit">Pounds moved</div>
+    </div>
+
+    <div class="bfStats">
+      <div class="bfStat">
+        <div class="bfStatVal">{{ summary.duration }}</div>
+        <div class="bfStatKey">TIME</div>
+      </div>
+      <div class="bfStat">
+        <div class="bfStatVal">{{ summary.setsCompleted }}</div>
+        <div class="bfStatKey">SETS</div>
+      </div>
+      <div class="bfStat">
+        <div class="bfStatVal">{{ summary.prs + summary.repPRs }}</div>
+        <div class="bfStatKey">PRs</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { SessionSummary } from '../../../lib/sessionSummary'
+
+const props = defineProps<{ summary: SessionSummary }>()
+
+const formattedVolume = computed(() => props.summary.totalVolume.toLocaleString('en-US'))
+</script>
+
+<style scoped>
+.bfRoot {
+  position: absolute;
+  inset: 0;
+  background: var(--accent);
+  color: var(--bg-primary);
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-family: var(--ff);
+}
+
+.bfHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.bfBrand {
+  font-family: var(--ff-mono);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.bfDate {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  opacity: 0.65;
+}
+
+.bfHero {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bfNumber {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 60px;
+  line-height: 0.9;
+  letter-spacing: -0.04em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.bfUnit {
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.bfStats {
+  display: flex;
+  gap: 24px;
+  align-items: flex-end;
+}
+
+.bfStat {
+  display: flex;
+  flex-direction: column;
+}
+
+.bfStatVal {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 28px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+}
+
+.bfStatKey {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.18em;
+  opacity: 0.65;
+  margin-top: 4px;
+}
+</style>

--- a/src/components/share/cards/BoldFloodCard.vue
+++ b/src/components/share/cards/BoldFloodCard.vue
@@ -7,7 +7,7 @@
 
     <div class="bfHero">
       <div class="bfNumber">{{ formattedVolume }}</div>
-      <div class="bfUnit">Pounds moved</div>
+      <div class="bfUnit">{{ summary.unitLabel === 'kg' ? 'Kilograms' : 'Pounds' }} moved</div>
     </div>
 
     <div class="bfStats">

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -12,8 +12,6 @@
  */
 
 import { ref, createApp, h, type Component, nextTick } from 'vue'
-import { Share as CapacitorShare } from '@capacitor/share'
-import { isNative } from '../lib/platform'
 import {
   renderNodeToBlob,
   defaultShareFilename,
@@ -121,22 +119,14 @@ export function useWorkoutShare() {
       const filename = defaultShareFilename(req.summary.rawDate, req.format)
       const file = new File([blob], filename, { type: 'image/png' })
 
-      // Capacitor native: write blob to filesystem and hand the URL to the
-      // share plugin. Without filesystem the plugin cannot accept a Blob —
-      // for the v1 native path we fall through to download until the
-      // filesystem write is wired (out of scope for this PR).
-      if (isNative) {
-        try {
-          await CapacitorShare.share({
-            title: 'Lift workout',
-            text: `${req.summary.totalVolume.toLocaleString('en-US')} lbs · ${req.summary.setsCompleted} sets`,
-          })
-          return { kind: 'shared' }
-        } catch (err) {
-          // Fall through to web share / download
-          lastError.value = err as Error
-        }
-      }
+      // Capacitor native path needs `@capacitor/filesystem` to write the
+      // blob to disk so the iOS share plugin can attach the file URL.
+      // Until that's wired, sharing on a native build falls through to the
+      // Web Share API (works on the iOS Safari PWA which is the current
+      // install target) and then to download. Skipping the native sheet
+      // entirely is intentional — calling `CapacitorShare.share({ text })`
+      // alone would silently drop the rendered image, which is worse than
+      // surfacing the download.
 
       if (canWebShareFiles([file])) {
         try {

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -1,0 +1,180 @@
+/**
+ * Orchestrates the share flow for issue #305 share cards:
+ *   1. Mount a card component offscreen (detached Vue app, no Pinia needed —
+ *      cards are pure presentational components that take a typed summary prop).
+ *   2. Wait for the next tick so the DOM and CSS are settled, then rasterize
+ *      the card to a PNG Blob via `html-to-image`.
+ *   3. Share via the native iOS share sheet (Capacitor), the Web Share API
+ *      (browser, iOS Safari 16.4+ supports image files), or fall back to a
+ *      direct download — same Blob → URL.createObjectURL pattern App.vue
+ *      already uses for CSV/JSON exports.
+ *   4. Always unmount and revoke the object URL.
+ */
+
+import { ref, createApp, h, type Component, nextTick } from 'vue'
+import { Share as CapacitorShare } from '@capacitor/share'
+import { isNative } from '../lib/platform'
+import {
+  renderNodeToBlob,
+  defaultShareFilename,
+  PREVIEW_SIZE,
+  EXPORT_PIXEL_RATIO,
+  type CardFormat,
+} from '../lib/shareImage'
+import type { SessionSummary } from '../lib/sessionSummary'
+
+export interface ShareCardRequest {
+  /** The Vue component that renders the card. */
+  component: Component
+  /** Format determines preview size and pixel-ratio'd output. */
+  format: CardFormat
+  /** The summary the card needs to render. */
+  summary: SessionSummary
+  /** Used to scope the offscreen container's data-theme/data-mode. */
+  theme: string
+  mode: 'dark' | 'light'
+}
+
+export type ShareResult =
+  | { kind: 'shared' }                   // native sheet / Web Share resolved
+  | { kind: 'downloaded'; filename: string }
+  | { kind: 'cancelled' }
+  | { kind: 'error'; error: Error }
+
+/**
+ * Browsers that support image files in the Web Share API.
+ * iOS Safari 16.4+ and Android Chrome both report `canShare({ files })` as true.
+ */
+function canWebShareFiles(files: File[]): boolean {
+  if (typeof navigator === 'undefined' || !navigator.share || !navigator.canShare) return false
+  try {
+    return navigator.canShare({ files })
+  } catch {
+    return false
+  }
+}
+
+/** Triggers a download via a temporary anchor element. Matches the dataExport.ts pattern. */
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  try {
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.style.display = 'none'
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+  } finally {
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+}
+
+/**
+ * Build a detached DOM container, mount the card into it, render to Blob,
+ * unmount. Returns the Blob.
+ */
+async function renderCardOffscreen(req: ShareCardRequest): Promise<Blob> {
+  const { width, height } = PREVIEW_SIZE[req.format]
+  const host = document.createElement('div')
+  // Offscreen but rendered: html-to-image needs the node in the DOM with real
+  // layout. Negative-position rather than display:none.
+  host.style.cssText =
+    `position:absolute;left:-10000px;top:0;width:${width}px;height:${height}px;` +
+    'pointer-events:none;contain:layout paint;'
+  host.setAttribute('data-theme', req.theme)
+  host.setAttribute('data-mode', req.mode)
+
+  document.body.appendChild(host)
+  const app = createApp({
+    render: () => h(req.component, { summary: req.summary }),
+  })
+
+  try {
+    app.mount(host)
+    // Two ticks: first to flush mount, second to flush any computed/CSS
+    // recalculation triggered by the freshly-set data-theme/data-mode.
+    await nextTick()
+    await nextTick()
+    return await renderNodeToBlob(host, { width, height, pixelRatio: EXPORT_PIXEL_RATIO })
+  } finally {
+    app.unmount()
+    host.remove()
+  }
+}
+
+export function useWorkoutShare() {
+  const isSharing = ref(false)
+  const lastError = ref<Error | null>(null)
+
+  /**
+   * Render → share. Resolves with the outcome; never throws on user-cancel.
+   * Errors during rendering or unexpected share failures resolve as
+   * { kind: 'error' } so the caller can surface a toast.
+   */
+  async function shareCard(req: ShareCardRequest): Promise<ShareResult> {
+    if (isSharing.value) return { kind: 'cancelled' }
+    isSharing.value = true
+    lastError.value = null
+    try {
+      const blob = await renderCardOffscreen(req)
+      const filename = defaultShareFilename(req.summary.rawDate, req.format)
+      const file = new File([blob], filename, { type: 'image/png' })
+
+      // Capacitor native: write blob to filesystem and hand the URL to the
+      // share plugin. Without filesystem the plugin cannot accept a Blob —
+      // for the v1 native path we fall through to download until the
+      // filesystem write is wired (out of scope for this PR).
+      if (isNative) {
+        try {
+          await CapacitorShare.share({
+            title: 'Lift workout',
+            text: `${req.summary.totalVolume.toLocaleString('en-US')} lbs · ${req.summary.setsCompleted} sets`,
+          })
+          return { kind: 'shared' }
+        } catch (err) {
+          // Fall through to web share / download
+          lastError.value = err as Error
+        }
+      }
+
+      if (canWebShareFiles([file])) {
+        try {
+          await navigator.share({ files: [file], title: 'Lift workout' })
+          return { kind: 'shared' }
+        } catch (err) {
+          // AbortError = user dismissed sheet. Anything else falls to download.
+          if ((err as DOMException).name === 'AbortError') return { kind: 'cancelled' }
+        }
+      }
+
+      downloadBlob(blob, filename)
+      return { kind: 'downloaded', filename }
+    } catch (err) {
+      lastError.value = err as Error
+      return { kind: 'error', error: err as Error }
+    } finally {
+      isSharing.value = false
+    }
+  }
+
+  /** Skip the share sheet and download directly. */
+  async function downloadCard(req: ShareCardRequest): Promise<ShareResult> {
+    if (isSharing.value) return { kind: 'cancelled' }
+    isSharing.value = true
+    lastError.value = null
+    try {
+      const blob = await renderCardOffscreen(req)
+      const filename = defaultShareFilename(req.summary.rawDate, req.format)
+      downloadBlob(blob, filename)
+      return { kind: 'downloaded', filename }
+    } catch (err) {
+      lastError.value = err as Error
+      return { kind: 'error', error: err as Error }
+    } finally {
+      isSharing.value = false
+    }
+  }
+
+  return { shareCard, downloadCard, isSharing, lastError }
+}

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -72,16 +72,64 @@ function downloadBlob(blob: Blob, filename: string): void {
  * Build a detached DOM container, mount the card into it, render to Blob,
  * unmount. Returns the Blob.
  */
+/**
+ * The list of theme custom properties consumed by share cards. Snapshotted
+ * from the live document at render time and inlined onto the offscreen
+ * host so theme variables resolve inside `html-to-image`'s cloned subtree
+ * (where the original `[data-theme="X"][data-mode="Y"]` selectors don't
+ * reliably match — the clone lives outside the original cascade).
+ */
+const THEME_VAR_NAMES = [
+  '--bg-primary',
+  '--bg-secondary',
+  '--bg-elevated',
+  '--bg-hover',
+  '--border',
+  '--border-strong',
+  '--text-primary',
+  '--text-secondary',
+  '--text-muted',
+  '--text-on-accent',
+  '--accent',
+  '--accent-hover',
+  '--accent-subtle',
+  '--pr',
+  '--pr-subtle',
+  '--mesh',
+  '--ff',
+  '--ff-display',
+  '--ff-mono',
+] as const
+
+function snapshotThemeVars(): string {
+  const root = getComputedStyle(document.documentElement)
+  const decls: string[] = []
+  for (const name of THEME_VAR_NAMES) {
+    const value = root.getPropertyValue(name).trim()
+    if (value) decls.push(`${name}:${value}`)
+  }
+  return decls.join(';')
+}
+
 async function renderCardOffscreen(req: ShareCardRequest): Promise<Blob> {
   const { width, height } = PREVIEW_SIZE[req.format]
   const host = document.createElement('div')
   // Offscreen but rendered: html-to-image needs the node in the DOM with real
-  // layout. Negative-position rather than display:none.
+  // layout. Inline the resolved theme variables onto the host so they survive
+  // html-to-image's clone-and-rehome step (the `[data-theme=…]` selectors
+  // don't reliably match in the cloned subtree, which leaves the rasterized
+  // image blank). Explicit `position: relative` on the inner provides the
+  // containing block for cards' absolute children.
   host.style.cssText =
     `position:absolute;left:-10000px;top:0;width:${width}px;height:${height}px;` +
-    'pointer-events:none;contain:layout paint;'
+    `pointer-events:none;` +
+    snapshotThemeVars()
   host.setAttribute('data-theme', req.theme)
   host.setAttribute('data-mode', req.mode)
+
+  const inner = document.createElement('div')
+  inner.style.cssText = `position:relative;width:${width}px;height:${height}px;`
+  host.appendChild(inner)
 
   document.body.appendChild(host)
   const app = createApp({
@@ -89,9 +137,9 @@ async function renderCardOffscreen(req: ShareCardRequest): Promise<Blob> {
   })
 
   try {
-    app.mount(host)
+    app.mount(inner)
     // Two ticks: first to flush mount, second to flush any computed/CSS
-    // recalculation triggered by the freshly-set data-theme/data-mode.
+    // recalculation triggered by the freshly-applied theme vars.
     await nextTick()
     await nextTick()
     return await renderNodeToBlob(host, { width, height, pixelRatio: EXPORT_PIXEL_RATIO })

--- a/src/lib/__tests__/sessionSummary.test.ts
+++ b/src/lib/__tests__/sessionSummary.test.ts
@@ -265,4 +265,29 @@ describe('buildSessionSummary', () => {
     const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises: [], streakWeeks: 7 })
     expect(summary.streak).toBe(7)
   })
+
+  it('defaults to lbs and an identity converter', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [{ id: 's1', weight: 225, reps: 5, date: '2026-04-21T15:00:00Z' }]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.unitLabel).toBe('lbs')
+    expect(summary.totalVolume).toBe(225 * 5)
+    expect(summary.bestSet?.weight).toBe(225)
+  })
+
+  it('routes weight fields through toDisplayUnits when supplied', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [{ id: 's1', weight: 225, reps: 5, date: '2026-04-21T15:00:00Z' }]),
+    ]
+    const summary = buildSessionSummary({
+      rawDate: '2026-04-21',
+      exercises,
+      unitLabel: 'kg',
+      toDisplayUnits: (lb) => +(lb * 0.453592).toFixed(1),
+    })
+    expect(summary.unitLabel).toBe('kg')
+    expect(summary.bestSet?.weight).toBeCloseTo(102.1, 1)
+    expect(summary.totalVolume).toBeCloseTo(510.3, 1)
+  })
 })

--- a/src/lib/__tests__/shareImage.test.ts
+++ b/src/lib/__tests__/shareImage.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { defaultShareFilename, PREVIEW_SIZE, EXPORT_PIXEL_RATIO } from '../shareImage'
+
+describe('shareImage', () => {
+  describe('defaultShareFilename', () => {
+    it('builds a YYYY-MM-DD prefixed filename for square format', () => {
+      expect(defaultShareFilename('2026-04-21')).toBe('lift-2026-04-21.png')
+    })
+
+    it('appends -story for vertical format', () => {
+      expect(defaultShareFilename('2026-04-21', 'story')).toBe('lift-2026-04-21-story.png')
+    })
+  })
+
+  describe('PREVIEW_SIZE', () => {
+    it('exposes 360x360 for square (rasterizes to 1080x1080 at 3x)', () => {
+      expect(PREVIEW_SIZE.square.width).toBe(360)
+      expect(PREVIEW_SIZE.square.height).toBe(360)
+      expect(PREVIEW_SIZE.square.width * EXPORT_PIXEL_RATIO).toBe(1080)
+    })
+
+    it('exposes 360x640 for story (rasterizes to 1080x1920 at 3x)', () => {
+      expect(PREVIEW_SIZE.story.width).toBe(360)
+      expect(PREVIEW_SIZE.story.height).toBe(640)
+      expect(PREVIEW_SIZE.story.height * EXPORT_PIXEL_RATIO).toBe(1920)
+    })
+  })
+})

--- a/src/lib/sessionSummary.ts
+++ b/src/lib/sessionSummary.ts
@@ -33,15 +33,17 @@ export interface SessionSummary {
   rawDate: string             // YYYY-MM-DD (key used everywhere internally)
   date: string                // 'Tue, Apr 22' formatted for display
   duration: string            // 'Xh Ym' / 'Ym' / '—' when the span is unknowable
-  totalVolume: number         // Σ weight × reps for the date
+  totalVolume: number         // Σ weight × reps, in display units
   setsCompleted: number
   exercises: number           // distinct exercise count for the date
   prs: number                 // weight/e1RM PRs (one per exercise, deduped)
   repPRs: number              // rep-at-weight PRs (one per exercise, deduped)
   bestSet: SessionBestSet | null
   highlights: SessionHighlight[]
-  weekVolume: number[]        // 7 entries, Mon→Sun for the week containing rawDate
+  weekVolume: number[]        // 7 entries, Mon→Sun, in display units
   streak: number              // weeks
+  /** Display unit label for any weight field — 'lbs' or 'kg'. */
+  unitLabel: string
 }
 
 export interface SessionSummaryInput {
@@ -51,6 +53,14 @@ export interface SessionSummaryInput {
   xpPerSet?: Record<string, SetXPEntry | number>
   /** Weekly streak count from the progression store. */
   streakWeeks?: number
+  /**
+   * Convert the stored weight (always pounds) to the user's display units.
+   * Defaults to identity (no conversion). Pass `useTheme().displayWeight`
+   * when called from a Vue context so cards render the correct numbers.
+   */
+  toDisplayUnits?: (lbValue: number) => number
+  /** Label to surface alongside weight values. Defaults to 'lbs'. */
+  unitLabel?: string
 }
 
 const WEEKDAY_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
@@ -128,6 +138,13 @@ export function toLocalDateKey(iso: string): string {
 /** Pure: compute per-day session summary. */
 export function buildSessionSummary(input: SessionSummaryInput): SessionSummary {
   const { rawDate, exercises, xpPerSet, streakWeeks = 0 } = input
+  const toDisplay = input.toDisplayUnits ?? ((lb: number) => lb)
+  const unitLabel = input.unitLabel ?? 'lbs'
+  /** Round small per-set values nicely; volume gets the same treatment then string-formatted. */
+  const cv = (lb: number) => {
+    const v = toDisplay(lb)
+    return Number.isInteger(v) ? v : Math.round(v * 10) / 10
+  }
 
   const dayKey = rawDate
   const todaysByExercise = new Map<string, { ex: Exercise; sets: WorkoutSet[] }>()
@@ -193,19 +210,19 @@ export function buildSessionSummary(input: SessionSummaryInput): SessionSummary 
       highlights.push({
         exerciseId: ex.id,
         name: ex.name,
-        weight: topSet.weight,
+        weight: cv(topSet.weight),
         reps: topSet.reps,
-        e1RM: topSet.estimated1RM,
+        e1RM: cv(topSet.estimated1RM),
         badge,
-        volume: exVolume,
+        volume: cv(exVolume),
       })
       if (!bestSet || topSet.estimated1RM > bestSet.e1RM) {
         bestSet = {
           exerciseId: ex.id,
           name: ex.name,
-          weight: topSet.weight,
+          weight: cv(topSet.weight),
           reps: topSet.reps,
-          e1RM: topSet.estimated1RM,
+          e1RM: cv(topSet.estimated1RM),
           isPR: exerciseHasPR,
         }
       }
@@ -245,13 +262,13 @@ export function buildSessionSummary(input: SessionSummaryInput): SessionSummary 
       }
     }
   }
-  const weekVolume = week.map((d) => weekVolumeMap.get(d) ?? 0)
+  const weekVolume = week.map((d) => cv(weekVolumeMap.get(d) ?? 0))
 
   return {
     rawDate,
     date: formatSessionDate(rawDate),
     duration,
-    totalVolume,
+    totalVolume: cv(totalVolume),
     setsCompleted,
     exercises: todaysByExercise.size,
     prs: prCount,
@@ -260,5 +277,6 @@ export function buildSessionSummary(input: SessionSummaryInput): SessionSummary 
     highlights,
     weekVolume,
     streak: streakWeeks,
+    unitLabel,
   }
 }

--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -32,9 +32,13 @@ export const EXPORT_PIXEL_RATIO = 3 // 360 → 1080, 640 → 1920
 /**
  * Render a single DOM node to a PNG Blob at high pixel density.
  *
- * The node is expected to be already mounted in the DOM (offscreen is fine —
- * `position: absolute; left: -10000px;` is the typical setup). All assets
- * (fonts, theme variables, gradients) must be loaded before calling.
+ * The node is expected to be already mounted in the DOM. The caller's
+ * positioning (typically `position:absolute; left:-10000px` to keep it
+ * offscreen) is overridden via the `style` option below — html-to-image
+ * preserves the cloned element's positioning into its SVG foreignObject,
+ * and a clone with `left: -10000px` renders entirely outside the SVG
+ * viewport, producing a transparent PNG. Forcing the clone to render at
+ * (0,0) inside the foreignObject is what we want.
  */
 export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): Promise<Blob> {
   const blob = await toBlob(node, {
@@ -43,6 +47,15 @@ export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): 
     pixelRatio: opts.pixelRatio ?? EXPORT_PIXEL_RATIO,
     cacheBust: true,
     backgroundColor: undefined,
+    style: {
+      position: 'static',
+      left: 'auto',
+      top: 'auto',
+      right: 'auto',
+      bottom: 'auto',
+      transform: 'none',
+      margin: '0',
+    },
   })
   if (!blob) throw new Error('html-to-image returned null blob')
   return blob

--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -1,0 +1,58 @@
+/**
+ * DOM → PNG rasterization helper for share cards (issue #305).
+ *
+ * Cards are designed at a small "preview" size (360×360 / 360×640) and then
+ * rasterized at a higher pixelRatio to produce social-platform-sized PNGs
+ * (1080×1080 for IG square, 1080×1920 for IG Story). Designing at a small
+ * size keeps the markup readable and matches the handoff prototype, while
+ * the pixelRatio multiplier produces the resolution platforms expect.
+ */
+
+import { toBlob } from 'html-to-image'
+
+export type CardFormat = 'square' | 'story'
+
+export interface ExportOptions {
+  /** Preview width in CSS pixels. */
+  width: number
+  /** Preview height in CSS pixels. */
+  height: number
+  /** Multiplier applied to width × height for the exported PNG. */
+  pixelRatio?: number
+}
+
+/** Default sizes — match the handoff design. */
+export const PREVIEW_SIZE: Record<CardFormat, { width: number; height: number }> = {
+  square: { width: 360, height: 360 },
+  story: { width: 360, height: 640 },
+}
+
+export const EXPORT_PIXEL_RATIO = 3 // 360 → 1080, 640 → 1920
+
+/**
+ * Render a single DOM node to a PNG Blob at high pixel density.
+ *
+ * The node is expected to be already mounted in the DOM (offscreen is fine —
+ * `position: absolute; left: -10000px;` is the typical setup). All assets
+ * (fonts, theme variables, gradients) must be loaded before calling.
+ */
+export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): Promise<Blob> {
+  const blob = await toBlob(node, {
+    width: opts.width,
+    height: opts.height,
+    pixelRatio: opts.pixelRatio ?? EXPORT_PIXEL_RATIO,
+    cacheBust: true,
+    backgroundColor: undefined,
+  })
+  if (!blob) throw new Error('html-to-image returned null blob')
+  return blob
+}
+
+/**
+ * Build a default `share-summary-YYYY-MM-DD.png` filename.
+ * Used for the download fallback path on browsers without `navigator.share`.
+ */
+export function defaultShareFilename(rawDate: string, format: CardFormat = 'square'): string {
+  const suffix = format === 'story' ? '-story' : ''
+  return `lift-${rawDate}${suffix}.png`
+}


### PR DESCRIPTION
## Summary

Continues [#305](https://github.com/aschung212/Lift/issues/305). Wires the actual share flow on top of the data layer + Workout Complete view that just shipped (#422). Picks the two highest-leverage card identities from the handoff (Bold flood + Best set) plus the picker shell that PR 3 will fill out with the remaining six squares and three story formats.

> Originally opened as #425 against PR 1's branch. PR 1 merged with --delete-branch which closed #425; this PR carries the same commits, retargeted to master.

- **`src/lib/shareImage.ts`** — `html-to-image` wrapper. Cards designed at 360×360 / 360×640 are rasterized at `pixelRatio: 3` to produce true 1080×1080 / 1080×1920 PNGs. Includes the `style` reset that prevents the offscreen host's `left:-10000px` from leaking into the rasterized output (would render blank otherwise).
- **`src/composables/useWorkoutShare.ts`** — orchestrator. Mounts the active card via `createApp` into an offscreen detached host, snapshots resolved theme variables onto the host so the rendered PNG matches the user's current theme, rasterizes, then shares via Web Share API → download fallback.
- **`src/components/share/cardRegistry.ts`** — typed catalog. PR 3 adds the remaining cards. `eligibleSquareCards()` filters by per-card predicates.
- **`BoldFloodCard.vue`** (#01) and **`BestSetCard.vue`** (#04) — handoff ports. All colors flow through theme tokens.
- **`SharePickerSheet.vue`** — bottom-sheet modal with horizontal scroll-snap thumbnails and Share / Save image actions. Thumbnails render the same card components used for export.
- **`WorkoutCompleteView.vue`** — adds the "Share summary" primary button.
- 4 unit tests for `shareImage`'s pure helpers.

Includes the 4 review fixes (P1 native-share defeat, P2 weight-unit conversion, P2 scroll-lock leak, P2 Escape double-close) and the blank-PNG fix (clone position reset + theme variable inlining).

## Test plan
- [ ] `npm test` — passes
- [ ] `npm run typecheck` — clean
- [ ] `npm run build` — picker chunks separately (~50KB / ~17KB gzipped)
- [ ] Manual: Finish workout → Share summary → see picker with 2 thumbs, both correctly themed
- [ ] Manual: tap "Save image" → PNG downloads with `lift-YYYY-MM-DD.png` filename and full visible content
- [ ] Manual: switch theme — both thumbs and the rasterized output reskin
- [ ] Manual: kg unit selected — every card displays kg-converted weights

🤖 Generated with [Claude Code](https://claude.com/claude-code)