### PR TITLE
perf(#482): conditional source maps — only generate when Sentry toke

### DIFF
--- a/src/lib/__tests__/buildConfigRegression.test.ts
+++ b/src/lib/__tests__/buildConfigRegression.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), 'utf-8')
+
+describe('vite.config.js regression', () => {
+  it('should only generate source maps when SENTRY_AUTH_TOKEN is set', () => {
+    // Source maps are ~1.75MB and should only be generated when Sentry will upload
+    // and delete them. When SENTRY_AUTH_TOKEN is missing, they ship to production.
+    // See: LIFT-482
+    expect(viteConfig).toContain('sourcemap: !!process.env.SENTRY_AUTH_TOKEN')
+    expect(viteConfig).not.toMatch(/sourcemap:\s*true/)
+  })
+
+  it('should conditionally include sentry plugin only when auth token exists', () => {
+    expect(viteConfig).toContain('process.env.SENTRY_AUTH_TOKEN')
+    expect(viteConfig).toContain('filesToDeleteAfterUpload')
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   build: {
     target: 'es2022',
-    sourcemap: true,
+    sourcemap: !!process.env.SENTRY_AUTH_TOKEN,
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-482](https://github.com/aschung212/Lift/issues/482)

Picked LIFT-482 — conditional source maps. This is the single largest payload reduction available: ~1.75MB of `.map` files were shipping to production when `SENTRY_AUTH_TOKEN` wasn't set. One-line config change with a regression test.

## Changes
- Changed `sourcemap: true` to `sourcemap: !!process.env.SENTRY_AUTH_TOKEN` in `vite.config.js:20`
- Added `buildConfigRegression.test.ts` to prevent reintroduction of unconditional source maps
- Verified: 60 test files, 1355 tests passing, build succeeds without map files

## Verification

### Steps to test
1. Open the Vercel preview deployment
2. Open browser DevTools → Network tab
3. Reload the page and check that no `.map` files are loaded
4. Verify the app loads and functions normally — navigate between Workouts, Calendar, and Weight tabs

### Expected behavior
- No `.map` files in the network waterfall
- App loads and works identically to production
- All tabs render correctly, modals open, exercises display

### What to watch for
- If Sentry error tracking stops working in production, verify that `SENTRY_AUTH_TOKEN` is set in Vercel production env vars (it should already be — this change doesn't affect that path)
- The Vercel preview environment likely doesn't have `SENTRY_AUTH_TOKEN`, so preview builds will also skip source maps (this is correct — Sentry should only ingest production maps)

### Risk assessment
- **Scope:** Build config only — no runtime code changed
- **Confidence:** High — the conditional Sentry plugin pattern already existed on lines 145-154, this just aligns sourcemap generation with the same gate
- **Rollback:** Revert single commit to restore `sourcemap: true`

## Screenshots
SCREENSHOT_ROUTE:NONE

## Commits
- [`f2e00b6`](https://github.com/aschung212/Lift/commit/f2e00b6) perf(#482): conditional source maps — only generate when Sentry token is set

## Test Results
- Before: 1353 passing
- After: 1355 passing (2 delta)

---
_Automated by overnight pipeline — Mon May  4 23:20:00 PDT 2026_

## Preview
Test on your phone: https://lift-91mlrhbfw-aschung212-1101s-projects.vercel.app