### PR TITLE
test: add unit tests for tombstones and epley modules

### DIFF
--- a/src/lib/__tests__/epley.test.ts
+++ b/src/lib/__tests__/epley.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { epley } from '../epley'
+
+describe('epley', () => {
+  it('returns weight itself for a single-rep set', () => {
+    expect(epley(315, 1)).toBe(315)
+  })
+
+  it('rounds to nearest integer for single-rep', () => {
+    expect(epley(315.6, 1)).toBe(316)
+    expect(epley(315.4, 1)).toBe(315)
+  })
+
+  it('applies the Epley formula for multi-rep sets', () => {
+    // 225 * (1 + 5/30) = 225 * 1.1667 = 262.5 → 263
+    expect(epley(225, 5)).toBe(263)
+  })
+
+  it('rounds the result to nearest integer', () => {
+    // 100 * (1 + 3/30) = 100 * 1.1 = 110
+    expect(epley(100, 3)).toBe(110)
+    // 135 * (1 + 8/30) = 135 * 1.2667 = 171.0 → 171
+    expect(epley(135, 8)).toBe(171)
+  })
+
+  it('handles high rep ranges', () => {
+    // 100 * (1 + 20/30) = 100 * 1.6667 = 166.67 → 167
+    expect(epley(100, 20)).toBe(167)
+  })
+
+  it('estimates increase for 2 reps vs 1 rep', () => {
+    // 300 * (1 + 2/30) = 300 * 1.0667 = 320
+    expect(epley(300, 2)).toBe(320)
+  })
+
+  it('produces consistent results for common gym scenarios', () => {
+    // Standard bench: 225x5
+    expect(epley(225, 5)).toBe(263)
+    // Standard squat: 315x3
+    expect(epley(315, 3)).toBe(347)
+    // Standard deadlift: 405x1
+    expect(epley(405, 1)).toBe(405)
+  })
+
+  it('handles bodyweight-scale weights', () => {
+    // 0 weight edge case
+    expect(epley(0, 5)).toBe(0)
+  })
+
+  it('is monotonically increasing with reps at fixed weight', () => {
+    const weight = 200
+    let prev = epley(weight, 1)
+    for (let reps = 2; reps <= 15; reps++) {
+      const current = epley(weight, reps)
+      expect(current).toBeGreaterThanOrEqual(prev)
+      prev = current
+    }
+  })
+
+  it('is monotonically increasing with weight at fixed reps', () => {
+    const reps = 5
+    let prev = epley(0, reps)
+    for (let w = 5; w <= 500; w += 5) {
+      const current = epley(w, reps)
+      expect(current).toBeGreaterThanOrEqual(prev)
+      prev = current
+    }
+  })
+})

