### PR TITLE
feat(#440): add launch_handler to manifest for single-window PWA behav

### DIFF
--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -44,6 +44,12 @@ describe('PWA manifest regression tests', () => {
     })
   })
 
+  describe('manifest includes launch_handler for single-window behavior', () => {
+    it('has launch_handler with navigate-existing client_mode', () => {
+      expect(viteConfig).toContain("client_mode: 'navigate-existing'")
+    })
+  })
+
   describe('manifest includes screenshots for richer install UI', () => {
     it('has narrow (mobile) screenshot entries', () => {
       expect(viteConfig).toContain("form_factor: 'narrow'")

--- a/vite.config.js
+++ b/vite.config.js
@@ -86,6 +86,9 @@ export default defineConfig({
             purpose: 'any maskable',
           },
         ],
+        launch_handler: {
+          client_mode: 'navigate-existing',
+        },
         screenshots: [
           {
             src: 'screenshot-mobile.png',


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-440](https://github.com/aschung212/Lift/issues/440)

LIFT-440 — Add `launch_handler` to PWA manifest for single-window behavior. Small, focused change with regression test.

## Changes
- Added `launch_handler: { client_mode: 'navigate-existing' }` to the VitePWA manifest config in `vite.config.js`
- Added regression test in `manifestRegression.test.ts` to pin the launch_handler configuration

## Verification

### Steps to test
1. Open the app in Chrome on Android (launch_handler is Chromium-only)
2. Install the PWA via the browser's "Add to Home Screen" prompt
3. Open the app from the home screen icon
4. Switch to another app, then tap the Lift icon again
5. The existing window should be focused — no second instance should appear

### Expected behavior
- Step 4-5: The already-open Lift window comes to the foreground instead of opening a new window
- On iOS Safari (which doesn't support launch_handler), the field is silently ignored — no regression

### What to watch for
- Verify the manifest loads correctly by checking DevTools → Application → Manifest
- Ensure no existing PWA behavior is broken (install prompt, offline caching, shortcuts)
- The field is a progressive enhancement — unsupported browsers simply ignore it

### Risk assessment
- **Scope:** Narrow — only affects the web app manifest, no runtime code changes
- **Confidence:** High — this is a declarative manifest field with no side effects
- **Rollback:** Revert the single commit; the field is purely additive

## Screenshots
SCREENSHOT_ROUTE:NONE

## Commits
- [`da02482`](https://github.com/aschung212/Lift/commit/da02482) feat(#440): add launch_handler to manifest for single-window PWA behavior

## Test Results
- Before: 1339 passing
- After: 1340 passing (1 delta)

---
_Automated by overnight pipeline — Wed Apr 29 00:08:09 PDT 2026_

## Preview
Test on your phone: https://lift-ab45k18m5-aschung212-1101s-projects.vercel.app