### PR TITLE
feat(#310): add supporter badge to progression badge case

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -133,6 +133,13 @@
                   </span>
                   <span class="themePreviewLabel">{{ isEternalLocked(t.id) ? '???' : t.label }}</span>
                 </button>
+                <!-- Supporter badge (displayed in grid when user has self-attested) -->
+                <div v-if="progressionStore.supporter" class="themePreview supporterBadge" aria-label="Supporter badge">
+                  <span class="themePreviewDot supporterBadgeDot">
+                    <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M12 2L9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2z"/></svg>
+                  </span>
+                  <span class="themePreviewLabel">Supporter</span>
+                </div>
               </div>
               <!-- Trial period banner -->
               <div v-if="progressionActive && !progressionStore.starterConfirmed" class="trialBanner">
@@ -493,6 +500,17 @@
                 </span>
                 <svg class="settingsChevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
               </a>
+              <div class="settingsRow">
+                <span class="settingsLabel">
+                  <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" style="vertical-align: -2px; margin-right: 6px; color: var(--accent)"><path d="M12 2L9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2z"/></svg>
+                  Supporter Badge
+                </span>
+                <label class="settingsToggle" aria-label="Toggle supporter badge">
+                  <input type="checkbox" :checked="progressionStore.supporter" @change="progressionStore.setSupporter(($event.target as HTMLInputElement).checked)" />
+                  <span class="toggleTrack"><span class="toggleThumb"></span></span>
+                </label>
+              </div>
+              <p v-if="!progressionStore.supporter" class="settingsCaption">Donated? Turn this on to show your supporter badge in the theme case.</p>
             </div>
 
             <div class="settingsGroup">

--- a/src/index.css
+++ b/src/index.css
@@ -1103,6 +1103,31 @@ html.modal-open .tabContent {
   color: var(--text-secondary);
 }
 
+/* ─── Supporter badge ───────────────────────────────────────────── */
+
+.supporterBadgeDot {
+  background: linear-gradient(135deg, #ffd700, #ffb800) !important;
+  color: #fff !important;
+  animation: supporterGlow 2.5s ease-in-out infinite;
+}
+
+@keyframes supporterGlow {
+  0%, 100% { box-shadow: 0 0 4px rgba(255, 215, 0, 0.3); }
+  50% { box-shadow: 0 0 12px rgba(255, 215, 0, 0.6); }
+}
+
+.supporterBadge .themePreviewLabel {
+  color: var(--accent);
+}
+
+.settingsCaption {
+  font-size: var(--font-caption2);
+  color: var(--text-secondary);
+  padding: 0 16px 8px;
+  margin: 0;
+  line-height: 1.4;
+}
+
 /* ─── Badge case header ──────────────────────────────────────────── */
 
 .badgeCaseHeader {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -223,6 +223,7 @@ export type Database = {
           starter_theme: string | null
           streak_history: Json
           streak_weeks: number
+          supporter: boolean
           total_xp: number
           unlocked_themes: Json
           updated_at: string
@@ -240,6 +241,7 @@ export type Database = {
           starter_theme?: string | null
           streak_history?: Json
           streak_weeks?: number
+          supporter?: boolean
           total_xp?: number
           unlocked_themes?: Json
           updated_at?: string
@@ -257,6 +259,7 @@ export type Database = {
           starter_theme?: string | null
           streak_history?: Json
           streak_weeks?: number
+          supporter?: boolean
           total_xp?: number
           unlocked_themes?: Json
           updated_at?: string

--- a/src/stores/__tests__/progression.test.ts
+++ b/src/stores/__tests__/progression.test.ts
@@ -848,4 +848,41 @@ describe('progression store', () => {
       expect(lastEntry.combinedMultiplier).toBe(1.1)
     })
   })
+
+  // ── Supporter badge ─────────────────────────────────────────────
+
+  describe('supporter badge', () => {
+    it('defaults supporter to false', () => {
+      const store = useProgressionStore()
+      expect(store.supporter).toBe(false)
+    })
+
+    it('setSupporter(true) enables the badge and persists', () => {
+      const store = useProgressionStore()
+      store.setSupporter(true)
+      expect(store.supporter).toBe(true)
+
+      const saved = JSON.parse(localStorage.getItem('user-progression')!)
+      expect(saved.supporter).toBe(true)
+    })
+
+    it('setSupporter(false) disables the badge and persists', () => {
+      const store = useProgressionStore()
+      store.setSupporter(true)
+      store.setSupporter(false)
+      expect(store.supporter).toBe(false)
+
+      const saved = JSON.parse(localStorage.getItem('user-progression')!)
+      expect(saved.supporter).toBe(false)
+    })
+
+    it('loads supporter state from localStorage', () => {
+      localStorage.setItem('user-progression', JSON.stringify({
+        supporter: true,
+      }))
+      setActivePinia(createPinia())
+      const store = useProgressionStore()
+      expect(store.supporter).toBe(true)
+    })
+  })
 })

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -85,6 +85,7 @@ export interface ProgressionState {
   streakHistory: StreakWeekEntry[]     // append-only
   xpPerSet: Record<string, SetXPEntry | number>  // setId → XP data (number = legacy format)
   bodyweightXPDates: string[]         // dates that earned bodyweight XP
+  supporter: boolean                   // user self-attested as a supporter (GitHub Sponsors / BuyMeACoffee)
 }
 
 // --- Unlock Thresholds (placeholder — tune with real data) ---
@@ -124,6 +125,7 @@ function defaultState(): ProgressionState {
     streakHistory: [],
     xpPerSet: {},
     bodyweightXPDates: [],
+    supporter: false,
   }
 }
 
@@ -282,6 +284,7 @@ export const useProgressionStore = defineStore('progression', {
       this.starterConfirmed = (data.starter_confirmed as boolean) ?? this.starterConfirmed
       this.epoch = (data.epoch as number) ?? this.epoch
       this.streakHistory = (data.streak_history as unknown as StreakWeekEntry[]) ?? this.streakHistory
+      this.supporter = (data.supporter as boolean) ?? this.supporter
 
       // Merge collection fields — union strategy, no data loss
       const remoteThemes = migrateUnlockedThemes((data.unlocked_themes as unknown) ?? [])
@@ -325,6 +328,7 @@ export const useProgressionStore = defineStore('progression', {
         streak_history: this.streakHistory as unknown as Json,
         xp_per_set: this.xpPerSet as unknown as Json,
         bodyweight_xp_dates: this.bodyweightXPDates as unknown as Json,
+        supporter: this.supporter,
       }
       syncQueue.enqueue('progression-sync', () =>
         supabase!.from('user_progression').upsert(payload)
@@ -599,6 +603,12 @@ export const useProgressionStore = defineStore('progression', {
 
     setShowProgression(value: boolean) {
       this.showProgression = value
+      this._persist()
+      this._syncToSupabase()
+    },
+
+    setSupporter(value: boolean) {
+      this.supporter = value
       this._persist()
       this._syncToSupabase()
     },

--- a/supabase/migrations/20260523000000_add_supporter_to_user_progression.sql
+++ b/supabase/migrations/20260523000000_add_supporter_to_user_progression.sql
@@ -1,0 +1,8 @@
+-- LIFT-310: add supporter self-attestation column to user_progression
+--
+-- A boolean flag the user toggles in settings to enable the supporter
+-- badge / theme after sponsoring via GitHub Sponsors or Buy Me a Coffee.
+-- Default false so existing rows stay unchanged.
+
+ALTER TABLE public.user_progression
+  ADD COLUMN IF NOT EXISTS supporter boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-310](https://github.com/aschung212/Lift/issues/310)

Picked LIFT-310 (supporter badge in progression badge case). This is a small, high-emotional-value feature that adds a visible gold star badge in the theme grid for users who self-attest as supporters (GitHub Sponsors / Buy Me a Coffee donors). It's the only remaining unblocked, unattempted feature issue.

## Changes
- Added `supporter: boolean` field to `ProgressionState` interface and default state
- Added `setSupporter(value)` action that persists and syncs to Supabase
- Added Supabase fetch/sync for the `supporter` field
- Added gold star supporter badge in the theme grid (appears after themes when enabled)
- Added supporter badge toggle in the Support settings section with caption text
- Added CSS for supporter badge (gold gradient, glow animation)
- Added 4 regression tests for supporter state management

## Verification

### Steps to test
1. Open Settings (gear icon top-left)
2. Scroll down to the "Support" section
3. Observe the "Supporter Badge" toggle row with a star icon
4. Observe the caption text below: "Donated? Turn this on to show your supporter badge in the theme case."
5. Toggle the supporter badge ON
6. Scroll back up to the Appearance section / theme grid
7. Observe a gold star "Supporter" badge at the end of the theme grid
8. Toggle the supporter badge OFF in Support section
9. Verify the gold star disappears from the theme grid

### Expected behavior
- Toggle OFF: No supporter badge visible in the theme grid; caption text shows below the toggle
- Toggle ON: Gold star badge appears at the end of the grid with a subtle pulsing glow; caption disappears
- The badge persists across page reloads (localStorage)
- The badge syncs across devices (Supabase)

### What to watch for
- Gold badge gradient should be visible across all 9 themes in both light and dark mode
- The badge should fit within the 5-column grid naturally (same sizing as theme dots: 44×44pt)
- No layout shift when toggling — the badge just appears/disappears at the end of the grid
- Caption text should be legible in both light and dark modes
- Toggle should update immediately without any page reload

### Risk assessment
- **Scope:** Narrow — only the settings sheet theme grid and support section
- **Confidence:** High — simple boolean toggle with no complex interactions
- **Rollback:** Revert single commit; the `supporter` field in localStorage/Supabase is ignored if the code doesn't reference it

## Screenshots
SCREENSHOT_ROUTE:/

## Commits
- [`7b5f557`](https://github.com/aschung212/Lift/commit/7b5f557) feat(#310): add supporter badge to progression badge case

## Test Results
- Before: 1353 passing
- After: 1357 passing (4 delta)

---
_Automated by overnight pipeline — Tue May  5 01:36:27 PDT 2026_

## Preview
Test on your phone: https://lift-9ielwd5tm-aschung212-1101s-projects.vercel.app