### PR TITLE
fix: use matchPrecache for offline fallback cache lookup

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="theme-color" content="#0f0f0f" />
+  <title>Lift — Offline</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+      background: #0a0a0a;
+      color: #e8e8e8;
+      min-height: 100dvh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      padding-top: calc(24px + env(safe-area-inset-top, 0px));
+      padding-bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+      -webkit-text-size-adjust: 100%;
+    }
+
+    .offline-content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+      text-align: center;
+      max-width: 320px;
+    }
+
+    .offline-icon {
+      width: 64px;
+      height: 64px;
+      color: #d4af37;
+      opacity: 0.8;
+    }
+
+    .offline-wordmark {
+      font-size: 48px;
+      font-weight: 800;
+      letter-spacing: -0.035em;
+      line-height: 1;
+      color: #d4af37;
+    }
+
+    .offline-heading {
+      font-size: 20px;
+      font-weight: 600;
+      line-height: 1.3;
+      color: #e8e8e8;
+    }
+
+    .offline-body {
+      font-size: 15px;
+      line-height: 1.5;
+      color: #888;
+    }
+
+    .offline-retry {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 200px;
+      min-height: 48px;
+      padding: 12px 32px;
+      border: none;
+      border-radius: 12px;
+      background: #d4af37;
+      color: #0a0a0a;
+      font-family: inherit;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+      -webkit-tap-highlight-color: transparent;
+      transition: opacity 0.15s ease;
+    }
+
+    .offline-retry:active {
+      opacity: 0.7;
+    }
+  </style>
+</head>
+<body>
+  <div class="offline-content">
+    <svg class="offline-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="1" y1="1" x2="23" y2="23"/>
+      <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/>
+      <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/>
+      <path d="M10.71 5.05A16 16 0 0 1 22.56 9"/>
+      <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/>
+      <path d="M8.53 16.11a6 6 0 0 1 6.95 0"/>
+      <line x1="12" y1="20" x2="12.01" y2="20"/>
+    </svg>
+    <div class="offline-wordmark">Lift</div>
+    <h1 class="offline-heading">You're offline</h1>
+    <p class="offline-body">
+      Check your connection and try again.
+      Your workout data is safe — it's stored locally on this device.
+    </p>
+    <button class="offline-retry" onclick="window.location.reload()">Try again</button>
+  </div>
+</body>
+</html>

--- a/src/lib/__tests__/offlineFallback.test.ts
+++ b/src/lib/__tests__/offlineFallback.test.ts
@@ -76,9 +76,9 @@ describe('Service worker offline fallback integration', () => {
     expect(swSource).toContain('setCatchHandler')
   })
 
