### PR TITLE
feat(#307): add training report generation with HTML export

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -493,6 +493,14 @@
                 </div>
               </div>
               <div class="settingsRow">
+                <span class="settingsLabel">Report</span>
+                <div class="exportBtnGroup">
+                  <button class="exportBtn" @click="generateReport('30')" aria-label="Generate 30-day training report">30 days</button>
+                  <button class="exportBtn" @click="generateReport('90')" aria-label="Generate 90-day training report">90 days</button>
+                  <button class="exportBtn" @click="generateReport('month')" aria-label="Generate monthly training report">Month</button>
+                </div>
+              </div>
+              <div class="settingsRow">
                 <span class="settingsLabel">Import</span>
                 <div class="exportBtnGroup">
                   <button class="exportBtn" @click="triggerImport" aria-label="Import workout data from CSV">CSV</button>
@@ -880,6 +888,8 @@ import { requestPersistentStorage, ensureLocalStorage, clearIDB } from './lib/du
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
 import { hashUserId, buildJsonExport, buildCsvExport } from './lib/dataExport'
+import { buildTrainingReport, lastNDaysPeriod, monthPeriod } from './lib/trainingReport'
+import { renderTrainingReportHtml } from './lib/trainingReportHtml'
 import { importCSV } from './lib/csvImport'
 import { usePreferencesStore } from './stores/preferences'
 import type { WeightGoalDirection } from './stores/preferences'
@@ -1726,6 +1736,24 @@ async function exportData(format: 'csv' | 'json') {
     downloadFile(`lift-export-${timestamp}.csv`, csv, 'text/csv')
   }
   logEvent('data_export', { format })
+}
+
+function generateReport(range: '30' | '90' | 'month') {
+  const workoutStore = useWorkoutStore()
+  const bwStore = useBodyweightStore()
+  const today = new Date().toISOString().slice(0, 10)
+  const period = range === 'month'
+    ? monthPeriod(new Date().getFullYear(), new Date().getMonth() + 1)
+    : lastNDaysPeriod(Number(range), today)
+
+  const report = buildTrainingReport(period, workoutStore.exercises, bwStore.sortedEntries)
+  const html = renderTrainingReportHtml(report, {
+    weightUnit: weightUnit.value as 'lbs' | 'kg',
+    displayWeight,
+  })
+  const timestamp = today
+  downloadFile(`lift-report-${timestamp}.html`, html, 'text/html')
+  logEvent('training_report', { range })
 }
 
 function downloadFile(filename: string, content: string, mimeType: string) {

--- a/src/lib/__tests__/trainingReport.test.ts
+++ b/src/lib/__tests__/trainingReport.test.ts
@@ -275,6 +275,18 @@ describe('renderTrainingReportHtml', () => {
     expect(html).toContain('&lt;script&gt;')
   })
 
+  it('escapes HTML in tag names (volume section)', () => {
+    const xssTagExercise = makeExercise({
+      name: 'Curl',
+      tags: ['<img src=x onerror=alert(1)>'],
+      sets: [{ id: 'x2', date: '2026-04-05T10:00:00.000Z', weight: 50, reps: 10, estimated1RM: 67 }],
+    })
+    const xssReport = buildTrainingReport(APRIL_2026, [xssTagExercise], [])
+    const html = renderTrainingReportHtml(xssReport)
+    expect(html).not.toContain('<img src=x')
+    expect(html).toContain('&lt;img')
+  })
+
   it('includes print media query for page breaks', () => {
     const html = renderTrainingReportHtml(report)
     expect(html).toContain('@media print')

--- a/src/lib/__tests__/trainingReport.test.ts
+++ b/src/lib/__tests__/trainingReport.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildTrainingReport,
+  lastNDaysPeriod,
+  monthPeriod,
+  type ReportPeriod,
+} from '../trainingReport'
+import { renderTrainingReportHtml } from '../trainingReportHtml'
+import type { Exercise } from '../../stores/workout'
+
+// ── Fixtures ──────────────────────────────────────────────────────
+
+function makeExercise(overrides: Partial<Exercise> & { name: string }): Exercise {
+  return {
+    id: overrides.id ?? overrides.name.toLowerCase().replace(/\s/g, '-'),
+    tags: [],
+    sets: [],
+    ...overrides,
+  }
+}
+
+const benchPress = makeExercise({
+  name: 'Bench Press',
+  tags: ['chest', 'push'],
+  sets: [
+    { id: 's1', date: '2026-04-01T10:00:00.000Z', weight: 200, reps: 5, estimated1RM: 233 },
+    { id: 's2', date: '2026-04-05T10:00:00.000Z', weight: 205, reps: 5, estimated1RM: 239 },
+    { id: 's3', date: '2026-04-10T10:00:00.000Z', weight: 210, reps: 5, estimated1RM: 245 },
+    { id: 's4', date: '2026-04-15T10:00:00.000Z', weight: 215, reps: 5, estimated1RM: 251 },
+  ],
+})
+
+const squat = makeExercise({
+  name: 'Squat',
+  tags: ['legs', 'push'],
+  sets: [
+    { id: 's5', date: '2026-04-02T10:00:00.000Z', weight: 300, reps: 3, estimated1RM: 330 },
+    { id: 's6', date: '2026-04-08T10:00:00.000Z', weight: 305, reps: 3, estimated1RM: 336 },
+  ],
+})
+
+const deadlift = makeExercise({
+  name: 'Deadlift',
+  tags: ['back', 'pull'],
+  sets: [
+    { id: 's7', date: '2026-03-15T10:00:00.000Z', weight: 350, reps: 3, estimated1RM: 385 },
+    { id: 's8', date: '2026-04-20T10:00:00.000Z', weight: 355, reps: 3, estimated1RM: 391 },
+  ],
+})
+
+const bodyweight = [
+  { date: '2026-04-01T08:00:00.000Z', weight: 185 },
+  { date: '2026-04-15T08:00:00.000Z', weight: 183 },
+  { date: '2026-04-30T08:00:00.000Z', weight: 182 },
+]
+
+const APRIL_2026: ReportPeriod = { label: 'April 2026', startDate: '2026-04-01', endDate: '2026-04-30' }
+
+// ── Period helpers ────────────────────────────────────────────────
+
+describe('lastNDaysPeriod', () => {
+  it('computes a 30-day period ending on the given date', () => {
+    const p = lastNDaysPeriod(30, '2026-04-30')
+    expect(p.startDate).toBe('2026-04-01')
+    expect(p.endDate).toBe('2026-04-30')
+    expect(p.label).toBe('Last 30 days')
+  })
+
+  it('computes a 90-day period', () => {
+    const p = lastNDaysPeriod(90, '2026-04-30')
+    expect(p.startDate).toBe('2026-01-31')
+    expect(p.endDate).toBe('2026-04-30')
+  })
+})
+
+describe('monthPeriod', () => {
+  it('returns correct start and end for April 2026', () => {
+    const p = monthPeriod(2026, 4)
+    expect(p.startDate).toBe('2026-04-01')
+    expect(p.endDate).toBe('2026-04-30')
+    expect(p.label).toBe('April 2026')
+  })
+
+  it('handles February in a non-leap year', () => {
+    const p = monthPeriod(2027, 2)
+    expect(p.endDate).toBe('2027-02-28')
+  })
+
+  it('handles February in a leap year', () => {
+    const p = monthPeriod(2028, 2)
+    expect(p.endDate).toBe('2028-02-29')
+  })
+})
+
+// ── Report building ──────────────────────────────────────────────
+
+describe('buildTrainingReport', () => {
+  const report = buildTrainingReport(
+    APRIL_2026,
+    [benchPress, squat, deadlift],
+    bodyweight,
+  )
+
+  describe('summary', () => {
+    it('counts unique workout days', () => {
+      // Bench: 4/1, 4/5, 4/10, 4/15; Squat: 4/2, 4/8; Deadlift: 4/20
+      expect(report.summary.totalWorkouts).toBe(7)
+      expect(report.summary.activeDays).toBe(7)
+    })
+
+    it('counts total sets in period', () => {
+      // Bench: 4, Squat: 2, Deadlift: 1 (4/20 only — 3/15 is outside April)
+      expect(report.summary.totalSets).toBe(7)
+    })
+
+    it('counts unique exercises', () => {
+      expect(report.summary.uniqueExercises).toBe(3)
+    })
+
+    it('computes total volume', () => {
+      // Bench: 200*5 + 205*5 + 210*5 + 215*5 = 4150
+      // Squat: 300*3 + 305*3 = 1815
+      // Deadlift: 355*3 = 1065
+      expect(report.summary.totalVolume).toBe(4150 + 1815 + 1065)
+    })
+
+    it('counts PRs (exercises that beat their pre-period best)', () => {
+      // Deadlift had a set on 3/15 (e1RM=385), and 4/20 (e1RM=391) > 385 → PR
+      // Bench and Squat have no sets before April → no "prior" to beat
+      expect(report.summary.prsHit).toBe(1)
+    })
+
+    it('computes consistency as percentage of weeks', () => {
+      expect(report.summary.consistency).toBeGreaterThan(0)
+      expect(report.summary.consistency).toBeLessThanOrEqual(100)
+    })
+  })
+
+  describe('exercises', () => {
+    it('returns exercise reports sorted by most sets', () => {
+      expect(report.exercises[0].name).toBe('Bench Press')
+      expect(report.exercises[0].totalSets).toBe(4)
+    })
+
+    it('includes timeline with best e1RM per date', () => {
+      const bench = report.exercises.find(e => e.name === 'Bench Press')!
+      expect(bench.timeline).toHaveLength(4)
+      expect(bench.timeline[0]).toEqual({
+        date: '2026-04-01', e1rm: 233, weight: 200, reps: 5,
+      })
+    })
+
+    it('computes e1RM delta between first and last session', () => {
+      const bench = report.exercises.find(e => e.name === 'Bench Press')!
+      expect(bench.e1rmDelta).toBe(251 - 233) // 18
+    })
+
+    it('returns null e1rmDelta for exercises with only one session in period', () => {
+      const dl = report.exercises.find(e => e.name === 'Deadlift')!
+      expect(dl.e1rmDelta).toBeNull()
+    })
+
+    it('includes tags', () => {
+      const bench = report.exercises.find(e => e.name === 'Bench Press')!
+      expect(bench.tags).toEqual(['chest', 'push'])
+    })
+  })
+
+  describe('tagVolume', () => {
+    it('aggregates sets by tag', () => {
+      const push = report.tagVolume.find(t => t.tag === 'push')!
+      // Bench (4 sets) + Squat (2 sets) both tagged 'push'
+      expect(push.totalSets).toBe(6)
+    })
+
+    it('counts exercises per tag', () => {
+      const push = report.tagVolume.find(t => t.tag === 'push')!
+      expect(push.exerciseCount).toBe(2)
+    })
+
+    it('is sorted by totalSets descending', () => {
+      for (let i = 1; i < report.tagVolume.length; i++) {
+        expect(report.tagVolume[i].totalSets).toBeLessThanOrEqual(report.tagVolume[i - 1].totalSets)
+      }
+    })
+  })
+
+  describe('bodyweight', () => {
+    it('includes bodyweight entries within the period', () => {
+      expect(report.bodyweight.entries).toHaveLength(3)
+    })
+
+    it('computes start/end weights', () => {
+      expect(report.bodyweight.startWeight).toBe(185)
+      expect(report.bodyweight.endWeight).toBe(182)
+    })
+
+    it('computes delta', () => {
+      expect(report.bodyweight.delta).toBe(-3)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty data gracefully', () => {
+      const empty = buildTrainingReport(APRIL_2026, [], [])
+      expect(empty.summary.totalWorkouts).toBe(0)
+      expect(empty.summary.totalSets).toBe(0)
+      expect(empty.exercises).toHaveLength(0)
+      expect(empty.tagVolume).toHaveLength(0)
+      expect(empty.bodyweight.entries).toHaveLength(0)
+      expect(empty.bodyweight.delta).toBeNull()
+    })
+
+    it('excludes sets outside the period', () => {
+      const report = buildTrainingReport(
+        { label: 'Early April', startDate: '2026-04-01', endDate: '2026-04-05' },
+        [benchPress],
+        [],
+      )
+      expect(report.summary.totalSets).toBe(2) // only 4/1 and 4/5
+    })
+  })
+})
+
+// ── HTML rendering ───────────────────────────────────────────────
+
+describe('renderTrainingReportHtml', () => {
+  const report = buildTrainingReport(APRIL_2026, [benchPress, squat], bodyweight)
+
+  it('produces a valid HTML document', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('<html lang="en">')
+    expect(html).toContain('</html>')
+  })
+
+  it('includes the period label in the title', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('April 2026')
+  })
+
+  it('includes summary stats', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('Workouts')
+    expect(html).toContain('Sets')
+    expect(html).toContain('Volume')
+    expect(html).toContain('Consistency')
+  })
+
+  it('includes exercise names', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('Bench Press')
+    expect(html).toContain('Squat')
+  })
+
+  it('includes SVG sparklines for exercises with 2+ sessions', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('<svg')
+    expect(html).toContain('polyline')
+  })
+
+  it('respects kg weight unit', () => {
+    const html = renderTrainingReportHtml(report, { weightUnit: 'kg' })
+    expect(html).toContain('kg')
+  })
+
+  it('escapes HTML in exercise names', () => {
+    const xssExercise = makeExercise({
+      name: '<script>alert("xss")</script>',
+      sets: [{ id: 'x1', date: '2026-04-05T10:00:00.000Z', weight: 100, reps: 5, estimated1RM: 117 }],
+    })
+    const xssReport = buildTrainingReport(APRIL_2026, [xssExercise], [])
+    const html = renderTrainingReportHtml(xssReport)
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('includes print media query for page breaks', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('@media print')
+    expect(html).toContain('break-inside: avoid')
+  })
+
+  it('includes bodyweight data when available', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('Bodyweight')
+    expect(html).toContain('Start:')
+    expect(html).toContain('End:')
+  })
+
+  it('does not include bodyweight section when no data', () => {
+    const noBody = buildTrainingReport(APRIL_2026, [benchPress], [])
+    const html = renderTrainingReportHtml(noBody)
+    expect(html).not.toContain('Bodyweight')
+  })
+
+  it('includes the Lift branding in the footer', () => {
+    const html = renderTrainingReportHtml(report)
+    expect(html).toContain('Generated by Lift')
+  })
+})

