### PR TITLE
fix(#497): reset all Pinia stores on signOut and deleteAccount

### DIFF
--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -11,17 +11,21 @@ vi.stubGlobal('matchMedia', vi.fn(() => ({
 })))
 
 // Mock all stores that useAuth imports
+const mockWorkoutReset = vi.fn()
+const mockBodyweightReset = vi.fn()
+const mockPreferencesReset = vi.fn()
+const mockProgressionReset = vi.fn()
 vi.mock('../../stores/workout', () => ({
-  useWorkoutStore: () => ({ init: vi.fn() })
+  useWorkoutStore: () => ({ init: vi.fn(), $reset: mockWorkoutReset })
 }))
 vi.mock('../../stores/bodyweight', () => ({
-  useBodyweightStore: () => ({ init: vi.fn() })
+  useBodyweightStore: () => ({ init: vi.fn(), $reset: mockBodyweightReset })
 }))
 vi.mock('../../stores/preferences', () => ({
-  usePreferencesStore: () => ({ init: vi.fn() })
+  usePreferencesStore: () => ({ init: vi.fn(), $reset: mockPreferencesReset })
 }))
 vi.mock('../../stores/progression', () => ({
-  useProgressionStore: () => ({ init: vi.fn() })
+  useProgressionStore: () => ({ init: vi.fn(), $reset: mockProgressionReset })
 }))
 vi.mock('../../lib/migrate', () => ({
   migrateLocalStorageToSupabase: vi.fn()
@@ -161,6 +165,43 @@ describe('useAuth', () => {
       await signOut()
       expect(user.value).toBeNull()
     })
+
+    // Regression LIFT-497: signOut must reset all Pinia stores to prevent data leak
+    it('resets all Pinia stores on sign out', async () => {
+      const { signOut, devSignIn } = useAuth()
+      await devSignIn()
+
+      mockWorkoutReset.mockClear()
+      mockBodyweightReset.mockClear()
+      mockPreferencesReset.mockClear()
+      mockProgressionReset.mockClear()
+
+      await signOut()
+
+      expect(mockWorkoutReset).toHaveBeenCalledOnce()
+      expect(mockBodyweightReset).toHaveBeenCalledOnce()
+      expect(mockPreferencesReset).toHaveBeenCalledOnce()
+      expect(mockProgressionReset).toHaveBeenCalledOnce()
+    })
+
+    // Regression LIFT-497: stores must reset even when supabase throws
+    it('resets stores even when supabase signOut throws', async () => {
+      mockSignOut.mockRejectedValueOnce(new Error('Network error'))
+      const { signOut, devSignIn } = useAuth()
+      await devSignIn()
+
+      mockWorkoutReset.mockClear()
+      mockBodyweightReset.mockClear()
+      mockPreferencesReset.mockClear()
+      mockProgressionReset.mockClear()
+
+      await signOut()
+
+      expect(mockWorkoutReset).toHaveBeenCalledOnce()
+      expect(mockBodyweightReset).toHaveBeenCalledOnce()
+      expect(mockPreferencesReset).toHaveBeenCalledOnce()
+      expect(mockProgressionReset).toHaveBeenCalledOnce()
+    })
   })
 
   describe('devSignIn', () => {
@@ -213,6 +254,24 @@ describe('useAuth', () => {
     it('exposes deleteAccount function', () => {
       const auth = useAuth()
       expect(typeof auth.deleteAccount).toBe('function')
+    })
+
+    // Regression LIFT-497: deleteAccount must reset all Pinia stores
+    it('resets all Pinia stores on account deletion', async () => {
+      const { deleteAccount, devSignIn } = useAuth()
+      await devSignIn()
+
+      mockWorkoutReset.mockClear()
+      mockBodyweightReset.mockClear()
+      mockPreferencesReset.mockClear()
+      mockProgressionReset.mockClear()
+
+      await deleteAccount()
+
+      expect(mockWorkoutReset).toHaveBeenCalledOnce()
+      expect(mockBodyweightReset).toHaveBeenCalledOnce()
+      expect(mockPreferencesReset).toHaveBeenCalledOnce()
+      expect(mockProgressionReset).toHaveBeenCalledOnce()
     })
 
     it('throws when Supabase deletion returns rejected promises', async () => {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -92,12 +92,20 @@ async function devSignIn(): Promise<void> {
   await initStores('local-dev')
 }
 
+function resetStores(): void {
+  useWorkoutStore().$reset()
+  useBodyweightStore().$reset()
+  usePreferencesStore().$reset()
+  useProgressionStore().$reset()
+}
+
 async function signOut(): Promise<void> {
   try {
     await supabase?.auth.signOut()
   } catch {
     // Network errors during sign-out should not block clearing the user
   } finally {
+    resetStores()
     user.value = null
   }
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-497](https://github.com/aschung212/Lift/issues/497)



## Changes




## Commits
- [`54b2e20`](https://github.com/aschung212/Lift/commit/54b2e20) fix(#497): reset all Pinia stores on signOut and deleteAccount

## Test Results
- Before: 1353 passing
- After: 1356 passing (3 delta)

---
_Automated by overnight pipeline — Wed May  6 02:08:12 PDT 2026_

## Preview
Test on your phone: https://lift-2unexwff2-aschung212-1101s-projects.vercel.app