### PR TITLE
fix(#343): add overrides for deprecated transitive dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3597,6 +3597,14 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/sourcemap-codec": {
+      "name": "@jridgewell/sourcemap-codec",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -9046,14 +9054,6 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/speakingurl": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
@@ -10550,6 +10550,14 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/workbox-build/node_modules/sourcemap-codec": {
+      "name": "@jridgewell/sourcemap-codec",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/workbox-cacheable-response": {
       "version": "7.4.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.4",
-    "esbuild": ">=0.25.0"
+    "esbuild": ">=0.25.0",
+    "sourcemap-codec": "npm:@jridgewell/sourcemap-codec@^1.5.0"
   }
 }

--- a/src/lib/__tests__/dependencyHealth.test.ts
+++ b/src/lib/__tests__/dependencyHealth.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const packageJson = JSON.parse(
+  readFileSync(resolve(__dirname, '../../../package.json'), 'utf-8')
+)
+
+const packageLock = JSON.parse(
+  readFileSync(resolve(__dirname, '../../../package-lock.json'), 'utf-8')
+)
+
+describe('dependency health', () => {
+  describe('npm overrides for known vulnerabilities and deprecations', () => {
+    it('should override serialize-javascript to patched version', () => {
+      expect(packageJson.overrides['serialize-javascript']).toBe('>=7.0.4')
+    })
+
+    it('should override esbuild to patched version', () => {
+      expect(packageJson.overrides['esbuild']).toBe('>=0.25.0')
+    })
+
+    it('should override sourcemap-codec with @jridgewell/sourcemap-codec', () => {
+      // sourcemap-codec is deprecated — the maintainer recommends @jridgewell/sourcemap-codec
+      // Used by magic-string@0.25.9 in workbox-build and @surma/rollup-plugin-off-main-thread
+      expect(packageJson.overrides['sourcemap-codec']).toBe(
+        'npm:@jridgewell/sourcemap-codec@^1.5.0'
+      )
+    })
+  })
+
+  describe('deprecated transitive dependencies tracking', () => {
+    // These are dev-only transitive deps that can't be safely overridden
+    // because the parent packages pin specific major versions with breaking API changes.
+    // Track them here so we notice when upstream fixes land.
+
+    it('should track glob deprecation from js-beautify (via @vue/test-utils)', () => {
+      const jsBeautifyGlob =
+        packageLock.packages['node_modules/js-beautify/node_modules/glob']
+      if (jsBeautifyGlob) {
+        // glob@10.x is deprecated by maintainer in favor of glob@13.x
+        // Cannot override: glob@13 removed glob.sync() which js-beautify uses
+        // Resolution: wait for @vue/test-utils to update js-beautify
+        expect(jsBeautifyGlob.version).toMatch(/^10\./)
+        expect(jsBeautifyGlob.deprecated).toBeTruthy()
+      }
+      // If the entry is gone, js-beautify upgraded — remove this test
+    })
+
+    it('should track glob deprecation from workbox-build (via vite-plugin-pwa)', () => {
+      const workboxGlob =
+        packageLock.packages['node_modules/workbox-build/node_modules/glob']
+      if (workboxGlob) {
+        // glob@11.x is deprecated by maintainer in favor of glob@13.x
+        // Cannot override: glob@13 has breaking API changes
+        // Resolution: wait for workbox-build v8 to update
+        expect(workboxGlob.version).toMatch(/^11\./)
+        expect(workboxGlob.deprecated).toBeTruthy()
+      }
+      // If the entry is gone, workbox-build upgraded — remove this test
+    })
+
+    it('should track source-map beta deprecation from workbox-build', () => {
+      const sourceMap = packageLock.packages['node_modules/source-map']
+      if (sourceMap?.deprecated) {
+        // source-map@0.8.0-beta.0 is an abandoned beta used by workbox-build
+        // for WASM-based source map parsing. No stable replacement exists.
+        // Cannot override: workbox-build depends on the beta API
+        // Resolution: wait for workbox-build v8
+        expect(sourceMap.version).toBe('0.8.0-beta.0')
+      }
+      // If the entry is not deprecated, workbox-build upgraded — remove this test
+    })
+
+    it('should verify sourcemap-codec override is applied in lock file', () => {
+      const codec = packageLock.packages['node_modules/sourcemap-codec']
+      // After npm install with the override, this entry should either:
+      // 1. Point to @jridgewell/sourcemap-codec (override applied)
+      // 2. Still show the old package (override not yet applied — run npm install)
+      if (codec && !codec.resolved?.includes('@jridgewell')) {
+        // Override hasn't been applied yet — this is expected until npm install runs
+        expect(codec.deprecated).toBeTruthy()
+      }
+    })
+  })
+
+  describe('no production deprecated dependencies', () => {
+    it('should have no deprecated packages in production dependencies', () => {
+      const prodDeprecated: string[] = []
+      for (const [name, info] of Object.entries(
+        packageLock.packages as Record<string, { deprecated?: string; dev?: boolean }>
+      )) {
+        if (info.deprecated && !info.dev && name.startsWith('node_modules/')) {
+          prodDeprecated.push(
+            `${name.replace('node_modules/', '')}@${(info as { version?: string }).version}`
+          )
+        }
+      }
+      expect(prodDeprecated).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add npm override for sourcemap-codec to npm:@jridgewell/sourcemap-codec (officially recommended drop-in replacement)
- Add dependencyHealth.test.ts (8 tests) to pin and track all deprecated transitive deps
- Remaining deprecated deps (glob@10/11, source-map@0.8.0-beta.0) tracked in tests but need upstream fixes in workbox-build and js-beautify

## Test plan
- All 1491 tests pass (70 files)
- Build succeeds with no new warnings
- dependencyHealth.test.ts verifies override configuration and tracks remaining deprecated deps
- No deprecated packages in production dependencies

Closes #343
