### PR TITLE
chore(LIFT-350): upload build artifacts for PR review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: ${{ github.event_name == 'push' && 7 || 3 }}
+
       - name: Check bundle size budget
         run: |
           # Total JS bundle budget: 500 KB (currently ~410 KB)


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-350](https://github.com/aschung212/Lift/issues/350)

Implemented **LIFT-350** — Upload build artifacts for PR review. This is a clean infrastructure improvement: adds `actions/upload-artifact@v4` after the Vite build step so `dist/` is downloadable from any CI run, useful for inspecting PWA manifests and bundle contents.

## Changes
- Added `actions/upload-artifact@v4` step after `npm run build` in the `build-and-test` job
- Retention: 3 days for PR runs, 7 days for master pushes (using GitHub Actions expression)

## Verification

### Steps to test
1. Open the PR on GitHub
2. Check the CI workflow runs — the `build-and-test` job should now have an "Upload build artifacts" step
3. After CI passes, go to the workflow run summary page
4. Verify a "dist" artifact appears in the Artifacts section
5. Download it and confirm it contains the built app files

### Expected behavior
- The "Upload build artifacts" step appears between "Run npm run build" and "Check bundle size budget"
- A downloadable "dist" artifact is available on the CI run summary
- PR runs show 3-day retention, master runs show 7-day retention

### What to watch for
- The artifact upload step should not fail if the build succeeds
- Retention days expression uses correct GitHub Actions ternary syntax
- Artifact name "dist" should not conflict with anything else

### Risk assessment
- **Scope:** Narrow — CI workflow only, no app code changes
- **Confidence:** High — standard GitHub Actions pattern, no conditional logic beyond retention
- **Rollback:** Revert the single commit to remove the step

## Screenshots
SCREENSHOT_ROUTE:NONE

## Commits
- [`347fd7a`](https://github.com/aschung212/Lift/commit/347fd7a) chore(LIFT-350): upload build artifacts for PR review

## Test Results
- Before: 1339 passing
- After: 1339 passing (0 delta)

---
_Automated by overnight pipeline — Fri May  1 00:13:34 PDT 2026_