### PR TITLE
feat(#468): track onboarding funnel with step-level analytics

### DIFF
--- a/src/components/OnboardingScreen.vue
+++ b/src/components/OnboardingScreen.vue
@@ -97,6 +97,8 @@ const { logEvent } = useAnalytics()
 
 const step = ref<'setup' | 'starter-flow'>('setup')
 let pendingSampleData = false
+let onboardingStartMs = 0
+let chosenPath = ''
 
 const STARTER_EXERCISES = [
   { name: 'Bench Press', tags: ['Push', 'Chest'] },
@@ -424,22 +426,32 @@ function handleStarterConfirm(themeId: ThemeId, weeklyGoal: number) {
   revertPreview()
   progressionStore.setStarterTheme(themeId, weeklyGoal)
   currentTheme.value = themeId
+  const durationMs = onboardingStartMs ? Date.now() - onboardingStartMs : 0
+  logEvent('onboarding_complete', { path: chosenPath, theme: themeId, goal: weeklyGoal, durationMs })
   finish(pendingSampleData)
 }
 
 function handleStarterSkip() {
   revertPreview()
+  const durationMs = onboardingStartMs ? Date.now() - onboardingStartMs : 0
+  logEvent('onboarding_complete', { path: chosenPath, theme: 'default', goal: 0, durationMs, skipped: true })
   finish(pendingSampleData)
 }
 
 function chooseEmpty() {
+  onboardingStartMs = Date.now()
+  chosenPath = 'empty'
   logEvent('onboarding_choice', { choice: 'empty' })
+  logEvent('onboarding_step', { step: 'choice', value: 'empty' })
   emit('started')
   goToStarter(false)
 }
 
 function chooseStarter() {
+  onboardingStartMs = Date.now()
+  chosenPath = 'starter'
   logEvent('onboarding_choice', { choice: 'starter' })
+  logEvent('onboarding_step', { step: 'choice', value: 'starter' })
   emit('started')
   for (const ex of STARTER_EXERCISES) {
     workoutStore.addExercise(ex.name, ex.tags)
@@ -450,7 +462,10 @@ function chooseStarter() {
 const noSync = { sync: false }
 
 function chooseExplore() {
+  onboardingStartMs = Date.now()
+  chosenPath = 'explore'
   logEvent('onboarding_choice', { choice: 'explore' })
+  logEvent('onboarding_step', { step: 'choice', value: 'explore' })
   emit('started')
   // Add exercises with sample sets — skip Supabase sync for sample data (MAS-197)
   for (const group of SAMPLE_SETS) {

--- a/src/components/StarterPickerFlow.vue
+++ b/src/components/StarterPickerFlow.vue
@@ -8,8 +8,8 @@
       <div class="spfExplainerRow">Earn enough XP to unlock new themes</div>
       <div class="spfExplainerRow">Build streaks for even more XP</div>
     </div>
-    <button class="spfPrimary" @click="step = 'pick'">Pick a Starter Theme</button>
-    <button v-if="showSkip" class="spfSecondary" @click="emit('revert-preview'); emit('skip')">Skip — I'll use the defaults</button>
+    <button class="spfPrimary" @click="goToPick">Pick a Starter Theme</button>
+    <button v-if="showSkip" class="spfSecondary" @click="skipFlow('explainer')">Skip — I'll use the defaults</button>
   </template>
 
   <!-- Step 2: Starter pick -->
@@ -35,8 +35,8 @@
       </button>
     </div>
     <div class="spfWarning">This choice is semi-permanent. You can change it later, but your progression will reset.</div>
-    <button class="spfPrimary" :disabled="!selection" @click="step = 'goal'">Next</button>
-    <button v-if="showSkip" class="spfSecondary" @click="emit('revert-preview'); emit('skip')">Skip</button>
+    <button class="spfPrimary" :disabled="!selection" @click="goToGoal">Next</button>
+    <button v-if="showSkip" class="spfSecondary" @click="skipFlow('pick')">Skip</button>
   </template>
 
   <!-- Step 3: Weekly goal -->
@@ -54,7 +54,7 @@
       <div class="spfGoalHint">You can increase this later without losing your streak. Decreasing it will reset your streak.</div>
       <div v-if="goal >= 7" class="spfGoalRest">Rest days are critical for recovery. 6 and 7 days earn the same bonus.</div>
     </div>
-    <button class="spfPrimary" @click="$emit('confirm', selection!, goal)">Let's Go</button>
+    <button class="spfPrimary" @click="confirmGoal">Let's Go</button>
     <button class="spfSecondary" @click="step = 'pick'">Back</button>
   </template>
 </template>
@@ -62,6 +62,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { THEME_PREVIEWS, type ThemeId } from '../composables/useTheme'
+import { useAnalytics } from '../composables/useAnalytics'
 
 const props = withDefaults(defineProps<{
   showSkip?: boolean
@@ -77,6 +78,8 @@ const emit = defineEmits<{
   preview: [themeId: ThemeId]
   'revert-preview': []
 }>()
+
+const { logEvent } = useAnalytics()
 
 const step = ref<'explainer' | 'pick' | 'goal'>('explainer')
 const selection = ref<ThemeId | null>(null)
@@ -99,6 +102,27 @@ const bonusLabel = computed(() => {
 
 function getPreview(id: ThemeId) {
   return THEME_PREVIEWS[id]?.[props.resolvedMode] || THEME_PREVIEWS[id]?.dark || { accent: '#888', bg: '#222' }
+}
+
+function goToPick() {
+  logEvent('onboarding_step', { step: 'explainer_done' })
+  step.value = 'pick'
+}
+
+function goToGoal() {
+  logEvent('onboarding_step', { step: 'pick_done', theme: selection.value })
+  step.value = 'goal'
+}
+
+function confirmGoal() {
+  logEvent('onboarding_step', { step: 'goal_done', goal: goal.value })
+  emit('confirm', selection.value!, goal.value)
+}
+
+function skipFlow(fromStep: string) {
+  logEvent('onboarding_step', { step: 'skip', from: fromStep })
+  emit('revert-preview')
+  emit('skip')
 }
 
 function selectStarter(id: ThemeId) {

--- a/src/components/__tests__/StarterPickerFlow.test.ts
+++ b/src/components/__tests__/StarterPickerFlow.test.ts
@@ -3,8 +3,17 @@ import { mount, VueWrapper } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import StarterPickerFlow from '../StarterPickerFlow.vue'
 
-import { getLocalStorageMock } from '../../__tests__/helpers'
+import { getLocalStorageMock, mockAnalytics } from '../../__tests__/helpers'
 const localStorageMock = getLocalStorageMock()
+
+const mockLogEvent = vi.fn()
+vi.mock('../../composables/useAnalytics', () => ({
+  useAnalytics: () => ({
+    logEvent: mockLogEvent,
+    tabSwitch: vi.fn(),
+    flushEngagement: vi.fn(),
+  })
+}))
 
 describe('StarterPickerFlow', () => {
   let wrapper: VueWrapper
@@ -69,6 +78,47 @@ describe('StarterPickerFlow', () => {
 
       expect(wrapper.emitted('revert-preview')).toHaveLength(1)
       expect(wrapper.emitted('skip')).toHaveLength(1)
+    })
+  })
+
+  describe('onboarding step analytics', () => {
+    it('fires onboarding_step when advancing from explainer to pick', async () => {
+      mockLogEvent.mockClear()
+      await wrapper.find('.spfPrimary').trigger('click')
+      expect(mockLogEvent).toHaveBeenCalledWith('onboarding_step', { step: 'explainer_done' })
+    })
+
+    it('fires onboarding_step when advancing from pick to goal', async () => {
+      mockLogEvent.mockClear()
+      await wrapper.find('.spfPrimary').trigger('click') // explainer → pick
+      mockLogEvent.mockClear()
+
+      const cards = wrapper.findAll('.spfCard')
+      await cards[0].trigger('click') // select fire
+      await wrapper.find('.spfPrimary').trigger('click') // pick → goal
+
+      expect(mockLogEvent).toHaveBeenCalledWith('onboarding_step', { step: 'pick_done', theme: 'fire' })
+    })
+
+    it('fires onboarding_step with skip and from step when skipping from explainer', async () => {
+      mockLogEvent.mockClear()
+      await wrapper.find('.spfSecondary').trigger('click') // Skip
+      expect(mockLogEvent).toHaveBeenCalledWith('onboarding_step', { step: 'skip', from: 'explainer' })
+    })
+
+    it('fires onboarding_step with goal_done on confirm', async () => {
+      mockLogEvent.mockClear()
+      await wrapper.find('.spfPrimary').trigger('click') // explainer → pick
+      const cards = wrapper.findAll('.spfCard')
+      await cards[1].trigger('click') // select water
+      await wrapper.find('.spfPrimary').trigger('click') // pick → goal
+      mockLogEvent.mockClear()
+
+      await wrapper.find('.spfPrimary').trigger('click') // confirm
+
+      expect(mockLogEvent).toHaveBeenCalledWith('onboarding_step', { step: 'goal_done', goal: 3 })
+      expect(wrapper.emitted('confirm')).toHaveLength(1)
+      expect(wrapper.emitted('confirm')![0]).toEqual(['water', 3])
     })
   })
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-468](https://github.com/aschung212/Lift/issues/468)

Implemented **LIFT-468** — Track onboarding funnel completion rate with step-level analytics. This was the highest-priority remaining issue (P2) and is essential for understanding where users drop off in the onboarding flow.

## Changes
- Added `onboarding_step` events at each StarterPickerFlow transition (explainer → pick → goal, plus skip from any step)
- Added `onboarding_complete` event in OnboardingScreen with `{path, theme, goal, durationMs}` metadata (plus `skipped: true` on skip)
- Preserved existing `onboarding_choice` events for backward compatibility
- Added 4 new test cases covering all step transitions and skip analytics
- Wired `useAnalytics` into `StarterPickerFlow.vue` (previously had no analytics)

## Verification

### Steps to test
1. Open Vercel Analytics dashboard for the project
2. Clear localStorage (or use incognito) to trigger onboarding
3. Go through the full onboarding flow: choose "Popular exercises" → read explainer → pick a starter theme → set weekly goal → confirm
4. Check Vercel Analytics for `onboarding_step` and `onboarding_complete` events
5. Repeat with "Skip" at the explainer step — verify `onboarding_step {step: 'skip', from: 'explainer'}` fires
6. Repeat with "Skip" at the pick step — verify skip event includes `from: 'pick'`

### Expected behavior
- Each step transition fires an `onboarding_step` event with the appropriate step name
- Completing the flow fires `onboarding_complete` with path, theme, goal, and durationMs
- Skipping fires both an `onboarding_step` skip event and `onboarding_complete` with `skipped: true`
- All existing onboarding behavior unchanged — UI, navigation, and data loading work identically

### What to watch for
- Verify the `durationMs` value is reasonable (seconds, not milliseconds of zero)
- Confirm skip from both explainer and pick steps fire correctly
- Ensure no double-firing of events (each transition should fire exactly one `onboarding_step`)
- Existing `onboarding_choice` events should still fire alongside new events

### Risk assessment
- **Scope:** Narrow — only onboarding flow, analytics-only change, no UI or data mutations
- **Confidence:** High — pure additive analytics with no behavioral changes, all tests pass
- **Rollback:** Remove the analytics calls; no data schema or UI to revert

## Screenshots
SCREENSHOT_ROUTE:NONE

## Commits
- [`e7682e3`](https://github.com/aschung212/Lift/commit/e7682e3) feat(#468): track onboarding funnel with step-level analytics

## Test Results
- Before: 1339 passing
- After: 1343 passing (4 delta)

---
_Automated by overnight pipeline — Thu Apr 30 23:51:46 PDT 2026_

## Preview
Test on your phone: https://lift-3vvqm4gwt-aschung212-1101s-projects.vercel.app