### PR TITLE
fix(#331): use ServiceWorker notifications and track background state

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -249,6 +249,21 @@
                   <span class="glassToggleThumb"></span>
                 </button>
               </div>
+              <div v-show="restTimerEnabled" class="settingsRow">
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel settingsLabelIndented">Notify when done</span>
+                  <span class="settingsHint">When app is in background</span>
+                </div>
+                <button
+                  :class="['glassToggle', { on: prefs.experience.restTimerNotification }]"
+                  @click="toggleExperience('restTimerNotification')"
+                  role="switch"
+                  :aria-checked="prefs.experience.restTimerNotification"
+                  :aria-label="prefs.experience.restTimerNotification ? 'Disable rest timer notification' : 'Enable rest timer notification'"
+                >
+                  <span class="glassToggleThumb"></span>
+                </button>
+              </div>
             </div>
 
             <div class="settingsGroup">
@@ -1585,7 +1600,7 @@ function setMode(mode: 'light' | 'dark' | 'auto') {
   logEvent('mode_toggle', { mode })
 }
 
-function toggleExperience(key: 'prCelebrations' | 'haptics' | 'screenWakeLock') {
+function toggleExperience(key: 'prCelebrations' | 'haptics' | 'screenWakeLock' | 'restTimerNotification') {
   const next = !prefs.experience[key]
   prefs.setExperienceFlag(key, next)
   logEvent('experience_toggle', { key, enabled: next })

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1001,7 +1001,7 @@ import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
 import { usePRBaseline } from '../composables/usePRBaseline'
 import { usePRBurst } from '../composables/usePRBurst'
-import { useNotification } from '../composables/useNotification'
+import { useNotification, useBackgroundTracker } from '../composables/useNotification'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
@@ -1018,6 +1018,7 @@ const { impactLight, notifySuccess } = useHaptics()
 const { prBaselineDate } = usePRBaseline()
 const { presentPRBurst } = usePRBurst()
 const { notify: sendNotification, requestPermission: requestNotificationPermission } = useNotification()
+const { wasBackgrounded, startTracking: startBgTracking, stopTracking: stopBgTracking } = useBackgroundTracker()
 
 // Screen Wake Lock — keep display on during active workouts
 import { useWakeLock } from '../composables/useWakeLock'
@@ -2187,8 +2188,10 @@ function startInterval() {
         if (_prefs.experience.restTimerNotification) {
           sendNotification('Rest Complete', {
             body: 'Time to get back to work 💪',
+            wasBackgrounded: wasBackgrounded.value,
           })
         }
+        stopBgTracking()
         if (!editingPresets.value) {
           onTimerComplete()
         }
@@ -2201,6 +2204,7 @@ function startRestTimer() {
   ensureAudioCtx()
   if (_prefs.experience.restTimerNotification) {
     requestNotificationPermission()
+    startBgTracking()
   }
   timerActive.value = true
   timerPaused.value = false

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1001,6 +1001,7 @@ import { useFocusTrap } from '../composables/useFocusTrap'
 import { useHaptics } from '../composables/useHaptics'
 import { usePRBaseline } from '../composables/usePRBaseline'
 import { usePRBurst } from '../composables/usePRBurst'
+import { useNotification } from '../composables/useNotification'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { THEMES } from '../composables/useTheme'
@@ -1016,6 +1017,7 @@ const { currentTheme, restTimerEnabled, restTimerAutoStart, weightUnit, displayW
 const { impactLight, notifySuccess } = useHaptics()
 const { prBaselineDate } = usePRBaseline()
 const { presentPRBurst } = usePRBurst()
+const { notify: sendNotification, requestPermission: requestNotificationPermission } = useNotification()
 
 // Screen Wake Lock — keep display on during active workouts
 import { useWakeLock } from '../composables/useWakeLock'
@@ -2182,6 +2184,11 @@ function startInterval() {
         timerIntervalId = null
         timerSeconds.value = 0
         timerAnnouncement.value = 'Rest timer done'
+        if (_prefs.experience.restTimerNotification) {
+          sendNotification('Rest Complete', {
+            body: 'Time to get back to work 💪',
+          })
+        }
         if (!editingPresets.value) {
           onTimerComplete()
         }
@@ -2192,6 +2199,9 @@ function startInterval() {
 
 function startRestTimer() {
   ensureAudioCtx()
+  if (_prefs.experience.restTimerNotification) {
+    requestNotificationPermission()
+  }
   timerActive.value = true
   timerPaused.value = false
   timerSeconds.value = restDuration.value

--- a/src/composables/__tests__/useNotification.test.ts
+++ b/src/composables/__tests__/useNotification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { useNotification } from '../useNotification'
+import { useNotification, useBackgroundTracker } from '../useNotification'
 
 describe('useNotification', () => {
   let originalNotification: typeof globalThis.Notification
@@ -101,7 +101,7 @@ describe('useNotification', () => {
   })
 
   describe('notify', () => {
-    it('does not show notification when app is visible', () => {
+    it('does not show notification when app is visible and was not backgrounded', async () => {
       const mockClose = vi.fn()
       const MockNotification = vi.fn().mockImplementation(() => ({ close: mockClose, onclick: null }))
       Object.defineProperty(MockNotification, 'permission', { value: 'granted', configurable: true })
@@ -109,14 +109,69 @@ describe('useNotification', () => {
       globalThis.Notification = MockNotification
 
       Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+      // Mock no service worker
+      Object.defineProperty(navigator, 'serviceWorker', { value: undefined, configurable: true })
 
       const { notify } = useNotification()
-      const result = notify('Test')
-      expect(result).toBeNull()
+      const result = await notify('Test')
+      expect(result).toBe(false)
       expect(MockNotification).not.toHaveBeenCalled()
     })
 
-    it('shows notification when app is hidden and permission granted', () => {
+    it('shows notification when app is hidden and permission granted', async () => {
+      const mockShowNotification = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: { getRegistration: vi.fn().mockResolvedValue({ showNotification: mockShowNotification }) },
+        configurable: true,
+      })
+
+      Object.defineProperty(globalThis, 'Notification', {
+        value: { permission: 'granted' },
+        writable: true,
+        configurable: true,
+      })
+
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+
+      const { notify } = useNotification()
+      const result = await notify('Rest Complete', { body: 'Time to lift' })
+      expect(result).toBe(true)
+      expect(mockShowNotification).toHaveBeenCalledWith('Rest Complete', expect.objectContaining({
+        body: 'Time to lift',
+        tag: 'lift-rest-timer',
+      }))
+    })
+
+    it('shows notification when wasBackgrounded is true even if currently visible', async () => {
+      const mockShowNotification = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: { getRegistration: vi.fn().mockResolvedValue({ showNotification: mockShowNotification }) },
+        configurable: true,
+      })
+
+      Object.defineProperty(globalThis, 'Notification', {
+        value: { permission: 'granted' },
+        writable: true,
+        configurable: true,
+      })
+
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+
+      const { notify } = useNotification()
+      const result = await notify('Rest Complete', { body: 'Back at it', wasBackgrounded: true })
+      expect(result).toBe(true)
+      expect(mockShowNotification).toHaveBeenCalledWith('Rest Complete', expect.objectContaining({
+        body: 'Back at it',
+        tag: 'lift-rest-timer',
+      }))
+    })
+
+    it('falls back to Notification constructor when SW is unavailable', async () => {
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: { getRegistration: vi.fn().mockResolvedValue(undefined) },
+        configurable: true,
+      })
+
       const mockClose = vi.fn()
       class MockNotification {
         static permission = 'granted'
@@ -130,28 +185,46 @@ describe('useNotification', () => {
       Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
 
       const { notify } = useNotification()
-      const result = notify('Rest Complete', { body: 'Time to lift' })
-      expect(result).not.toBeNull()
-      expect(result).toBeInstanceOf(MockNotification)
-      expect((result as unknown as MockNotification).title).toBe('Rest Complete')
-      expect((result as unknown as MockNotification).options).toMatchObject({
-        body: 'Time to lift',
-        tag: 'lift-rest-timer',
-      })
+      const result = await notify('Rest Complete', { body: 'Time to lift' })
+      expect(result).toBe(true)
     })
 
-    it('does not show notification when permission is not granted', () => {
-      const MockNotification = vi.fn()
-      Object.defineProperty(MockNotification, 'permission', { value: 'default', configurable: true })
-      // @ts-expect-error test mock
-      globalThis.Notification = MockNotification
+    it('does not show notification when permission is not granted', async () => {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: { permission: 'default' },
+        writable: true,
+        configurable: true,
+      })
 
       Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
 
       const { notify } = useNotification()
-      const result = notify('Test')
-      expect(result).toBeNull()
-      expect(MockNotification).not.toHaveBeenCalled()
+      const result = await notify('Test')
+      expect(result).toBe(false)
+    })
+
+    it('returns true even if Notification constructor throws', async () => {
+      // SW available but throws, constructor also throws
+      Object.defineProperty(navigator, 'serviceWorker', {
+        value: { getRegistration: vi.fn().mockResolvedValue(undefined) },
+        configurable: true,
+      })
+
+      Object.defineProperty(globalThis, 'Notification', {
+        value: class {
+          static permission = 'granted'
+          constructor() { throw new TypeError('Illegal constructor') }
+        },
+        writable: true,
+        configurable: true,
+      })
+
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+
+      const { notify } = useNotification()
+      // Should not throw, just return false
+      const result = await notify('Test')
+      expect(result).toBe(false)
     })
   })
 
@@ -174,5 +247,37 @@ describe('useNotification', () => {
       await requestPermission()
       expect(hasAskedBefore()).toBe(true)
     })
+  })
+})
+
+describe('useBackgroundTracker', () => {
+  it('starts with wasBackgrounded false', () => {
+    const { wasBackgrounded } = useBackgroundTracker()
+    expect(wasBackgrounded.value).toBe(false)
+  })
+
+  it('sets wasBackgrounded to true when visibility changes to hidden', () => {
+    const { wasBackgrounded, startTracking, stopTracking } = useBackgroundTracker()
+    startTracking()
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    expect(wasBackgrounded.value).toBe(true)
+    stopTracking()
+  })
+
+  it('resets wasBackgrounded when startTracking is called again', () => {
+    const { wasBackgrounded, startTracking, stopTracking } = useBackgroundTracker()
+    startTracking()
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+    document.dispatchEvent(new Event('visibilitychange'))
+    expect(wasBackgrounded.value).toBe(true)
+
+    // Reset by calling startTracking again
+    startTracking()
+    expect(wasBackgrounded.value).toBe(false)
+    stopTracking()
   })
 })

--- a/src/composables/__tests__/useNotification.test.ts
+++ b/src/composables/__tests__/useNotification.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useNotification } from '../useNotification'
+
+describe('useNotification', () => {
+  let originalNotification: typeof globalThis.Notification
+
+  beforeEach(() => {
+    originalNotification = globalThis.Notification
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    globalThis.Notification = originalNotification
+    vi.restoreAllMocks()
+  })
+
+  describe('isSupported', () => {
+    it('returns true when Notification is available', () => {
+      // @ts-expect-error test mock
+      globalThis.Notification = class {} as unknown as typeof Notification
+      const { isSupported } = useNotification()
+      expect(isSupported()).toBe(true)
+    })
+
+    it('returns false when Notification is not available', () => {
+      // @ts-expect-error test mock
+      delete globalThis.Notification
+      const { isSupported } = useNotification()
+      expect(isSupported()).toBe(false)
+    })
+  })
+
+  describe('hasPermission', () => {
+    it('returns true when permission is granted', () => {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: { permission: 'granted' },
+        writable: true,
+        configurable: true,
+      })
+      const { hasPermission } = useNotification()
+      expect(hasPermission()).toBe(true)
+    })
+
+    it('returns false when permission is denied', () => {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: { permission: 'denied' },
+        writable: true,
+        configurable: true,
+      })
+      const { hasPermission } = useNotification()
+      expect(hasPermission()).toBe(false)
+    })
+  })
+
+  describe('requestPermission', () => {
+    it('resolves to true when permission is granted', async () => {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: {
+          permission: 'default',
+          requestPermission: vi.fn().mockResolvedValue('granted'),
+        },
+        writable: true,
+        configurable: true,
+      })
+      const { requestPermission } = useNotification()
+      const result = await requestPermission()
+      expect(result).toBe(true)
+    })
+
+    it('returns false without prompting when already denied', async () => {
+      const mockRequest = vi.fn()
+      Object.defineProperty(globalThis, 'Notification', {
+        value: {
+          permission: 'denied',
+          requestPermission: mockRequest,
+        },
+        writable: true,
+        configurable: true,
+      })
+      const { requestPermission } = useNotification()
+      const result = await requestPermission()
+      expect(result).toBe(false)
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('returns true without prompting when already granted', async () => {
+      const mockRequest = vi.fn()
+      Object.defineProperty(globalThis, 'Notification', {
+        value: {
+          permission: 'granted',
+          requestPermission: mockRequest,
+        },
+        writable: true,
+        configurable: true,
+      })
+      const { requestPermission } = useNotification()
+      const result = await requestPermission()
+      expect(result).toBe(true)
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('notify', () => {
+    it('does not show notification when app is visible', () => {
+      const mockClose = vi.fn()
+      const MockNotification = vi.fn().mockImplementation(() => ({ close: mockClose, onclick: null }))
+      Object.defineProperty(MockNotification, 'permission', { value: 'granted', configurable: true })
+      // @ts-expect-error test mock
+      globalThis.Notification = MockNotification
+
+      Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true })
+
+      const { notify } = useNotification()
+      const result = notify('Test')
+      expect(result).toBeNull()
+      expect(MockNotification).not.toHaveBeenCalled()
+    })
+
+    it('shows notification when app is hidden and permission granted', () => {
+      const mockClose = vi.fn()
+      class MockNotification {
+        static permission = 'granted'
+        close = mockClose
+        onclick = null
+        constructor(public title: string, public options?: NotificationOptions) {}
+      }
+      // @ts-expect-error test mock
+      globalThis.Notification = MockNotification
+
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+
+      const { notify } = useNotification()
+      const result = notify('Rest Complete', { body: 'Time to lift' })
+      expect(result).not.toBeNull()
+      expect(result).toBeInstanceOf(MockNotification)
+      expect((result as unknown as MockNotification).title).toBe('Rest Complete')
+      expect((result as unknown as MockNotification).options).toMatchObject({
+        body: 'Time to lift',
+        tag: 'lift-rest-timer',
+      })
+    })
+
+    it('does not show notification when permission is not granted', () => {
+      const MockNotification = vi.fn()
+      Object.defineProperty(MockNotification, 'permission', { value: 'default', configurable: true })
+      // @ts-expect-error test mock
+      globalThis.Notification = MockNotification
+
+      Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true })
+
+      const { notify } = useNotification()
+      const result = notify('Test')
+      expect(result).toBeNull()
+      expect(MockNotification).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('hasAskedBefore', () => {
+    it('returns false initially', () => {
+      const { hasAskedBefore } = useNotification()
+      expect(hasAskedBefore()).toBe(false)
+    })
+
+    it('returns true after permission is requested', async () => {
+      Object.defineProperty(globalThis, 'Notification', {
+        value: {
+          permission: 'default',
+          requestPermission: vi.fn().mockResolvedValue('denied'),
+        },
+        writable: true,
+        configurable: true,
+      })
+      const { requestPermission, hasAskedBefore } = useNotification()
+      await requestPermission()
+      expect(hasAskedBefore()).toBe(true)
+    })
+  })
+})

--- a/src/composables/useNotification.ts
+++ b/src/composables/useNotification.ts
@@ -11,7 +11,7 @@
  * Android Chrome and iOS 16.4+ PWAs), falling back to the Notification constructor.
  */
 
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onUnmounted } from 'vue'
 
 const PERMISSION_KEY = 'notification-permission-asked'
 
@@ -65,7 +65,11 @@ async function notify(
   // Only fire if the app IS backgrounded or WAS backgrounded during the timer
   if (!isBackgrounded() && !wasBg) return false
 
-  const finalOptions: NotificationOptions = {
+  // `renotify` is a non-standard but widely-supported Chrome/Android extension
+  // that re-fires a notification with the same tag (so a second rest-timer
+  // completion still alerts). It's missing from the standard NotificationOptions
+  // TS type, so we extend it locally rather than asserting the whole object.
+  const finalOptions: NotificationOptions & { renotify?: boolean } = {
     icon: '/icon-192.png',
     badge: '/icon-192.png',
     tag: 'lift-rest-timer',

--- a/src/composables/useNotification.ts
+++ b/src/composables/useNotification.ts
@@ -1,0 +1,84 @@
+/**
+ * Composable for sending browser notifications when the app is backgrounded.
+ * Used by the rest timer to alert users when their rest period is complete.
+ */
+
+const PERMISSION_KEY = 'notification-permission-asked'
+
+/** Whether the browser supports the Notification API */
+function isSupported(): boolean {
+  return 'Notification' in window
+}
+
+/** Whether we already have permission granted */
+function hasPermission(): boolean {
+  return isSupported() && Notification.permission === 'granted'
+}
+
+/** Whether permission was previously denied (don't ask again) */
+function isDenied(): boolean {
+  return isSupported() && Notification.permission === 'denied'
+}
+
+/** Whether the app is currently not visible to the user */
+function isBackgrounded(): boolean {
+  return document.visibilityState === 'hidden'
+}
+
+/**
+ * Request notification permission. Returns true if granted.
+ * Only asks once — if denied, returns false without prompting.
+ */
+async function requestPermission(): Promise<boolean> {
+  if (!isSupported()) return false
+  if (hasPermission()) return true
+  if (isDenied()) return false
+
+  const result = await Notification.requestPermission()
+  localStorage.setItem(PERMISSION_KEY, 'true')
+  return result === 'granted'
+}
+
+/**
+ * Show a notification if the app is backgrounded and permission is granted.
+ * Returns the Notification instance if shown, null otherwise.
+ */
+function notify(title: string, options?: NotificationOptions): Notification | null {
+  if (!hasPermission() || !isBackgrounded()) return null
+
+  const notification = new Notification(title, {
+    icon: '/icon-192.png',
+    badge: '/icon-192.png',
+    tag: 'lift-rest-timer',
+    renotify: true,
+    ...options,
+  })
+
+  // Auto-close after 5 seconds
+  setTimeout(() => notification.close(), 5000)
+
+  // Focus the app when the notification is clicked
+  notification.onclick = () => {
+    window.focus()
+    notification.close()
+  }
+
+  return notification
+}
+
+/** Whether we've already asked the user for permission in a previous session */
+function hasAskedBefore(): boolean {
+  return localStorage.getItem(PERMISSION_KEY) === 'true'
+}
+
+export function useNotification() {
+  return {
+    isSupported,
+    hasPermission,
+    isDenied,
+    isBackgrounded,
+    hasAskedBefore,
+    requestPermission,
+    notify,
+  }
+}

--- a/src/composables/useNotification.ts
+++ b/src/composables/useNotification.ts
@@ -1,7 +1,17 @@
 /**
  * Composable for sending browser notifications when the app is backgrounded.
  * Used by the rest timer to alert users when their rest period is complete.
+ *
+ * Handles two scenarios:
+ * 1. App is currently backgrounded — show notification immediately
+ * 2. App was backgrounded during a timer — show notification when interval resumes
+ *    (mobile browsers suspend JS, so the timer fires when the user returns)
+ *
+ * Uses ServiceWorkerRegistration.showNotification() when available (required on
+ * Android Chrome and iOS 16.4+ PWAs), falling back to the Notification constructor.
  */
+
+import { ref, onMounted, onUnmounted } from 'vue'
 
 const PERMISSION_KEY = 'notification-permission-asked'
 
@@ -40,35 +50,87 @@ async function requestPermission(): Promise<boolean> {
 }
 
 /**
- * Show a notification if the app is backgrounded and permission is granted.
- * Returns the Notification instance if shown, null otherwise.
+ * Show a notification via ServiceWorker (preferred) or Notification constructor (fallback).
+ * Fires when the app is backgrounded OR was recently backgrounded (covers the case where
+ * the browser suspended JS and the timer fires after the user returns).
  */
-function notify(title: string, options?: NotificationOptions): Notification | null {
-  if (!hasPermission() || !isBackgrounded()) return null
+async function notify(
+  title: string,
+  options?: NotificationOptions & { wasBackgrounded?: boolean },
+): Promise<boolean> {
+  if (!hasPermission()) return false
 
-  const notification = new Notification(title, {
+  const { wasBackgrounded: wasBg, ...notifOptions } = options ?? {}
+
+  // Only fire if the app IS backgrounded or WAS backgrounded during the timer
+  if (!isBackgrounded() && !wasBg) return false
+
+  const finalOptions: NotificationOptions = {
     icon: '/icon-192.png',
     badge: '/icon-192.png',
     tag: 'lift-rest-timer',
     renotify: true,
-    ...options,
-  })
-
-  // Auto-close after 5 seconds
-  setTimeout(() => notification.close(), 5000)
-
-  // Focus the app when the notification is clicked
-  notification.onclick = () => {
-    window.focus()
-    notification.close()
+    ...notifOptions,
   }
 
-  return notification
+  try {
+    // Prefer ServiceWorker showNotification — required on Android Chrome & iOS PWAs
+    const reg = await navigator.serviceWorker?.getRegistration()
+    if (reg) {
+      await reg.showNotification(title, finalOptions)
+      return true
+    }
+  } catch {
+    // Fall through to constructor fallback
+  }
+
+  try {
+    const notification = new Notification(title, finalOptions)
+    setTimeout(() => notification.close(), 5000)
+    notification.onclick = () => {
+      window.focus()
+      notification.close()
+    }
+    return true
+  } catch {
+    // Notification constructor not supported (some mobile browsers)
+    return false
+  }
 }
 
 /** Whether we've already asked the user for permission in a previous session */
 function hasAskedBefore(): boolean {
   return localStorage.getItem(PERMISSION_KEY) === 'true'
+}
+
+/**
+ * Tracks whether the document was backgrounded since calling `startTracking()`.
+ * Used by the rest timer to know if a notification should fire even though the
+ * app is now visible (because JS was suspended while backgrounded).
+ */
+export function useBackgroundTracker() {
+  const wasBackgrounded = ref(false)
+
+  function onVisibilityChange() {
+    if (document.visibilityState === 'hidden') {
+      wasBackgrounded.value = true
+    }
+  }
+
+  function startTracking() {
+    wasBackgrounded.value = false
+    document.addEventListener('visibilitychange', onVisibilityChange)
+  }
+
+  function stopTracking() {
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+  }
+
+  onUnmounted(() => {
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+  })
+
+  return { wasBackgrounded, startTracking, stopTracking }
 }
 
 export function useNotification() {

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -29,6 +29,8 @@ export interface ExperienceFlags {
   haptics: boolean
   /** Keep the screen awake during rest timer and set logging. */
   screenWakeLock: boolean
+  /** Show a browser notification when the rest timer completes while the app is backgrounded. */
+  restTimerNotification: boolean
 }
 
 const DEFAULT_WEIGHT_GOAL: WeightGoalConfig = {
@@ -49,6 +51,7 @@ const DEFAULT_EXPERIENCE: ExperienceFlags = {
   prCelebrations: true,
   haptics: true,
   screenWakeLock: true,
+  restTimerNotification: true,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-331](https://github.com/aschung212/Lift/issues/331)



## Changes




## Commits
- [`6595da3`](https://github.com/aschung212/Lift/commit/6595da3) fix(#331): use ServiceWorker notifications and track background state
- [`182038f`](https://github.com/aschung212/Lift/commit/182038f) feat(#331): push notifications for rest timer completion when backgrounded

## Test Results
- Before: 1351 passing
- After: 1357 passing (6 delta)

---
_Automated by overnight pipeline — Sat May  2 00:38:24 PDT 2026_

## Preview
Test on your phone: https://lift-48hqljh2l-aschung212-1101s-projects.vercel.app