### PR TITLE
fix(#485): use StaleWhileRevalidate for sets cache instead of CacheFir

### DIFF
--- a/src/lib/__tests__/workboxCacheRegression.test.ts
+++ b/src/lib/__tests__/workboxCacheRegression.test.ts
@@ -1,0 +1,87 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Regression tests for Workbox runtime cache configuration.
+ *
+ * Validates that endpoint-specific caches are defined with appropriate
+ * strategies and capacities. Prevents regression to a single catch-all
+ * cache that would evict entries for power users with large datasets.
+ */
+
+const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), 'utf-8')
+
+describe('Workbox runtime cache configuration', () => {
+  describe('endpoint-specific caches exist', () => {
+    it('has a dedicated sets cache with CacheFirst strategy', () => {
+      expect(viteConfig).toContain("cacheName: 'supabase-sets'")
+      // Sets are append-only, so CacheFirst is appropriate
+      const setsSection = viteConfig.slice(
+        viteConfig.indexOf("cacheName: 'supabase-sets'") - 200,
+        viteConfig.indexOf("cacheName: 'supabase-sets'") + 100
+      )
+      expect(setsSection).toContain("handler: 'CacheFirst'")
+    })
+
+    it('has a dedicated exercises cache with NetworkFirst strategy', () => {
+      expect(viteConfig).toContain("cacheName: 'supabase-exercises'")
+      const exercisesSection = viteConfig.slice(
+        viteConfig.indexOf("cacheName: 'supabase-exercises'") - 200,
+        viteConfig.indexOf("cacheName: 'supabase-exercises'") + 100
+      )
+      expect(exercisesSection).toContain("handler: 'NetworkFirst'")
+    })
+
+    it('has a dedicated bodyweight cache', () => {
+      expect(viteConfig).toContain("cacheName: 'supabase-bodyweight'")
+    })
+
+    it('has a dedicated progression cache', () => {
+      expect(viteConfig).toContain("cacheName: 'supabase-progression'")
+    })
+
+    it('has a catch-all supabase-api cache for unknown endpoints', () => {
+      expect(viteConfig).toContain("cacheName: 'supabase-api'")
+    })
+
+    it('keeps auth as NetworkOnly (never cache tokens)', () => {
+      expect(viteConfig).toContain("cacheName: 'supabase-auth'")
+      const authSection = viteConfig.slice(
+        viteConfig.indexOf("cacheName: 'supabase-auth'") - 200,
+        viteConfig.indexOf("cacheName: 'supabase-auth'") + 100
+      )
+      expect(authSection).toContain("handler: 'NetworkOnly'")
+    })
+  })
+
+  describe('cache capacities are tuned for power users', () => {
+    it('sets cache allows 500 entries (100+ exercises × multiple pages)', () => {
+      const setsSection = viteConfig.slice(
+        viteConfig.indexOf("cacheName: 'supabase-sets'"),
+        viteConfig.indexOf("cacheName: 'supabase-sets'") + 300
+      )
+      expect(setsSection).toContain('maxEntries: 500')
+    })
+
+    it('exercises cache allows 200 entries', () => {
+      const exercisesSection = viteConfig.slice(
+        viteConfig.indexOf("cacheName: 'supabase-exercises'"),
+        viteConfig.indexOf("cacheName: 'supabase-exercises'") + 300
+      )
+      expect(exercisesSection).toContain('maxEntries: 200')
+    })
+  })
+
+  describe('cache ordering is specific-first', () => {
+    it('specific endpoint caches appear before the catch-all', () => {
+      const setsPos = viteConfig.indexOf("cacheName: 'supabase-sets'")
+      const exercisesPos = viteConfig.indexOf("cacheName: 'supabase-exercises'")
+      const catchAllPos = viteConfig.indexOf("cacheName: 'supabase-api'")
+      // Specific caches must come before catch-all so Workbox matches them first
+      expect(setsPos).toBeLessThan(catchAllPos)
+      expect(exercisesPos).toBeLessThan(catchAllPos)
+    })
+  })
+})

