### PR TITLE
fix(#471): use correct CSS vars and add event-driven reactivity

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1083,6 +1083,7 @@ function clearSampleData() {
   localStorage.removeItem('sample-data')
   localStorage.setItem('fresh-start', 'true')
   hasSampleData.value = false
+  window.dispatchEvent(new CustomEvent('fresh-start'))
 }
 
 function closeSettings() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1081,6 +1081,7 @@ function clearSampleData() {
   }
   bwStore.clearAll()
   localStorage.removeItem('sample-data')
+  localStorage.setItem('fresh-start', 'true')
   hasSampleData.value = false
 }
 

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -993,7 +993,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, watch, nextTick, onUnmounted, defineAsyncComponent } from 'vue'
+import { ref, reactive, computed, watch, nextTick, onMounted, onUnmounted, defineAsyncComponent } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
 import { toLocalDateKey } from '../lib/sessionSummary'
 
@@ -1158,6 +1158,9 @@ function computeAndLogXP(exerciseId: string, setId: string, estimated1RM: number
 // ── Fresh-start transition card ─────────────────────────────────
 // Shown after user clears sample data, dismissed on first exercise add
 const showFreshStart = ref(localStorage.getItem('fresh-start') === 'true')
+function onFreshStart() { showFreshStart.value = true }
+onMounted(() => { window.addEventListener('fresh-start', onFreshStart) })
+onUnmounted(() => { window.removeEventListener('fresh-start', onFreshStart) })
 watch(() => store.exercises.length, (len) => {
   if (len > 0 && showFreshStart.value) {
     localStorage.removeItem('fresh-start')

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -68,7 +68,18 @@
       </div>
     </template>
 
-    <p v-if="store.exercises.length === 0" class="wtEmpty">
+    <div v-if="store.exercises.length === 0 && showFreshStart" class="wtFreshStart">
+      <div class="wtFreshStartIcon" aria-hidden="true">
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg>
+      </div>
+      <p class="wtFreshStartTitle">You're starting fresh!</p>
+      <p class="wtFreshStartBody">Add your first exercise to begin tracking your lifts.</p>
+      <button class="wtFreshStartCta" @click="openNewExerciseModal">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Add Exercise
+      </button>
+    </div>
+    <p v-else-if="store.exercises.length === 0" class="wtEmpty">
       No exercises yet. Hit "+ New Exercise" to add your first one.
     </p>
 
@@ -1143,6 +1154,16 @@ function computeAndLogXP(exerciseId: string, setId: string, estimated1RM: number
     showXPToast(parts.join(' · '), progressionStore.progressPercent, progressionStore.totalXP, progressionStore.nextUnlockThreshold)
   }
 }
+
+// ── Fresh-start transition card ─────────────────────────────────
+// Shown after user clears sample data, dismissed on first exercise add
+const showFreshStart = ref(localStorage.getItem('fresh-start') === 'true')
+watch(() => store.exercises.length, (len) => {
+  if (len > 0 && showFreshStart.value) {
+    localStorage.removeItem('fresh-start')
+    showFreshStart.value = false
+  }
+})
 
 // ── View toggle ──────────────────────────────────────────────────
 const listView = ref<'exercises' | 'timeline'>(

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -182,6 +182,20 @@ describe('WorkoutTracker', () => {
       const wrapper = mountTracker()
       expect(wrapper.find('.wtTagFilterBar').exists()).toBe(false)
     })
+
+    it('shows fresh-start transition card after clearing sample data', () => {
+      localStorageMock.setItem('fresh-start', 'true')
+      const wrapper = mountTracker()
+      expect(wrapper.find('.wtFreshStart').exists()).toBe(true)
+      expect(wrapper.find('.wtFreshStartTitle').text()).toContain('starting fresh')
+      expect(wrapper.find('.wtFreshStartCta').exists()).toBe(true)
+    })
+
+    it('shows default empty state when fresh-start flag is absent', () => {
+      const wrapper = mountTracker()
+      expect(wrapper.find('.wtFreshStart').exists()).toBe(false)
+      expect(wrapper.find('.wtEmpty').text()).toContain('No exercises yet')
+    })
   })
 
   describe('exercise list', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -2078,8 +2078,8 @@ html.theme-fading .settingsSheet {
   padding: 32px 24px;
   margin: 16px;
   border-radius: 16px;
-  background: var(--glass-bg);
-  border: 1px solid var(--glass-border);
+  background: var(--glass-fill);
+  border: 1px solid var(--glass-edge);
   text-align: center;
   animation: wtFreshStartFadeIn 0.4s ease-out;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2069,6 +2069,67 @@ html.theme-fading .settingsSheet {
   line-height: 1.6;
 }
 
+/* ─── Fresh-start transition card (shown after clearing sample data) ───── */
+
+.wtFreshStart {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 32px 24px;
+  margin: 16px;
+  border-radius: 16px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  text-align: center;
+  animation: wtFreshStartFadeIn 0.4s ease-out;
+}
+
+@keyframes wtFreshStartFadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.wtFreshStartIcon {
+  color: var(--accent);
+  margin-bottom: 12px;
+  opacity: 0.8;
+}
+
+.wtFreshStartTitle {
+  font-size: var(--font-body);
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+}
+
+.wtFreshStartBody {
+  font-size: var(--font-footnote);
+  color: var(--text-muted);
+  margin: 0 0 24px;
+  line-height: 1.5;
+}
+
+.wtFreshStartCta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 24px;
+  border-radius: 12px;
+  background: var(--accent);
+  color: var(--text-on-accent, var(--bg-primary));
+  font-size: var(--font-callout);
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  min-height: 44px;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 0.15s ease;
+}
+
+.wtFreshStartCta:active {
+  opacity: 0.8;
+}
+
 /* ─── Exercise list ─────────────────────────────────────────────────────── */
 
 /* ─── Timeline view ─────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-471](https://github.com/aschung212/Lift/issues/471)



## Changes




## Commits
- [`f1e184b`](https://github.com/aschung212/Lift/commit/f1e184b) fix(#471): use correct CSS vars and add event-driven reactivity
- [`77202ff`](https://github.com/aschung212/Lift/commit/77202ff) feat(#471): add fresh-start transition card after clearing sample data

## Test Results
- Before: 1339 passing
- After: 1341 passing (2 delta)

---
_Automated by overnight pipeline — Thu Apr 30 23:36:19 PDT 2026_

## Preview
Test on your phone: https://lift-c36p3kq50-aschung212-1101s-projects.vercel.app