--- a/src/lib/__tests__/tombstones.test.ts
+++ b/src/lib/__tests__/tombstones.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  addTombstone,
+  removeTombstone,
+  isTombstoned,
+  cleanupTombstones,
+  _resetTombstones,
+} from '../tombstones'
+
+import { getLocalStorageMock } from '../../__tests__/helpers'
+const localStorageMock = getLocalStorageMock()
+
+describe('tombstones', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    _resetTombstones()
+  })
+
+  describe('addTombstone', () => {
+    it('marks an ID as tombstoned', () => {
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+    })
+
+    it('persists to localStorage', () => {
+      addTombstone('exercises', 'ex-1')
+      const stored = JSON.parse(localStorageMock.getItem('lift-sync-tombstones')!)
+      expect(stored.exercises).toContain('ex-1')
+    })
+
+    it('does not affect other stores', () => {
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('sets', 'ex-1')).toBe(false)
+    })
+
+    it('handles multiple IDs in same store', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+    })
+
+    it('is idempotent — adding the same ID twice does not create duplicates', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-1')
+      const stored = JSON.parse(localStorageMock.getItem('lift-sync-tombstones')!)
+      expect(stored.exercises.length).toBe(1)
+    })
+  })
+
+  describe('removeTombstone', () => {
+    it('removes a previously added tombstone', () => {
+      addTombstone('exercises', 'ex-1')
+      removeTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+    })
+
+    it('does not throw when removing a non-existent ID', () => {
+      expect(() => removeTombstone('exercises', 'non-existent')).not.toThrow()
+    })
+
+    it('cleans up the store key when all IDs are removed', () => {
+      addTombstone('exercises', 'ex-1')
+      removeTombstone('exercises', 'ex-1')
+      const stored = JSON.parse(localStorageMock.getItem('lift-sync-tombstones')!)
+      expect(stored.exercises).toBeUndefined()
+    })
+
+    it('does not affect other IDs in the same store', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      removeTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+    })
+  })
+
+  describe('isTombstoned', () => {
+    it('returns false for an ID that was never tombstoned', () => {
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+    })
+
+    it('returns false for an empty store name', () => {
+      expect(isTombstoned('nonexistent-store', 'id-1')).toBe(false)
+    })
+
+    it('reads from localStorage on first access after reset', () => {
+      // Simulate data from a previous session
+      localStorageMock.setItem(
+        'lift-sync-tombstones',
+        JSON.stringify({ exercises: ['ex-old'] })
+      )
+      _resetTombstones() // Clear in-memory cache
+      expect(isTombstoned('exercises', 'ex-old')).toBe(true)
+    })
+  })
+
+  describe('cleanupTombstones', () => {
+    it('removes tombstones for IDs no longer in remote', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      addTombstone('exercises', 'ex-3')
+
+      // ex-2 is still on remote — it should NOT be cleaned up
+      // ex-1 and ex-3 are not on remote — they SHOULD be cleaned up
+      const remoteIds = new Set(['ex-2'])
+      cleanupTombstones('exercises', remoteIds)
+
+      expect(isTombstoned('exercises', 'ex-1')).toBe(false)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(true)
+      expect(isTombstoned('exercises', 'ex-3')).toBe(false)
+    })
+
+    it('does nothing when there are no tombstones', () => {
+      cleanupTombstones('exercises', new Set(['ex-1']))
+      const stored = localStorageMock.getItem('lift-sync-tombstones')
+      // Should not write to localStorage if there's nothing to clean
+      expect(stored).toBeNull()
+    })
+
+    it('does not affect tombstones in other stores', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('sets', 'set-1')
+
+      cleanupTombstones('exercises', new Set()) // remove all exercise tombstones
+      expect(isTombstoned('sets', 'set-1')).toBe(true)
+    })
+
+    it('persists cleanup to localStorage', () => {
+      addTombstone('exercises', 'ex-1')
+      addTombstone('exercises', 'ex-2')
+      cleanupTombstones('exercises', new Set(['ex-1'])) // ex-1 still remote
+
+      _resetTombstones() // Force reload from localStorage
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+      expect(isTombstoned('exercises', 'ex-2')).toBe(false)
+    })
+  })
+
+  describe('cross-store isolation', () => {
+    it('tombstones in different stores are independent', () => {
+      addTombstone('exercises', 'shared-id')
+      addTombstone('sets', 'shared-id')
+
+      removeTombstone('exercises', 'shared-id')
+      expect(isTombstoned('exercises', 'shared-id')).toBe(false)
+      expect(isTombstoned('sets', 'shared-id')).toBe(true)
+    })
+  })
+
+  describe('resilience', () => {
+    it('handles corrupt localStorage gracefully', () => {
+      localStorageMock.setItem('lift-sync-tombstones', 'not-valid-json{{{')
+      _resetTombstones()
+      // Should not throw; should treat as empty
+      expect(isTombstoned('exercises', 'anything')).toBe(false)
+      // Should still be able to add new tombstones
+      addTombstone('exercises', 'ex-1')
+      expect(isTombstoned('exercises', 'ex-1')).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary



## Changes




## Commits
- [`d25c48c`](https://github.com/aschung212/Lift/commit/d25c48c) test: add unit tests for tombstones and epley modules

## Test Results
- Before: 1353 passing
- After: 1381 passing (28 delta)

---
_Automated by overnight pipeline — Wed May  6 01:47:01 PDT 2026_

## Preview
Test on your phone: https://lift-rdyoyczim-aschung212-1101s-projects.vercel.app