### PR TITLE
fix(#486): reset scroll to top for first-visit tabs and use switchTab 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1211,7 +1211,7 @@ const tabIndicatorStyle = computed(() => {
 // Fall back if active tab gets disabled
 watch(() => prefs.features, () => {
   if (!prefs.features[activeTab.value]) {
-    activeTab.value = visibleTabs.value[0]?.id || 'workouts'
+    switchTab(visibleTabs.value[0]?.id || 'workouts')
   }
 }, { deep: true })
 
@@ -1232,10 +1232,10 @@ function switchTab(tabId: string) {
   localStorage.setItem('active-tab', tabId)
   tabSwitch(from, tabId)
   checkForSWUpdate()
-  // Restore scroll position of incoming tab
+  // Restore scroll position of incoming tab (default to top)
   nextTick(() => {
-    if (tabContentEl.value && tabScrollPositions[tabId] != null) {
-      tabContentEl.value.scrollTop = tabScrollPositions[tabId]
+    if (tabContentEl.value) {
+      tabContentEl.value.scrollTop = tabScrollPositions[tabId] ?? 0
     }
   })
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,9 +54,13 @@
             </button>
           </div>
         </div>
-        <div v-show="activeTab === 'workouts'" class="tabContent"><WorkoutTracker ref="workoutTrackerRef" /></div>
-        <div v-show="activeTab === 'calendar'" class="tabContent"><CalendarView /></div>
-        <div v-show="activeTab === 'weight'" class="tabContent"><BodyweightTracker /></div>
+        <div ref="tabContentEl" class="tabContent">
+          <KeepAlive>
+            <WorkoutTracker v-if="activeTab === 'workouts'" ref="workoutTrackerRef" />
+            <CalendarView v-else-if="activeTab === 'calendar'" />
+            <BodyweightTracker v-else-if="activeTab === 'weight'" />
+          </KeepAlive>
+        </div>
       </main>
 
       <!-- Tab bar -->
@@ -1211,15 +1215,29 @@ watch(() => prefs.features, () => {
   }
 }, { deep: true })
 
+// ── Tab scroll position preservation ─────────────────────────────
+const tabContentEl = ref<HTMLElement | null>(null)
+const tabScrollPositions: Record<string, number> = {}
+
 // ── Analytics ────────────────────────────────────────────────────
 function switchTab(tabId: string) {
   const from = activeTab.value
   closeSettings()
   if (from === tabId) return
+  // Save scroll position of outgoing tab
+  if (tabContentEl.value) {
+    tabScrollPositions[from] = tabContentEl.value.scrollTop
+  }
   activeTab.value = tabId
   localStorage.setItem('active-tab', tabId)
   tabSwitch(from, tabId)
   checkForSWUpdate()
+  // Restore scroll position of incoming tab
+  nextTick(() => {
+    if (tabContentEl.value && tabScrollPositions[tabId] != null) {
+      tabContentEl.value.scrollTop = tabScrollPositions[tabId]
+    }
+  })
 }
 
 function selectTheme(id: string) {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-486](https://github.com/aschung212/Lift/issues/486)



## Changes




## Commits
- [`fa7cce4`](https://github.com/aschung212/Lift/commit/fa7cce4) fix(#486): reset scroll to top for first-visit tabs and use switchTab in fallback
- [`6587742`](https://github.com/aschung212/Lift/commit/6587742) perf(#486): use v-if + KeepAlive for inactive tabs instead of v-show

## Test Results
- Before: 1353 passing
- After: 1353 passing (0 delta)

---
_Automated by overnight pipeline — Mon May  4 23:13:46 PDT 2026_

## Preview
Test on your phone: https://lift-pzgtt6uo6-aschung212-1101s-projects.vercel.app