-  it('SW catch handler serves offline.html for document requests', () => {
+  it('SW catch handler serves offline.html for document requests via matchPrecache', () => {
     expect(swSource).toContain("request.destination === 'document'")
-    expect(swSource).toContain('offline.html')
+    expect(swSource).toContain("matchPrecache('/offline.html')")
   })
 
   it('SW includes NavigationRoute for SPA routing', () => {

--- a/src/lib/__tests__/offlineFallback.test.ts
+++ b/src/lib/__tests__/offlineFallback.test.ts
@@ -1,0 +1,104 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Regression tests for the offline fallback page and service worker config.
+ *
+ * Validates that:
+ * - public/offline.html exists and is self-contained (no external deps)
+ * - The service worker source uses injectManifest with a catch handler
+ * - The VitePWA config includes offline.html in includeAssets
+ */
+
+const publicDir = resolve(__dirname, '../../../public')
+const offlinePath = resolve(publicDir, 'offline.html')
+const swPath = resolve(__dirname, '../../sw.ts')
+const viteConfigPath = resolve(__dirname, '../../../vite.config.js')
+
+describe('Offline fallback page', () => {
+  it('offline.html exists in public/', () => {
+    expect(existsSync(offlinePath)).toBe(true)
+  })
+
+  it('is self-contained with no external stylesheet links', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    // No external CSS — all styles must be inline
+    expect(html).not.toMatch(/<link[^>]+rel=["']stylesheet["']/)
+  })
+
+  it('is self-contained with no external script tags', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    // No external scripts — inline only (onclick is fine)
+    expect(html).not.toMatch(/<script[^>]+src=/)
+  })
+
+  it('has a retry button that reloads the page', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    expect(html).toContain('window.location.reload()')
+  })
+
+  it('includes the Lift branding', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    expect(html).toContain('Lift')
+    expect(html).toContain('offline')
+  })
+
+  it('uses safe-area-insets for iOS compatibility', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    expect(html).toContain('safe-area-inset')
+  })
+
+  it('has a proper viewport meta tag', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    expect(html).toContain('viewport-fit=cover')
+  })
+
+  it('does not reference the deployment domain (no URLs to fabricate)', () => {
+    const html = readFileSync(offlinePath, 'utf-8')
+    // Self-contained page should not reference any external domains
+    expect(html).not.toContain('vercel.app')
+    expect(html).not.toContain('supabase')
+    expect(html).not.toContain('http')
+  })
+})
+
+describe('Service worker offline fallback integration', () => {
+  const swSource = readFileSync(swPath, 'utf-8')
+  const viteConfig = readFileSync(viteConfigPath, 'utf-8')
+
+  it('SW uses injectManifest strategy', () => {
+    expect(viteConfig).toContain("strategies: 'injectManifest'")
+  })
+
+  it('SW source uses setCatchHandler for offline fallback', () => {
+    expect(swSource).toContain('setCatchHandler')
+  })
+
+  it('SW catch handler serves offline.html for document requests', () => {
+    expect(swSource).toContain("request.destination === 'document'")
+    expect(swSource).toContain('offline.html')
+  })
+
+  it('SW includes NavigationRoute for SPA routing', () => {
+    expect(swSource).toContain('NavigationRoute')
+    expect(swSource).toContain("createHandlerBoundToURL('/index.html')")
+  })
+
+  it('offline.html is listed in VitePWA includeAssets', () => {
+    expect(viteConfig).toContain('offline.html')
+  })
+
+  it('SW includes precacheAndRoute for asset caching', () => {
+    expect(swSource).toContain('precacheAndRoute')
+    expect(swSource).toContain('self.__WB_MANIFEST')
+  })
+
+  it('SW includes Supabase runtime caching routes', () => {
+    expect(swSource).toContain('supabase-api')
+    expect(swSource).toContain('supabase-auth')
+    expect(swSource).toContain('NetworkFirst')
+    expect(swSource).toContain('NetworkOnly')
+  })
+})

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,0 +1,69 @@
+/// <reference lib="webworker" />
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from 'workbox-precaching'
+import { clientsClaim } from 'workbox-core'
+import { registerRoute, NavigationRoute, setCatchHandler } from 'workbox-routing'
+import { NetworkFirst, NetworkOnly } from 'workbox-strategies'
+import { ExpirationPlugin } from 'workbox-expiration'
+import { CacheableResponsePlugin } from 'workbox-cacheable-response'
+
+declare let self: ServiceWorkerGlobalScope
+
+// Take control immediately on install/activate
+self.skipWaiting()
+clientsClaim()
+
+// Clean up old precache versions on activate
+cleanupOutdatedCaches()
+
+// Precache all build assets (VitePWA injects the manifest here)
+precacheAndRoute(self.__WB_MANIFEST)
+
+// SPA navigation: serve precached index.html for all navigation requests
+const navigationHandler = createHandlerBoundToURL('/index.html')
+registerRoute(new NavigationRoute(navigationHandler))
+
+// Runtime cache: Supabase REST API — NetworkFirst with 24h cache
+registerRoute(
+  /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,
+  new NetworkFirst({
+    cacheName: 'supabase-api',
+    plugins: [
+      new ExpirationPlugin({
+        maxEntries: 50,
+        maxAgeSeconds: 60 * 60 * 24, // 24 hours
+      }),
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+    ],
+    networkTimeoutSeconds: 3,
+  })
+)
+
+// Runtime cache: Supabase Auth — NetworkOnly (never cache auth responses)
+registerRoute(
+  /^https:\/\/.*\.supabase\.co\/auth\/v1\/.*/i,
+  new NetworkOnly({
+    cacheName: 'supabase-auth',
+  })
+)
+
+// Offline fallback: serve offline.html when a navigation request fails
+// and the precached index.html is also unavailable (e.g. corrupted cache,
+// first visit without connectivity after SW install).
+setCatchHandler(async ({ request }) => {
+  if (request.destination === 'document') {
+    const cache = await caches.open('workbox-precache-v2-' + self.registration.scope)
+    const fallback = await cache.match('/offline.html')
+    if (fallback) return fallback
+
+    // Try alternate key format (workbox adds revision hashes to precache keys)
+    for (const key of await cache.keys()) {
+      if (key.url.endsWith('/offline.html')) {
+        const response = await cache.match(key)
+        if (response) return response
+      }
+    }
+  }
+  return Response.error()
+})

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,5 +1,5 @@
 /// <reference lib="webworker" />
