### PR TITLE
fix(#500): add custom reset() to workout store for sign-out data clearing

### DIFF
--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -16,7 +16,7 @@ const mockBodyweightReset = vi.fn()
 const mockPreferencesReset = vi.fn()
 const mockProgressionReset = vi.fn()
 vi.mock('../../stores/workout', () => ({
-  useWorkoutStore: () => ({ init: vi.fn(), $reset: mockWorkoutReset })
+  useWorkoutStore: () => ({ init: vi.fn(), reset: mockWorkoutReset })
 }))
 vi.mock('../../stores/bodyweight', () => ({
   useBodyweightStore: () => ({ init: vi.fn(), $reset: mockBodyweightReset })

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -93,7 +93,9 @@ async function devSignIn(): Promise<void> {
 }
 
 function resetStores(): void {
-  useWorkoutStore().$reset()
+  // Workout store uses composition API (shallowRef for perf), so Pinia
+  // can't auto-generate $reset. It exposes a custom reset() instead.
+  useWorkoutStore().reset()
   useBodyweightStore().$reset()
   usePreferencesStore().$reset()
   useProgressionStore().$reset()

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -895,4 +895,39 @@ describe('workout store', () => {
       expect(result[0].sets.map(s => s.id)).toEqual(['s1', 's2', 's3'])
     })
   })
+
+  // ── reset ──────────────────────────────────────────────────────────
+  // Regression #500: composition-API stores don't get $reset for free.
+  // Without a custom reset(), sign-out fails to clear workout data.
+  describe('reset', () => {
+    it('clears all state back to empty defaults', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench Press', ['Push'])
+      store.addCustomTag('Hypertrophy')
+      store.setTagRecoveryDays('Push', 3)
+      expect(store.exercises.length).toBeGreaterThan(0)
+      expect(store.customTags.length).toBeGreaterThan(0)
+      expect(Object.keys(store.tagRecoveryDays).length).toBeGreaterThan(0)
+
+      store.reset()
+
+      expect(store.exercises).toEqual([])
+      expect(store.customTags).toEqual([])
+      expect(store.tagRecoveryDays).toEqual({})
+      expect(store.tagRecoveryExcluded).toEqual([])
+    })
+
+    it('persists cleared state to localStorage', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Squat', ['Legs'])
+      expect(localStorage.getItem('workout-exercises')).not.toBe('[]')
+
+      store.reset()
+
+      expect(localStorage.getItem('workout-exercises')).toBe('[]')
+      expect(localStorage.getItem('lift-custom-tags')).toBe('[]')
+      expect(localStorage.getItem('lift-tag-recovery-days')).toBe('{}')
+      expect(localStorage.getItem('lift-tag-recovery-excluded')).toBe('[]')
+    })
+  })
 })

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -160,6 +160,22 @@ export const useWorkoutStore = defineStore('workout', () => {
   const tagRecoveryExcluded = shallowRef<string[]>(JSON.parse(localStorage.getItem('lift-tag-recovery-excluded') || '[]'))
   let _userId: string | null = null
 
+  // ── reset (composition-API stores don't get $reset for free) ────────
+  // Pinia only auto-generates $reset for options-API stores. This setup
+  // store must provide its own reset so sign-out clears workout data.
+  function reset() {
+    exercises.value = []
+    customTags.value = []
+    tagRecoveryDays.value = {}
+    tagRecoveryExcluded.value = []
+    _userId = null
+    triggerRef(exercises)
+    triggerRef(customTags)
+    triggerRef(tagRecoveryDays)
+    triggerRef(tagRecoveryExcluded)
+    _persist()
+  }
+
   // ── Persistence ────────────────────────────────────────────────────
   function _persist() {
     const data = JSON.stringify(exercises.value)
@@ -1017,6 +1033,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     tagRecoveryDays,
     tagRecoveryExcluded,
     // Actions
+    reset,
     init,
     addExercise,
     setExercisePlateCountMode,


### PR DESCRIPTION
## Summary
- Pinia only auto-generates `$reset()` for options-API stores. The workout store uses the composition API (setup function with `shallowRef` for perf), so `$reset()` throws at runtime
- Sign-out (`useAuth.resetStores`) silently failed to clear workout data — a privacy/security issue where stale exercises remained visible until page refresh
- Added a custom `reset()` method to the workout store that clears all reactive state and persists the cleared state
- Updated `useAuth.resetStores()` to call `workoutStore.reset()` instead of `workoutStore.$reset()`

## Root cause
The workout store was converted from options API to composition API (setup function) in the shallowRef perf optimization. Pinia `$reset()` relies on snapshotting the state factory, which only exists for options-API stores. The existing test in `useAuth.test.ts` mocked `$reset` as `vi.fn()`, masking the runtime error.

## Changes
- `src/stores/workout.ts` — Added `reset()` method that clears all state and triggers persistence
- `src/composables/useAuth.ts` — Call `workoutStore.reset()` instead of `$reset()`
- `src/composables/__tests__/useAuth.test.ts` — Updated mock from `$reset` to `reset`
- `src/stores/__tests__/workout.test.ts` — Added integration tests: reset clears state and persists to localStorage

## Test plan
- [x] New integration tests verify reset() clears all state fields
- [x] New integration tests verify reset() persists cleared state to localStorage
- [x] Existing sign-out tests pass with updated mock
- [x] Full test suite: 1485 tests pass (69 files)

Closes #500