--- a/src/lib/__tests__/workboxCacheRegression.test.ts
+++ b/src/lib/__tests__/workboxCacheRegression.test.ts
@@ -15,14 +15,14 @@ const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), '
 
 describe('Workbox runtime cache configuration', () => {
   describe('endpoint-specific caches exist', () => {
-    it('has a dedicated sets cache with CacheFirst strategy', () => {
+    it('has a dedicated sets cache with StaleWhileRevalidate strategy', () => {
       expect(viteConfig).toContain("cacheName: 'supabase-sets'")
-      // Sets are append-only, so CacheFirst is appropriate
+      // StaleWhileRevalidate: fast offline load + background refresh for new sets
       const setsSection = viteConfig.slice(
         viteConfig.indexOf("cacheName: 'supabase-sets'") - 200,
         viteConfig.indexOf("cacheName: 'supabase-sets'") + 100
       )
-      expect(setsSection).toContain("handler: 'CacheFirst'")
+      expect(setsSection).toContain("handler: 'StaleWhileRevalidate'")
     })
 
     it('has a dedicated exercises cache with NetworkFirst strategy', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -116,6 +116,70 @@ export default defineConfig({
         skipWaiting: true,
         runtimeCaching: [
           {
+            // Sets are append-only (logged sets never change) — CacheFirst with large capacity
+            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/sets\b/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'supabase-sets',
+              expiration: {
+                maxEntries: 500,
+                maxAgeSeconds: 60 * 60 * 24 * 7, // 7 days
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Exercises change infrequently (renames, tag edits) — NetworkFirst with generous capacity
+            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/exercises\b/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-exercises',
+              expiration: {
+                maxEntries: 200,
+                maxAgeSeconds: 60 * 60 * 12, // 12 hours
+              },
+              networkTimeoutSeconds: 3,
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Bodyweight entries — moderate churn, NetworkFirst
+            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/bodyweight_entries\b/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-bodyweight',
+              expiration: {
+                maxEntries: 200,
+                maxAgeSeconds: 60 * 60 * 12, // 12 hours
+              },
+              networkTimeoutSeconds: 3,
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Progression/XP data — small payload, short TTL
+            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/(user_progression|xp_events|progression_snapshots)\b/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'supabase-progression',
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60 * 6, // 6 hours
+              },
+              networkTimeoutSeconds: 3,
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Catch-all for any other Supabase REST endpoints
             urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,
             handler: 'NetworkFirst',
             options: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -116,9 +116,11 @@ export default defineConfig({
         skipWaiting: true,
         runtimeCaching: [
           {
-            // Sets are append-only (logged sets never change) — CacheFirst with large capacity
+            // Sets collection grows as new sets are logged — StaleWhileRevalidate
+            // serves cached response instantly for offline/fast load while updating
+            // the cache in the background so new sets from other devices appear next load
             urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/sets\b/i,
-            handler: 'CacheFirst',
+            handler: 'StaleWhileRevalidate',
             options: {
               cacheName: 'supabase-sets',
               expiration: {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-485](https://github.com/aschung212/Lift/issues/485)

Picked LIFT-485 — tuning Workbox runtime cache. The single `supabase-api` cache (50 entries) causes eviction for power users with large datasets. Splitting by endpoint with appropriate strategies and capacities improves offline resilience and reduces repeat network requests.

## Changes
- Split single Workbox runtime cache into 5 endpoint-specific caches: sets (500 entries, SWR, 7d), exercises (200 entries, NetworkFirst, 12h), bodyweight (200 entries, NetworkFirst, 12h), progression (50 entries, NetworkFirst, 6h), catch-all (50 entries, NetworkFirst, 24h)
- Used StaleWhileRevalidate for sets (instant offline response + background refresh for new data from other devices)
- Kept auth as NetworkOnly (never cache tokens)
- Ordered specific patterns before catch-all so Workbox matches correctly
- Added regression test suite validating cache names, strategies, capacities, and ordering

## Verification

### Steps to test
1. Open the app on the Workouts tab
2. Log a few sets on any exercise
3. Switch to airplane mode
4. Kill and reopen the app (or navigate away and back)
5. Verify the exercises list and recent sets still load from cache
6. Turn network back on — verify new data syncs in

### Expected behavior
- In offline mode, exercises and sets load instantly from their dedicated caches
- On reconnect, StaleWhileRevalidate background-refreshes the sets cache
- No visible difference in normal usage — this is invisible infrastructure

### What to watch for
- Service worker failing to register after the config change (check DevTools > Application > Service Workers)
- Cache storage showing the new cache names (supabase-sets, supabase-exercises, supabase-bodyweight, supabase-progression)
- Offline mode not loading data (would indicate regex mismatch)

### Risk assessment
- **Scope:** Service worker caching only — no UI/component changes
- **Confidence:** High — Workbox config is well-documented, patterns are straightforward regex
- **Rollback:** Revert the vite.config.js changes; existing caches self-clean on next SW update

## Screenshots
SCREENSHOT_ROUTE:NONE

## Commits
- [`5615ff0`](https://github.com/aschung212/Lift/commit/5615ff0) fix(#485): use StaleWhileRevalidate for sets cache instead of CacheFirst
- [`d952f7d`](https://github.com/aschung212/Lift/commit/d952f7d) perf(#485): split Workbox runtime cache by endpoint with tuned capacities

## Test Results
- Before: 1353 passing
- After: 1362 passing (9 delta)

---
_Automated by overnight pipeline — Mon May  4 23:41:44 PDT 2026_

## Preview
Test on your phone: https://lift-lrfsziwjs-aschung212-1101s-projects.vercel.app