### PR TITLE
fix(#483): add missing v-memo deps — index, lastSet data, weightUnit

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -91,6 +91,7 @@
       <li
         v-for="(exercise, index) in filteredExercises"
         :key="exercise.id"
+        v-memo="[exercise.name, exercise.sets.length, exercise.tags, prBaselineDate, dragState.dragging && dragState.fromIndex === index, dragState.dragging && dragState.overIndex === index && dragState.fromIndex !== index, isFilteringActive]"
         class="wtExerciseItem"
         :class="{
           'wt-dragging': !isFilteringActive && dragState.dragging && dragState.fromIndex === index,

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -91,7 +91,7 @@
       <li
         v-for="(exercise, index) in filteredExercises"
         :key="exercise.id"
-        v-memo="[exercise.name, exercise.sets.length, exercise.tags, prBaselineDate, dragState.dragging && dragState.fromIndex === index, dragState.dragging && dragState.overIndex === index && dragState.fromIndex !== index, isFilteringActive]"
+        v-memo="[exercise.name, exercise.sets.length, exercise.sets[exercise.sets.length - 1]?.weight, exercise.sets[exercise.sets.length - 1]?.reps, exercise.tags, prBaselineDate, weightUnit, index, dragState.dragging && dragState.fromIndex === index, dragState.dragging && dragState.overIndex === index && dragState.fromIndex !== index, isFilteringActive]"
         class="wtExerciseItem"
         :class="{
           'wt-dragging': !isFilteringActive && dragState.dragging && dragState.fromIndex === index,

--- a/src/lib/__tests__/vMemoRegression.test.ts
+++ b/src/lib/__tests__/vMemoRegression.test.ts
@@ -1,0 +1,43 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const workoutTracker = readFileSync(
+  resolve(__dirname, '../../components/WorkoutTracker.vue'),
+  'utf-8'
+)
+
+/**
+ * Structural regression tests for v-memo directives in WorkoutTracker.
+ *
+ * v-memo skips VDOM diffing for list items whose dependencies haven't changed,
+ * significantly reducing render cost for users with 50+ exercises. These tests
+ * ensure the directives aren't accidentally removed during refactoring.
+ *
+ * Note: v-memo only works on the same element as v-for (or on a root v-for
+ * template). It cannot be used inside a nested v-for (vue/valid-v-memo).
+ *
+ * See: LIFT-483
+ */
+describe('v-memo performance directives', () => {
+  it('exercise list items have v-memo on the v-for element', () => {
+    // The main exercise v-for loop must include v-memo with exercise identity deps
+    // v-memo and v-for must be on the same element (the <li>)
+    expect(workoutTracker).toMatch(
+      /v-for="\(exercise, index\) in filteredExercises"[\s\S]{1,200}?v-memo="\[/
+    )
+  })
+
+  it('v-memo includes exercise.sets.length to trigger on new sets', () => {
+    expect(workoutTracker).toMatch(/v-memo=".*exercise\.sets\.length/)
+  })
+
+  it('v-memo includes exercise.name for rename detection', () => {
+    expect(workoutTracker).toMatch(/v-memo=".*exercise\.name/)
+  })
+
+  it('v-memo includes drag state dependencies', () => {
+    expect(workoutTracker).toMatch(/v-memo=".*dragState\.dragging/)
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-483](https://github.com/aschung212/Lift/issues/483)



## Changes




## Commits
- [`23f5ddc`](https://github.com/aschung212/Lift/commit/23f5ddc) fix(#483): add missing v-memo deps — index, lastSet data, weightUnit
- [`1b053bd`](https://github.com/aschung212/Lift/commit/1b053bd) perf(#483): add v-memo to exercise list items in WorkoutTracker

## Test Results
- Before: 1353 passing
- After: 1357 passing (4 delta)

---
_Automated by overnight pipeline — Mon May  4 23:33:16 PDT 2026_

## Preview
Test on your phone: https://lift-p2i7ny71q-aschung212-1101s-projects.vercel.app