### PR TITLE
feat(#473): add value proposition to bodyweight tracker empty state

### DIFF
--- a/src/components/BodyweightTracker.vue
+++ b/src/components/BodyweightTracker.vue
@@ -141,8 +141,10 @@
 
     <!-- graph placeholder handled by bwStatsSingle above -->
 
-    <p v-else-if="store.entries.length === 0" class="wtEmpty">
-      Hit "+ Log" to record your first weigh-in.
+    <p v-else-if="store.entries.length === 0" class="wtEmpty bwEmptyState">
+      Track your weight to spot trends over time.<br />
+      Weigh in at the same time each day for best accuracy.<br />
+      <span class="bwEmptyCta">Tap "+ Log" above to record your first weigh-in.</span>
     </p>
 
     <!-- Entries list (newest first) -->

--- a/src/components/__tests__/BodyweightTracker.test.ts
+++ b/src/components/__tests__/BodyweightTracker.test.ts
@@ -87,9 +87,13 @@ describe('BodyweightTracker', () => {
   })
 
   describe('empty state', () => {
-    it('shows empty message when no entries', () => {
+    it('shows value proposition and CTA when no entries', () => {
       const wrapper = mountTracker()
-      expect(wrapper.find('.wtEmpty').text()).toContain('Log')
+      const empty = wrapper.find('.bwEmptyState')
+      expect(empty.exists()).toBe(true)
+      expect(empty.text()).toContain('Track your weight to spot trends')
+      expect(empty.text()).toContain('same time each day')
+      expect(empty.find('.bwEmptyCta').text()).toContain('+ Log')
     })
 
     it('renders "+ Log" button', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -6074,6 +6074,16 @@ html.theme-fading .settingsSheet {
   text-align: center;
 }
 
+.bwEmptyState {
+  padding: 32px 24px;
+}
+.bwEmptyCta {
+  display: block;
+  margin-top: 8px;
+  opacity: 0.7;
+  font-size: var(--font-caption1);
+}
+
 /* ─── Responsive ─────────────────────────────────────────────────────────── */
 
 @media (max-width: 480px) {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-473](https://github.com/aschung212/Lift/issues/473)

Implemented **LIFT-473** — Bodyweight tracker empty state doesn't explain WHY to track. This is the last remaining unworked UI/UX issue. The old empty state just said "Hit + Log" with no context; the new one explains the value of tracking bodyweight and gives a consistency tip.

## Changes
- Updated `BodyweightTracker.vue` empty state from a bare CTA to a 3-line message: value prop, consistency tip, and action prompt
- Added `bwEmptyState` and `bwEmptyCta` CSS classes for subtle visual hierarchy (CTA is smaller/dimmer)
- Updated the test to verify the new value prop text and CTA element

## Verification

### Steps to test
1. Navigate to the Bodyweight tab (bottom tab bar, scale icon)
2. If you have existing entries, clear them via Settings or use a fresh account
3. Observe the empty state text below the hero header

### Expected behavior
- The empty state shows three lines:
  - "Track your weight to spot trends over time."
  - "Weigh in at the same time each day for best accuracy."
  - "Tap '+ Log' above to record your first weigh-in." (slightly smaller/dimmer)
- The "+ Log" button in the hero header above still works normally

### What to watch for
- Text should be readable in all 10 themes (both light and dark mode) — uses `--text-muted` which is theme-aware
- The CTA line should be visually subordinate (smaller font, lower opacity) to the value prop lines
- After logging a first entry, the empty state should disappear and be replaced by the single-entry prompt
- No layout shift when transitioning from empty → 1 entry

### Risk assessment
- **Scope:** Narrow — only affects `BodyweightTracker` empty state (visible only when zero entries exist)
- **Confidence:** High — text-only change using existing CSS custom properties, all tests pass
- **Rollback:** Revert the single commit

## Screenshots
SCREENSHOT_ROUTE:/

## Commits
- [`345ff11`](https://github.com/aschung212/Lift/commit/345ff11) feat(#473): add value proposition to bodyweight tracker empty state

## Test Results
- Before: 1339 passing
- After: 1339 passing (0 delta)

---
_Automated by overnight pipeline — Fri May  1 00:08:49 PDT 2026_

## Preview
Test on your phone: https://lift-kif3wplm7-aschung212-1101s-projects.vercel.app