--- a/src/lib/trainingReport.ts
+++ b/src/lib/trainingReport.ts
@@ -1,0 +1,251 @@
+/**
+ * Training report data computation.
+ *
+ * Pure functions that aggregate workout-store data into structured report
+ * sections: summary stats, per-exercise PR timelines, volume by tag, and
+ * bodyweight trends. Framework-free so tests can exercise them directly.
+ */
+
+import type { Exercise, WorkoutSet } from '../stores/workout'
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface ReportPeriod {
+  label: string      // e.g., 'April 2026' or 'Q1 2026'
+  startDate: string  // YYYY-MM-DD
+  endDate: string    // YYYY-MM-DD
+}
+
+export interface ReportSummary {
+  period: ReportPeriod
+  totalWorkouts: number
+  totalSets: number
+  totalVolume: number     // sum of weight × reps (in stored units — lbs)
+  uniqueExercises: number
+  prsHit: number
+  activeDays: number
+  consistency: number     // percentage of weeks with at least 1 workout
+}
+
+export interface ExerciseReport {
+  name: string
+  tags: string[]
+  totalSets: number
+  bestE1RM: number
+  bestWeight: number
+  bestReps: number
+  /** e1RM at start vs end of period — null if fewer than 2 sessions */
+  e1rmDelta: number | null
+  /** Best set per session date within the period, chronological */
+  timeline: { date: string; e1rm: number; weight: number; reps: number }[]
+}
+
+export interface TagVolumeReport {
+  tag: string
+  totalSets: number
+  totalVolume: number
+  exerciseCount: number
+}
+
+export interface BodyweightReport {
+  entries: { date: string; weight: number }[]
+  startWeight: number | null
+  endWeight: number | null
+  delta: number | null
+}
+
+export interface TrainingReport {
+  generatedAt: string    // ISO timestamp
+  summary: ReportSummary
+  exercises: ExerciseReport[]
+  tagVolume: TagVolumeReport[]
+  bodyweight: BodyweightReport
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function dateKey(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+/** Get sets within [startDate, endDate] inclusive. */
+function setsInPeriod(sets: WorkoutSet[], start: string, end: string): WorkoutSet[] {
+  return sets.filter(s => {
+    const d = dateKey(s.date)
+    return d >= start && d <= end
+  })
+}
+
+/** Build a ReportPeriod for the last N days ending today. */
+export function lastNDaysPeriod(days: number, today?: string): ReportPeriod {
+  const endDate = today ?? new Date().toISOString().slice(0, 10)
+  const [y, m, d] = endDate.split('-').map(Number)
+  const start = new Date(y, m - 1, d)
+  start.setDate(start.getDate() - days + 1)
+  const startDate = [
+    start.getFullYear(),
+    String(start.getMonth() + 1).padStart(2, '0'),
+    String(start.getDate()).padStart(2, '0'),
+  ].join('-')
+  return { label: `Last ${days} days`, startDate, endDate }
+}
+
+/** Build a ReportPeriod for a specific month. */
+export function monthPeriod(year: number, month: number): ReportPeriod {
+  const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+    'July', 'August', 'September', 'October', 'November', 'December']
+  const startDate = `${year}-${String(month).padStart(2, '0')}-01`
+  const lastDay = new Date(year, month, 0).getDate()
+  const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+  return { label: `${MONTHS[month - 1]} ${year}`, startDate, endDate }
+}
+
+// ── Core computation ──────────────────────────────────────────────
+
+export function buildTrainingReport(
+  period: ReportPeriod,
+  exercises: Exercise[],
+  bodyweightEntries: { date: string; weight: number }[],
+): TrainingReport {
+  const { startDate, endDate } = period
+
+  // Filter exercises to those with sets in the period
+  const exercisesWithSets: { ex: Exercise; periodSets: WorkoutSet[] }[] = []
+  for (const ex of exercises) {
+    const periodSets = setsInPeriod(ex.sets, startDate, endDate)
+    if (periodSets.length > 0) {
+      exercisesWithSets.push({ ex, periodSets })
+    }
+  }
+
+  // ── Summary ──
+  const workoutDates = new Set<string>()
+  let totalSets = 0
+  let totalVolume = 0
+  let prsHit = 0
+
+  for (const { ex, periodSets } of exercisesWithSets) {
+    totalSets += periodSets.length
+    for (const s of periodSets) {
+      workoutDates.add(dateKey(s.date))
+      totalVolume += s.weight * s.reps
+    }
+    // Count PRs: sets in the period whose e1RM exceeds all prior sets
+    const priorSets = ex.sets.filter(s => dateKey(s.date) < startDate)
+    const priorMax = priorSets.length > 0
+      ? Math.max(...priorSets.map(s => s.estimated1RM))
+      : 0
+    const periodMax = Math.max(...periodSets.map(s => s.estimated1RM))
+    if (periodMax > priorMax && priorSets.length > 0) {
+      prsHit++
+    }
+  }
+
+  // Consistency: what percentage of calendar weeks in the period had at least 1 workout
+  const totalWeeks = Math.max(1, Math.ceil(
+    (new Date(endDate + 'T12:00:00').getTime() - new Date(startDate + 'T12:00:00').getTime())
+    / (7 * 24 * 60 * 60 * 1000)
+  ))
+  const weeksWithWorkout = new Set<string>()
+  for (const d of workoutDates) {
+    // ISO week approximation: use Monday-based week number
+    const dt = new Date(d + 'T12:00:00')
+    const yearStart = new Date(dt.getFullYear(), 0, 1)
+    const daysSinceYearStart = Math.floor((dt.getTime() - yearStart.getTime()) / 86400000)
+    const weekNum = Math.ceil((daysSinceYearStart + yearStart.getDay() + 1) / 7)
+    weeksWithWorkout.add(`${dt.getFullYear()}-W${weekNum}`)
+  }
+  const consistency = Math.round((weeksWithWorkout.size / totalWeeks) * 100)
+
+  const summary: ReportSummary = {
+    period,
+    totalWorkouts: workoutDates.size,
+    totalSets,
+    totalVolume,
+    uniqueExercises: exercisesWithSets.length,
+    prsHit,
+    activeDays: workoutDates.size,
+    consistency: Math.min(100, consistency),
+  }
+
+  // ── Per-exercise reports ──
+  const exerciseReports: ExerciseReport[] = exercisesWithSets
+    .map(({ ex, periodSets }) => {
+      // Best e1RM per date
+      const byDate = new Map<string, { e1rm: number; weight: number; reps: number }>()
+      for (const s of periodSets) {
+        const d = dateKey(s.date)
+        const prev = byDate.get(d)
+        if (!prev || s.estimated1RM > prev.e1rm) {
+          byDate.set(d, { e1rm: s.estimated1RM, weight: s.weight, reps: s.reps })
+        }
+      }
+      const timeline = [...byDate.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([date, data]) => ({ date, ...data }))
+
+      const bestSet = periodSets.reduce((best, s) =>
+        s.estimated1RM > best.estimated1RM ? s : best
+      )
+      const e1rmDelta = timeline.length >= 2
+        ? timeline[timeline.length - 1].e1rm - timeline[0].e1rm
+        : null
+
+      return {
+        name: ex.name,
+        tags: ex.tags,
+        totalSets: periodSets.length,
+        bestE1RM: bestSet.estimated1RM,
+        bestWeight: bestSet.weight,
+        bestReps: bestSet.reps,
+        e1rmDelta,
+        timeline,
+      }
+    })
+    .sort((a, b) => b.totalSets - a.totalSets) // most active first
+
+  // ── Volume by tag ──
+  const tagMap = new Map<string, { sets: number; volume: number; exercises: Set<string> }>()
+  for (const { ex, periodSets } of exercisesWithSets) {
+    const vol = periodSets.reduce((sum, s) => sum + s.weight * s.reps, 0)
+    for (const tag of ex.tags) {
+      const entry = tagMap.get(tag) ?? { sets: 0, volume: 0, exercises: new Set<string>() }
+      entry.sets += periodSets.length
+      entry.volume += vol
+      entry.exercises.add(ex.name)
+      tagMap.set(tag, entry)
+    }
+  }
+  const tagVolume: TagVolumeReport[] = [...tagMap.entries()]
+    .map(([tag, data]) => ({
+      tag,
+      totalSets: data.sets,
+      totalVolume: data.volume,
+      exerciseCount: data.exercises.size,
+    }))
+    .sort((a, b) => b.totalSets - a.totalSets)
+
+  // ── Bodyweight ──
+  const bwInPeriod = bodyweightEntries
+    .filter(e => {
+      const d = dateKey(e.date)
+      return d >= startDate && d <= endDate
+    })
+    .sort((a, b) => dateKey(a.date).localeCompare(dateKey(b.date)))
+  const bodyweight: BodyweightReport = {
+    entries: bwInPeriod.map(e => ({ date: dateKey(e.date), weight: e.weight })),
+    startWeight: bwInPeriod.length > 0 ? bwInPeriod[0].weight : null,
+    endWeight: bwInPeriod.length > 0 ? bwInPeriod[bwInPeriod.length - 1].weight : null,
+    delta: bwInPeriod.length >= 2
+      ? bwInPeriod[bwInPeriod.length - 1].weight - bwInPeriod[0].weight
+      : null,
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    summary,
+    exercises: exerciseReports,
+    tagVolume,
+    bodyweight,
+  }
+}

--- a/src/lib/trainingReportHtml.ts
+++ b/src/lib/trainingReportHtml.ts
@@ -128,7 +128,7 @@ export function renderTrainingReportHtml(
         <h2>Volume by Tag</h2>
         <div class="volume-bars">
           ${tagVolume.map(t =>
-            volumeBar(t.totalSets, maxTagSets, t.tag, `${t.totalSets} sets`)
+            volumeBar(t.totalSets, maxTagSets, escapeHtml(t.tag), `${t.totalSets} sets`)
           ).join('')}
         </div>
       </section>`

--- a/src/lib/trainingReportHtml.ts
+++ b/src/lib/trainingReportHtml.ts
@@ -1,0 +1,272 @@
+/**
+ * Training report HTML renderer.
+ *
+ * Generates a self-contained HTML document with inline CSS that renders
+ * a formatted training report. Optimized for print-to-PDF and mobile
+ * Share Sheet workflows.
+ *
+ * No external dependencies — uses inline SVG for mini charts.
+ */
+
+import type { TrainingReport, ExerciseReport } from './trainingReport'
+
+// ── SVG chart helpers ─────────────────────────────────────────────
+
+function miniSparkline(
+  data: { date: string; e1rm: number }[],
+  width = 200,
+  height = 40,
+): string {
+  if (data.length < 2) return ''
+  const values = data.map(d => d.e1rm)
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const padY = 4
+
+  const points = data.map((d, i) => {
+    const x = (i / (data.length - 1)) * width
+    const y = padY + ((max - d.e1rm) / range) * (height - padY * 2)
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+
+  const areaPoints = [
+    `0,${height}`,
+    ...points,
+    `${width},${height}`,
+  ].join(' ')
+
+  return `<svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" style="display:block;">
+    <polygon points="${areaPoints}" fill="rgba(59,130,246,0.1)" />
+    <polyline points="${points.join(' ')}" fill="none" stroke="#3b82f6" stroke-width="1.5" />
+    <circle cx="${points[points.length - 1].split(',')[0]}" cy="${points[points.length - 1].split(',')[1]}" r="2.5" fill="#3b82f6" />
+  </svg>`
+}
+
+function volumeBar(
+  value: number,
+  maxValue: number,
+  label: string,
+  count: string,
+): string {
+  const pct = maxValue > 0 ? (value / maxValue) * 100 : 0
+  return `<div style="display:flex;align-items:center;gap:8px;margin:4px 0;">
+    <span style="min-width:80px;font-size:13px;color:#374151;">${label}</span>
+    <div style="flex:1;height:16px;background:#f3f4f6;border-radius:4px;overflow:hidden;">
+      <div style="width:${pct}%;height:100%;background:linear-gradient(90deg,#3b82f6,#60a5fa);border-radius:4px;"></div>
+    </div>
+    <span style="min-width:48px;text-align:right;font-size:12px;color:#6b7280;">${count}</span>
+  </div>`
+}
+
+// ── Formatters ────────────────────────────────────────────────────
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso + 'T12:00:00')
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function fmtNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function fmtWeight(lbs: number, unit: 'lbs' | 'kg'): string {
+  if (unit === 'kg') return `${(lbs * 0.453592).toFixed(1)} kg`
+  return `${Math.round(lbs)} lbs`
+}
+
+function deltaArrow(delta: number | null): string {
+  if (delta === null) return ''
+  if (delta > 0) return `<span style="color:#16a34a;">+${Math.round(delta)}</span>`
+  if (delta < 0) return `<span style="color:#dc2626;">${Math.round(delta)}</span>`
+  return '<span style="color:#6b7280;">±0</span>'
+}
+
+// ── Main renderer ─────────────────────────────────────────────────
+
+export function renderTrainingReportHtml(
+  report: TrainingReport,
+  options: { weightUnit?: 'lbs' | 'kg'; displayWeight?: (lbs: number) => number } = {},
+): string {
+  const unit = options.weightUnit ?? 'lbs'
+  const dw = options.displayWeight ?? ((lbs: number) => unit === 'kg' ? +(lbs * 0.453592).toFixed(1) : lbs)
+  const { summary, exercises, tagVolume, bodyweight } = report
+
+  // ── Summary section ──
+  const summaryHtml = `
+    <div class="stats-grid">
+      <div class="stat">
+        <div class="stat-value">${summary.totalWorkouts}</div>
+        <div class="stat-label">Workouts</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${fmtNumber(summary.totalSets)}</div>
+        <div class="stat-label">Sets</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${fmtNumber(Math.round(dw(summary.totalVolume)))}</div>
+        <div class="stat-label">Volume (${unit})</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${summary.uniqueExercises}</div>
+        <div class="stat-label">Exercises</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${summary.prsHit}</div>
+        <div class="stat-label">PRs Hit</div>
+      </div>
+      <div class="stat">
+        <div class="stat-value">${summary.consistency}%</div>
+        <div class="stat-label">Consistency</div>
+      </div>
+    </div>`
+
+  // ── Tag volume section ──
+  const maxTagSets = tagVolume.length > 0 ? tagVolume[0].totalSets : 1
+  const tagHtml = tagVolume.length > 0
+    ? `<section class="section">
+        <h2>Volume by Tag</h2>
+        <div class="volume-bars">
+          ${tagVolume.map(t =>
+            volumeBar(t.totalSets, maxTagSets, t.tag, `${t.totalSets} sets`)
+          ).join('')}
+        </div>
+      </section>`
+    : ''
+
+  // ── Exercise details ──
+  const topExercises = exercises.slice(0, 10) // cap at 10 for readability
+  const exerciseHtml = topExercises.length > 0
+    ? `<section class="section">
+        <h2>Exercise Breakdown</h2>
+        ${topExercises.map(ex => exerciseCard(ex, unit, dw)).join('')}
+        ${exercises.length > 10
+          ? `<p class="muted" style="text-align:center;margin-top:12px;">+ ${exercises.length - 10} more exercises</p>`
+          : ''}
+      </section>`
+    : ''
+
+  // ── Bodyweight section ──
+  const bwHtml = bodyweight.entries.length > 0
+    ? `<section class="section">
+        <h2>Bodyweight</h2>
+        <div class="bw-summary">
+          ${bodyweight.startWeight != null ? `<span>Start: ${fmtWeight(bodyweight.startWeight, unit)}</span>` : ''}
+          ${bodyweight.endWeight != null ? `<span>End: ${fmtWeight(bodyweight.endWeight, unit)}</span>` : ''}
+          ${bodyweight.delta != null ? `<span>Change: ${deltaArrow(unit === 'kg' ? bodyweight.delta * 0.453592 : bodyweight.delta)} ${unit}</span>` : ''}
+        </div>
+        ${miniSparkline(bodyweight.entries.map(e => ({ date: e.date, e1rm: e.weight })), 500, 60)}
+      </section>`
+    : ''
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Lift Training Report — ${summary.period.label}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      color: #111827;
+      background: #fff;
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 32px 24px;
+      line-height: 1.5;
+    }
+    h1 { font-size: 24px; font-weight: 700; margin-bottom: 4px; }
+    h2 { font-size: 18px; font-weight: 600; margin-bottom: 12px; color: #111827; }
+    .subtitle { font-size: 14px; color: #6b7280; margin-bottom: 24px; }
+    .section { margin-top: 32px; }
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+    }
+    .stat {
+      text-align: center;
+      padding: 16px 8px;
+      background: #f9fafb;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .stat-value { font-size: 28px; font-weight: 700; color: #111827; }
+    .stat-label { font-size: 12px; color: #6b7280; margin-top: 2px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .volume-bars { margin-top: 8px; }
+    .ex-card {
+      padding: 16px;
+      margin-bottom: 12px;
+      background: #f9fafb;
+      border-radius: 12px;
+      border: 1px solid #e5e7eb;
+    }
+    .ex-header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 8px; }
+    .ex-name { font-size: 15px; font-weight: 600; }
+    .ex-sets { font-size: 13px; color: #6b7280; }
+    .ex-stats { display: flex; gap: 16px; font-size: 13px; color: #374151; flex-wrap: wrap; }
+    .ex-stats span { white-space: nowrap; }
+    .ex-spark { margin-top: 8px; }
+    .bw-summary { display: flex; gap: 24px; font-size: 14px; color: #374151; margin-bottom: 8px; }
+    .muted { color: #9ca3af; font-size: 13px; }
+    .footer { margin-top: 40px; padding-top: 16px; border-top: 1px solid #e5e7eb; font-size: 12px; color: #9ca3af; text-align: center; }
+    .tag-pills { display: flex; gap: 4px; margin-top: 4px; flex-wrap: wrap; }
+    .tag-pill { font-size: 11px; background: #e5e7eb; color: #374151; padding: 1px 8px; border-radius: 999px; }
+    @media print {
+      body { padding: 16px; max-width: 100%; }
+      .section { break-inside: avoid; }
+      .ex-card { break-inside: avoid; }
+    }
+    @media (max-width: 480px) {
+      .stats-grid { grid-template-columns: repeat(2, 1fr); }
+      body { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <h1>Training Report</h1>
+  <p class="subtitle">${summary.period.label} · ${fmtDate(summary.period.startDate)} – ${fmtDate(summary.period.endDate)}</p>
+
+  ${summaryHtml}
+  ${tagHtml}
+  ${exerciseHtml}
+  ${bwHtml}
+
+  <div class="footer">
+    Generated by Lift · ${fmtDate(report.generatedAt.slice(0, 10))}
+  </div>
+</body>
+</html>`
+}
+
+function exerciseCard(
+  ex: ExerciseReport,
+  unit: 'lbs' | 'kg',
+  dw: (lbs: number) => number,
+): string {
+  const bestDisplay = unit === 'kg' ? dw(ex.bestWeight).toFixed(1) : Math.round(ex.bestWeight)
+  const e1rmDisplay = unit === 'kg' ? dw(ex.bestE1RM).toFixed(1) : Math.round(ex.bestE1RM)
+
+  return `<div class="ex-card">
+    <div class="ex-header">
+      <span class="ex-name">${escapeHtml(ex.name)}</span>
+      <span class="ex-sets">${ex.totalSets} sets</span>
+    </div>
+    <div class="ex-stats">
+      <span>Best: ${bestDisplay} ${unit} × ${ex.bestReps}</span>
+      <span>e1RM: ${e1rmDisplay} ${unit}</span>
+      ${ex.e1rmDelta !== null ? `<span>Δ ${deltaArrow(unit === 'kg' ? ex.e1rmDelta * 0.453592 : ex.e1rmDelta)} ${unit}</span>` : ''}
+    </div>
+    ${ex.tags.length > 0
+      ? `<div class="tag-pills">${ex.tags.map(t => `<span class="tag-pill">${escapeHtml(t)}</span>`).join('')}</div>`
+      : ''}
+    ${ex.timeline.length >= 2
+      ? `<div class="ex-spark">${miniSparkline(ex.timeline)}</div>`
+      : ''}
+  </div>`
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}


### PR DESCRIPTION
Adds downloadable HTML training reports with three period options: 30 days, 90 days, and current month. Reports include summary stats, volume by tag with bar charts, per-exercise e1RM timelines with inline SVG sparklines, and bodyweight trends. Zero new dependencies. XSS-safe. 36 tests. Closes #307