-import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL } from 'workbox-precaching'
+import { precacheAndRoute, cleanupOutdatedCaches, createHandlerBoundToURL, matchPrecache } from 'workbox-precaching'
 import { clientsClaim } from 'workbox-core'
 import { registerRoute, NavigationRoute, setCatchHandler } from 'workbox-routing'
 import { NetworkFirst, NetworkOnly } from 'workbox-strategies'
@@ -51,19 +51,11 @@ registerRoute(
 // Offline fallback: serve offline.html when a navigation request fails
 // and the precached index.html is also unavailable (e.g. corrupted cache,
 // first visit without connectivity after SW install).
+// Uses matchPrecache to correctly resolve revision-hashed precache keys.
 setCatchHandler(async ({ request }) => {
   if (request.destination === 'document') {
-    const cache = await caches.open('workbox-precache-v2-' + self.registration.scope)
-    const fallback = await cache.match('/offline.html')
+    const fallback = await matchPrecache('/offline.html')
     if (fallback) return fallback
-
-    // Try alternate key format (workbox adds revision hashes to precache keys)
-    for (const key of await cache.keys()) {
-      if (key.url.endsWith('/offline.html')) {
-        const response = await cache.match(key)
-        if (response) return response
-      }
-    }
   }
   return Response.error()
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,8 +33,11 @@ export default defineConfig({
   plugins: [
     vue(),
     VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png'],
+      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'offline.html'],
       manifest: {
         name: 'Lift — Workout Tracker',
         short_name: 'Lift',
@@ -110,34 +113,8 @@ export default defineConfig({
           },
         ],
       },
-      workbox: {
+      injectManifest: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-        clientsClaim: true,
-        skipWaiting: true,
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'supabase-api',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 24, // 24 hours
-              },
-              networkTimeoutSeconds: 3,
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            urlPattern: /^https:\/\/.*\.supabase\.co\/auth\/v1\/.*/i,
-            handler: 'NetworkOnly',
-            options: {
-              cacheName: 'supabase-auth',
-            },
-          },
-        ],
       },
     }),
     // Upload source maps to Sentry on production builds


### PR DESCRIPTION
## Summary



## Changes




## Commits
- [`fc3c437`](https://github.com/aschung212/Lift/commit/fc3c437) fix: use matchPrecache for offline fallback cache lookup
- [`2fea099`](https://github.com/aschung212/Lift/commit/2fea099) feat: add offline fallback page for failed navigations (closes #437)

## Test Results
- Before: 1339 passing
- After: 1354 passing (15 delta)

---
_Automated by overnight pipeline — Tue Apr 28 23:15:13 PDT 2026_

## Preview
Test on your phone: https://lift-qo80opa9r-aschung212-1101s-projects.vercel.app