### PR TITLE
perf(#435): exclude screenshots and OG image from service worker preca

### DIFF
--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -61,4 +61,26 @@ describe('PWA manifest regression tests', () => {
       expect(existsSync(resolve(publicDir, 'screenshot-calendar.png'))).toBe(true)
     })
   })
+
+  describe('workbox globIgnores excludes non-essential large assets from precache', () => {
+    it('excludes screenshot PNGs from precache', () => {
+      expect(viteConfig).toContain("'screenshot-*.png'")
+    })
+
+    it('excludes og-image.png from precache', () => {
+      expect(viteConfig).toContain("'og-image.png'")
+    })
+
+    it('excludes icon-source.png from precache', () => {
+      expect(viteConfig).toContain("'icon-source.png'")
+    })
+
+    it('excludes og-preview.html from precache', () => {
+      expect(viteConfig).toContain("'og-preview.html'")
+    })
+
+    it('has globIgnores array in workbox config', () => {
+      expect(viteConfig).toContain('globIgnores:')
+    })
+  })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -112,6 +112,12 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        globIgnores: [
+          'screenshot-*.png',
+          'og-image.png',
+          'icon-source.png',
+          'og-preview.html',
+        ],
         clientsClaim: true,
         skipWaiting: true,
         runtimeCaching: [


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-435](https://github.com/aschung212/Lift/issues/435)

Picked **LIFT-435** — exclude screenshots and OG image from service worker precache. Priority 2 issue with direct impact on first-install performance. The `globPatterns: ['**/*.{png}']` was precaching ~2MB of assets (3 screenshots, og-image, icon-source) that users never need on first load.

## Changes
- Added `globIgnores` array to workbox config in `vite.config.js` excluding `screenshot-*.png`, `og-image.png`, `icon-source.png`, and `og-preview.html`
- Added 5 regression tests in `manifestRegression.test.ts` to ensure these exclusions persist
- Verified built `sw.js` contains zero references to excluded files while essential icons (icon-192, icon-512, apple-touch-icon, favicon) remain precached

## Verification

### Steps to test
1. Open the Vercel preview URL on iPhone
2. Clear the site data (Settings > Safari > Website Data) to force a fresh install
3. Navigate to the app — it should load and install the service worker
4. Open Safari Web Inspector (or Chrome DevTools on desktop) and check the Cache Storage entries
5. Verify that `screenshot-mobile.png`, `screenshot-detail.png`, `screenshot-calendar.png`, `og-image.png`, and `icon-source.png` are NOT in the precache
6. Verify that `icon-192.png`, `icon-512.png`, `apple-touch-icon.png`, and `favicon.ico` ARE in the precache
7. The PWA install prompt should still show screenshots correctly (they load on-demand from the server)

### Expected behavior
- App loads normally, all features work
- Service worker installs faster due to ~2MB less precache
- PWA install UI still shows screenshots (fetched on-demand, not precached)
- All app icons display correctly

### What to watch for
- PWA install screenshots not appearing (they should still load from network)
- Missing app icons on home screen after install
- Any broken images in the app itself

### Risk assessment
- **Scope:** Narrow — only affects service worker precache configuration
- **Confidence:** High — verified in built SW output, and screenshots are still served normally via HTTP
- **Rollback:** Revert the single commit; no data or state changes

SCREENSHOT_ROUTE:NONE

## Commits
- [`74a5d3d`](https://github.com/aschung212/Lift/commit/74a5d3d) perf(#435): exclude screenshots and OG image from service worker precache

## Test Results
- Before: 1339 passing
- After: 1344 passing (5 delta)

---
_Automated by overnight pipeline — Tue Apr 28 23:21:45 PDT 2026_

## Preview
Test on your phone: https://lift-cgohrnpm7-aschung212-1101s-projects.vercel.app