### PR TITLE
fix(#321): add missing localStorage keys to deleteAccount cleanup

### DIFF
--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -177,20 +177,23 @@ describe('useAuth', () => {
       const { deleteAccount, devSignIn } = useAuth()
       await devSignIn()
 
-      // Set some localStorage keys
-      localStorage.setItem('workout-exercises', '[]')
-      localStorage.setItem('bodyweight-entries', '[]')
-      localStorage.setItem('user-progression', '{}')
-      localStorage.setItem('app-theme', 'fire')
-      localStorage.setItem('rest-duration', '90')
+      // Set all localStorage keys used by the app
+      const allKeys = [
+        'workout-exercises', 'bodyweight-entries', 'user-progression', 'user-preferences',
+        'lift-custom-tags', 'lift-tag-recovery-days', 'lift-tag-recovery-excluded',
+        'onboarding-complete', 'sample-data', 'active-tab', 'wt-list-view',
+        'rest-duration', 'rest-warning-options', 'rest-warnings', 'rest-presets-disabled', 'rest-presets',
+        'app-theme', 'app-mode', 'app-glass', 'rest-timer', 'rest-timer-autostart', 'weight-unit',
+      ]
+      for (const key of allKeys) {
+        localStorage.setItem(key, 'test-value')
+      }
 
       await deleteAccount()
 
-      expect(localStorage.getItem('workout-exercises')).toBeNull()
-      expect(localStorage.getItem('bodyweight-entries')).toBeNull()
-      expect(localStorage.getItem('user-progression')).toBeNull()
-      expect(localStorage.getItem('app-theme')).toBeNull()
-      expect(localStorage.getItem('rest-duration')).toBeNull()
+      for (const key of allKeys) {
+        expect(localStorage.getItem(key)).toBeNull()
+      }
     })
 
     it('signs user out after deletion', async () => {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -133,7 +133,8 @@ async function deleteAccount(): Promise<void> {
   // Clear all localStorage keys used by the app
   const localStorageKeys = [
     'workout-exercises', 'bodyweight-entries', 'user-progression', 'user-preferences',
-    'lift-custom-tags', 'onboarding-complete', 'sample-data', 'active-tab',
+    'lift-custom-tags', 'lift-tag-recovery-days', 'lift-tag-recovery-excluded',
+    'onboarding-complete', 'sample-data', 'active-tab', 'wt-list-view',
     'rest-duration', 'rest-warning-options', 'rest-warnings', 'rest-presets-disabled', 'rest-presets',
     'app-theme', 'app-mode', 'app-glass', 'rest-timer', 'rest-timer-autostart', 'weight-unit',
   ]


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-321](https://github.com/aschung212/Lift/issues/321)

Picked **LIFT-321** — a bug fix for missing localStorage cleanup keys in `deleteAccount()`. Three keys (`lift-tag-recovery-days`, `lift-tag-recovery-excluded`, `wt-list-view`) were not being removed when a user deleted their account, meaning a subsequent user logging in on the same device would inherit stale config.

## Changes
- Added 3 missing localStorage keys to the `deleteAccount()` cleanup list in `useAuth.ts`
- Upgraded the regression test from spot-checking 5 keys to verifying all 22 keys are cleared

## Verification

### Steps to test
1. Navigate to the app and log sets, configure tag recovery settings (Settings > Tag Recovery), and switch the workout list view to "Timeline"
2. Go to Settings > Delete Account and confirm deletion
3. Sign in with a different account (or the same one)
4. Check Settings > Tag Recovery — should show defaults, not previous user's config
5. Check Workouts tab — list view should be "Exercises" (default), not "Timeline"

### Expected behavior
- After account deletion and re-login, all settings return to defaults
- No tag recovery configuration persists from the deleted account
- Workout list view resets to "Exercises" (the default)

### What to watch for
- Ensure the delete account flow still completes without errors
- Verify other localStorage keys (theme, rest timer, etc.) are still properly cleaned
- Check that IndexedDB cleanup still works

### Risk assessment
- **Scope:** Narrow — only affects the `deleteAccount()` function in `useAuth.ts`
- **Confidence:** High — straightforward addition of missing keys to an existing cleanup list, comprehensive test verifies all keys
- **Rollback:** Simple revert of one commit

## Screenshots
SCREENSHOT_ROUTE:NONE

## Commits
- [`bfb8513`](https://github.com/aschung212/Lift/commit/bfb8513) fix(#321): add missing localStorage keys to deleteAccount cleanup

## Test Results
- Before: 1353 passing
- After: 1353 passing (0 delta)

---
_Automated by overnight pipeline — Wed May  6 02:00:39 PDT 2026_

## Preview
Test on your phone: https://lift-r30jz6xax-aschung212-1101s-projects.vercel.app