### PR TITLE
feat(#307): add training report generation with print-to-PDF

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -499,6 +499,13 @@
                 </div>
                 <input ref="importFileInput" type="file" accept=".csv" class="hiddenFileInput" aria-label="Import CSV file" @change="handleImportFile" />
               </div>
+              <div class="settingsRow">
+                <span class="settingsLabel">Report</span>
+                <div class="exportBtnGroup">
+                  <button v-for="p in (['month', 'quarter', 'year'] as const)" :key="p" class="exportBtn" :class="{ exportBtnActive: reportPeriod === p }" :aria-label="`${p} training report`" :aria-pressed="reportPeriod === p" @click="reportPeriod = p">{{ p === 'quarter' ? 'Quarter' : p === 'year' ? 'Year' : 'Month' }}</button>
+                  <button class="exportBtn exportBtnPrimary" aria-label="Generate training report" @click="generateReport">Generate</button>
+                </div>
+              </div>
               <div v-if="importResult" class="settingsImportResult" role="status">
                 <span v-if="importResult.error" class="settingsImportError">{{ importResult.error }}</span>
                 <span v-else class="settingsImportSuccess">Imported {{ importResult.exercises }} exercise{{ importResult.exercises !== 1 ? 's' : '' }} with {{ importResult.sets }} sets ({{ importResult.format }})</span>
@@ -880,6 +887,8 @@ import { requestPersistentStorage, ensureLocalStorage, clearIDB } from './lib/du
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
 import { hashUserId, buildJsonExport, buildCsvExport } from './lib/dataExport'
+import { buildTrainingReport, type ReportPeriod } from './lib/trainingReport'
+import { renderReport, openReportWindow } from './lib/reportRenderer'
 import { importCSV } from './lib/csvImport'
 import { usePreferencesStore } from './stores/preferences'
 import type { WeightGoalDirection } from './stores/preferences'
@@ -1738,6 +1747,24 @@ function downloadFile(filename: string, content: string, mimeType: string) {
   a.click()
   document.body.removeChild(a)
   URL.revokeObjectURL(url)
+}
+
+// ── Training Report ─────────────────────────────────────────────
+const reportPeriod = ref<ReportPeriod>('month')
+
+function generateReport() {
+  const workoutStore = useWorkoutStore()
+  const bwStore = useBodyweightStore()
+  const report = buildTrainingReport({
+    exercises: workoutStore.exercises,
+    bodyweight: bwStore.sortedEntries,
+    period: reportPeriod.value,
+    toDisplayUnits: displayWeight,
+    unitLabel: weightUnit.value === 'kg' ? 'kg' : 'lbs',
+  })
+  const html = renderReport(report)
+  openReportWindow(html)
+  logEvent('training_report', { period: reportPeriod.value })
 }
 
 // ── CSV Import ──────────────────────────────────────────────────

--- a/src/index.css
+++ b/src/index.css
@@ -1805,6 +1805,15 @@ html.theme-fading .settingsSheet {
   cursor: pointer;
 }
 .exportBtn:active { opacity: 0.6; }
+.exportBtnActive {
+  background: var(--accent);
+  color: var(--bg);
+}
+.exportBtnPrimary {
+  background: var(--accent);
+  color: var(--bg);
+  font-weight: 600;
+}
 
 .hiddenFileInput {
   position: absolute;

--- a/src/lib/__tests__/reportRenderer.test.ts
+++ b/src/lib/__tests__/reportRenderer.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { renderReport } from '../reportRenderer'
+import type { TrainingReport } from '../trainingReport'
+
+function makeReport(overrides: Partial<TrainingReport> = {}): TrainingReport {
+  return {
+    periodLabel: 'April 2026',
+    startDate: '2026-04-01',
+    endDate: '2026-04-30',
+    unitLabel: 'lbs',
+    totalWorkoutDays: 12,
+    totalSets: 48,
+    totalVolume: 125000,
+    uniqueExercises: 8,
+    prCount: 3,
+    exerciseProgressions: [],
+    tagVolume: [],
+    weeklyConsistency: [],
+    bodyweight: { timeline: [], startWeight: null, endWeight: null, delta: null },
+    prTimeline: [],
+    ...overrides,
+  }
+}
+
+describe('renderReport', () => {
+  it('returns valid HTML with doctype and charset', () => {
+    const html = renderReport(makeReport())
+    expect(html).toContain('<!DOCTYPE html>')
+    expect(html).toContain('<meta charset="utf-8">')
+  })
+
+  it('includes the period label in the title and header', () => {
+    const html = renderReport(makeReport({ periodLabel: 'Q2 2026' }))
+    expect(html).toContain('Q2 2026')
+    expect(html).toContain('<title>Lift Training Report')
+  })
+
+  it('renders summary stat cards', () => {
+    const html = renderReport(makeReport({
+      totalWorkoutDays: 15,
+      totalSets: 60,
+      totalVolume: 200000,
+      uniqueExercises: 10,
+      prCount: 5,
+    }))
+    expect(html).toContain('15')      // workout days
+    expect(html).toContain('60')      // total sets
+    expect(html).toContain('200,000') // volume formatted
+    expect(html).toContain('10')      // exercises
+    expect(html).toContain('5')       // PRs
+  })
+
+  it('renders exercise progression rows', () => {
+    const html = renderReport(makeReport({
+      exerciseProgressions: [{
+        name: 'Bench Press',
+        tags: ['chest', 'push'],
+        timeline: [
+          { date: '2026-04-01', e1RM: 250 },
+          { date: '2026-04-15', e1RM: 265 },
+        ],
+        peakE1RM: 265,
+        startE1RM: 250,
+        delta: 15,
+        totalSets: 12,
+        totalVolume: 30000,
+      }],
+    }))
+    expect(html).toContain('Bench Press')
+    expect(html).toContain('chest, push')
+    expect(html).toContain('250 → 265 lbs')
+    expect(html).toContain('+15')
+    // Should contain an SVG sparkline
+    expect(html).toContain('<svg')
+    expect(html).toContain('polyline')
+  })
+
+  it('renders PR timeline rows', () => {
+    const html = renderReport(makeReport({
+      prTimeline: [{
+        date: '2026-04-10',
+        exerciseName: 'Squat',
+        weight: 315,
+        reps: 5,
+        e1RM: 368,
+      }],
+    }))
+    expect(html).toContain('Squat')
+    expect(html).toContain('315 lbs')
+    expect(html).toContain('368 lbs')
+    expect(html).toContain('Apr 10, 2026')
+  })
+
+  it('renders tag volume table', () => {
+    const html = renderReport(makeReport({
+      tagVolume: [
+        { tag: 'legs', sets: 20, volume: 80000 },
+        { tag: 'chest', sets: 15, volume: 45000 },
+      ],
+    }))
+    expect(html).toContain('legs')
+    expect(html).toContain('chest')
+    expect(html).toContain('Volume by Muscle Group')
+  })
+
+  it('renders bodyweight section when data exists', () => {
+    const html = renderReport(makeReport({
+      bodyweight: {
+        timeline: [
+          { date: '2026-04-01', weight: 185 },
+          { date: '2026-04-30', weight: 182 },
+        ],
+        startWeight: 185,
+        endWeight: 182,
+        delta: -3,
+      },
+    }))
+    expect(html).toContain('Body Weight')
+    expect(html).toContain('185')
+    expect(html).toContain('182')
+    expect(html).toContain('-3')
+  })
+
+  it('omits bodyweight section when no data', () => {
+    const html = renderReport(makeReport())
+    expect(html).not.toContain('Body Weight')
+  })
+
+  it('includes print hint with Cmd+P instruction', () => {
+    const html = renderReport(makeReport())
+    expect(html).toContain('Cmd+P')
+    expect(html).toContain('Ctrl+P')
+  })
+
+  it('hides print hint in @media print', () => {
+    const html = renderReport(makeReport())
+    expect(html).toContain('.print-hint { display: none; }')
+  })
+
+  it('escapes HTML in exercise names', () => {
+    const html = renderReport(makeReport({
+      exerciseProgressions: [{
+        name: 'Press <script>alert(1)</script>',
+        tags: [],
+        timeline: [{ date: '2026-04-01', e1RM: 100 }],
+        peakE1RM: 100,
+        startE1RM: 100,
+        delta: 0,
+        totalSets: 1,
+        totalVolume: 100,
+      }],
+    }))
+    expect(html).not.toContain('<script>')
+    expect(html).toContain('&lt;script&gt;')
+  })
+
+  it('uses kg unit label when provided', () => {
+    const html = renderReport(makeReport({ unitLabel: 'kg' }))
+    expect(html).toContain('Volume (kg)')
+  })
+
+  it('renders weekly consistency chart and table', () => {
+    const html = renderReport(makeReport({
+      weeklyConsistency: [
+        { weekStart: '2026-04-06', daysTrained: 4, sets: 20, volume: 50000 },
+        { weekStart: '2026-04-13', daysTrained: 3, sets: 15, volume: 40000 },
+      ],
+    }))
+    expect(html).toContain('Weekly Consistency')
+    expect(html).toContain('Apr 6')
+    expect(html).toContain('Apr 13')
+  })
+})

--- a/src/lib/__tests__/trainingReport.test.ts
+++ b/src/lib/__tests__/trainingReport.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest'
+import { buildTrainingReport, type ReportInput } from '../trainingReport'
+import type { Exercise } from '../../stores/workout'
+import type { BodyweightEntry } from '../../stores/bodyweight'
+
+function makeExercise(
+  name: string,
+  tags: string[],
+  sets: { date: string; weight: number; reps: number; estimated1RM: number }[],
+): Exercise {
+  return {
+    id: `ex-${name.toLowerCase().replace(/\s+/g, '-')}`,
+    name,
+    tags,
+    sets: sets.map((s, i) => ({ id: `set-${name}-${i}`, ...s })),
+  }
+}
+
+function makeBW(date: string, weight: number): BodyweightEntry {
+  return { id: `bw-${date}`, date: `${date}T23:59:00.000Z`, weight }
+}
+
+const baseInput: ReportInput = {
+  exercises: [],
+  bodyweight: [],
+  period: 'month',
+  referenceDate: '2026-04-15',
+}
+
+describe('buildTrainingReport', () => {
+  describe('period boundaries', () => {
+    it('computes monthly period label and bounds', () => {
+      const report = buildTrainingReport({ ...baseInput, referenceDate: '2026-04-15' })
+      expect(report.periodLabel).toBe('April 2026')
+      expect(report.startDate).toBe('2026-04-01')
+      expect(report.endDate).toBe('2026-04-30')
+    })
+
+    it('computes quarterly period label and bounds', () => {
+      const report = buildTrainingReport({ ...baseInput, period: 'quarter', referenceDate: '2026-05-20' })
+      expect(report.periodLabel).toBe('Q2 2026')
+      expect(report.startDate).toBe('2026-04-01')
+      expect(report.endDate).toBe('2026-06-30')
+    })
+
+    it('computes yearly period label and bounds', () => {
+      const report = buildTrainingReport({ ...baseInput, period: 'year', referenceDate: '2026-08-01' })
+      expect(report.periodLabel).toBe('2026')
+      expect(report.startDate).toBe('2026-01-01')
+      expect(report.endDate).toBe('2026-12-31')
+    })
+
+    it('handles Q1 correctly', () => {
+      const report = buildTrainingReport({ ...baseInput, period: 'quarter', referenceDate: '2026-02-10' })
+      expect(report.periodLabel).toBe('Q1 2026')
+      expect(report.startDate).toBe('2026-01-01')
+      expect(report.endDate).toBe('2026-03-31')
+    })
+
+    it('handles Q4 correctly', () => {
+      const report = buildTrainingReport({ ...baseInput, period: 'quarter', referenceDate: '2026-12-01' })
+      expect(report.periodLabel).toBe('Q4 2026')
+      expect(report.startDate).toBe('2026-10-01')
+      expect(report.endDate).toBe('2026-12-31')
+    })
+  })
+
+  describe('summary stats', () => {
+    it('counts workout days, sets, volume, and exercises', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+          { date: '2026-04-05T10:05:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+          { date: '2026-04-07T10:00:00.000Z', weight: 230, reps: 3, estimated1RM: 253 },
+        ]),
+        makeExercise('Squat', ['legs'], [
+          { date: '2026-04-05T11:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.totalWorkoutDays).toBe(2) // Apr 5 and Apr 7
+      expect(report.totalSets).toBe(4)
+      expect(report.uniqueExercises).toBe(2)
+      // Volume: 225*5 + 225*5 + 230*3 + 315*5 = 1125+1125+690+1575 = 4515
+      expect(report.totalVolume).toBe(4515)
+    })
+
+    it('excludes sets outside the period', () => {
+      const exercises = [
+        makeExercise('Deadlift', ['back'], [
+          { date: '2026-03-31T10:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 }, // March
+          { date: '2026-04-01T10:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 }, // April
+          { date: '2026-05-01T10:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 }, // May
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.totalSets).toBe(1) // Only April set
+    })
+
+    it('returns zeros for empty data', () => {
+      const report = buildTrainingReport(baseInput)
+      expect(report.totalWorkoutDays).toBe(0)
+      expect(report.totalSets).toBe(0)
+      expect(report.totalVolume).toBe(0)
+      expect(report.uniqueExercises).toBe(0)
+      expect(report.prCount).toBe(0)
+    })
+  })
+
+  describe('exercise progressions', () => {
+    it('computes e1RM timeline with best per day', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          { date: '2026-04-01T10:00:00.000Z', weight: 200, reps: 5, estimated1RM: 233 },
+          { date: '2026-04-01T10:05:00.000Z', weight: 225, reps: 3, estimated1RM: 248 }, // better e1RM same day
+          { date: '2026-04-08T10:00:00.000Z', weight: 230, reps: 5, estimated1RM: 268 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.exerciseProgressions).toHaveLength(1)
+
+      const bench = report.exerciseProgressions[0]
+      expect(bench.name).toBe('Bench Press')
+      expect(bench.timeline).toHaveLength(2) // 2 days
+      expect(bench.timeline[0].e1RM).toBe(248) // best of day 1
+      expect(bench.timeline[1].e1RM).toBe(268) // day 2
+      expect(bench.startE1RM).toBe(248)
+      expect(bench.peakE1RM).toBe(268)
+      expect(bench.delta).toBe(20)
+    })
+
+    it('sorts exercises by total volume descending', () => {
+      const exercises = [
+        makeExercise('Curls', ['arms'], [
+          { date: '2026-04-01T10:00:00.000Z', weight: 30, reps: 10, estimated1RM: 40 },
+        ]),
+        makeExercise('Squat', ['legs'], [
+          { date: '2026-04-01T10:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.exerciseProgressions[0].name).toBe('Squat')
+      expect(report.exerciseProgressions[1].name).toBe('Curls')
+    })
+  })
+
+  describe('PR detection', () => {
+    it('detects PRs when e1RM exceeds prior best', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          // Prior sets (before April)
+          { date: '2026-03-15T10:00:00.000Z', weight: 200, reps: 5, estimated1RM: 233 },
+          // Period sets
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.prCount).toBe(1)
+      expect(report.prTimeline).toHaveLength(1)
+      expect(report.prTimeline[0].exerciseName).toBe('Bench Press')
+      expect(report.prTimeline[0].e1RM).toBe(253)
+    })
+
+    it('does not flag a PR when e1RM is below prior best', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          { date: '2026-03-15T10:00:00.000Z', weight: 250, reps: 5, estimated1RM: 292 },
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.prCount).toBe(0)
+      expect(report.prTimeline).toHaveLength(0)
+    })
+
+    it('tracks multiple PRs within the period', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          { date: '2026-03-15T10:00:00.000Z', weight: 200, reps: 5, estimated1RM: 233 },
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+          { date: '2026-04-15T10:00:00.000Z', weight: 240, reps: 5, estimated1RM: 280 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.prCount).toBe(2)
+      expect(report.prTimeline).toHaveLength(2)
+    })
+  })
+
+  describe('tag volume', () => {
+    it('aggregates volume by tag', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest', 'push'], [
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+        ]),
+        makeExercise('OHP', ['shoulders', 'push'], [
+          { date: '2026-04-05T10:00:00.000Z', weight: 135, reps: 8, estimated1RM: 171 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      const pushTag = report.tagVolume.find(t => t.tag === 'push')
+      expect(pushTag).toBeDefined()
+      expect(pushTag!.sets).toBe(2) // 1 bench + 1 OHP
+      // Volume: 225*5 + 135*8 = 1125 + 1080 = 2205
+      expect(pushTag!.volume).toBe(2205)
+    })
+
+    it('sorts tags by sets descending', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+        ]),
+        makeExercise('Squat', ['legs'], [
+          { date: '2026-04-05T10:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 },
+          { date: '2026-04-06T10:00:00.000Z', weight: 315, reps: 5, estimated1RM: 368 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      expect(report.tagVolume[0].tag).toBe('legs')
+      expect(report.tagVolume[1].tag).toBe('chest')
+    })
+  })
+
+  describe('weekly consistency', () => {
+    it('groups sets into weeks and counts training days', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          // Week of Apr 6 (Mon)
+          { date: '2026-04-06T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+          { date: '2026-04-08T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+          // Week of Apr 13 (Mon)
+          { date: '2026-04-14T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+        ]),
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, exercises })
+      // Should have multiple weeks filling the month
+      expect(report.weeklyConsistency.length).toBeGreaterThanOrEqual(4)
+
+      const week1 = report.weeklyConsistency.find(w => w.weekStart === '2026-04-06')
+      expect(week1).toBeDefined()
+      expect(week1!.daysTrained).toBe(2)
+      expect(week1!.sets).toBe(2)
+
+      const week2 = report.weeklyConsistency.find(w => w.weekStart === '2026-04-13')
+      expect(week2).toBeDefined()
+      expect(week2!.daysTrained).toBe(1)
+    })
+
+    it('fills empty weeks with zeros', () => {
+      const report = buildTrainingReport(baseInput)
+      // April 2026 should have ~5 weeks
+      expect(report.weeklyConsistency.length).toBeGreaterThanOrEqual(4)
+      for (const week of report.weeklyConsistency) {
+        expect(week.daysTrained).toBe(0)
+        expect(week.sets).toBe(0)
+        expect(week.volume).toBe(0)
+      }
+    })
+  })
+
+  describe('bodyweight', () => {
+    it('extracts bodyweight entries within the period', () => {
+      const bodyweight = [
+        makeBW('2026-03-30', 185), // Before period
+        makeBW('2026-04-01', 184),
+        makeBW('2026-04-15', 182),
+        makeBW('2026-04-30', 180),
+        makeBW('2026-05-01', 179), // After period
+      ]
+
+      const report = buildTrainingReport({ ...baseInput, bodyweight })
+      expect(report.bodyweight.timeline).toHaveLength(3) // 3 in April
+      expect(report.bodyweight.startWeight).toBe(184)
+      expect(report.bodyweight.endWeight).toBe(180)
+      expect(report.bodyweight.delta).toBe(-4)
+    })
+
+    it('handles no bodyweight data', () => {
+      const report = buildTrainingReport(baseInput)
+      expect(report.bodyweight.timeline).toHaveLength(0)
+      expect(report.bodyweight.startWeight).toBeNull()
+      expect(report.bodyweight.endWeight).toBeNull()
+      expect(report.bodyweight.delta).toBeNull()
+    })
+  })
+
+  describe('unit conversion', () => {
+    it('applies toDisplayUnits to volume and e1RM values', () => {
+      const exercises = [
+        makeExercise('Bench Press', ['chest'], [
+          { date: '2026-04-05T10:00:00.000Z', weight: 225, reps: 5, estimated1RM: 253 },
+        ]),
+      ]
+
+      const toKg = (lbs: number) => Math.round(lbs * 0.453592 * 10) / 10
+
+      const report = buildTrainingReport({
+        ...baseInput,
+        exercises,
+        toDisplayUnits: toKg,
+        unitLabel: 'kg',
+      })
+
+      expect(report.unitLabel).toBe('kg')
+      // Volume should be in kg: 225*0.453592 * 5 ≈ 510
+      expect(report.totalVolume).toBeGreaterThan(500)
+      expect(report.totalVolume).toBeLessThan(520)
+    })
+  })
+})

--- a/src/lib/reportRenderer.ts
+++ b/src/lib/reportRenderer.ts
@@ -1,0 +1,436 @@
+/**
+ * Report Renderer — generates a printable HTML report from TrainingReport data.
+ *
+ * Opens a new window with styled HTML that the user can print to PDF via
+ * the browser's native Print dialog (Cmd+P / Ctrl+P). No external dependencies.
+ *
+ * The printed output uses @media print rules for clean, professional formatting.
+ */
+
+import type { TrainingReport, ExerciseE1RMProgression, PREvent } from './trainingReport'
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US')
+}
+
+function formatVolume(n: number, unit: string): string {
+  return `${formatNumber(n)} ${unit}`
+}
+
+function formatDate(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${d}, ${y}`
+}
+
+function formatWeekLabel(mondayStr: string): string {
+  const [, m, d] = mondayStr.split('-').map(Number)
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return `${months[m - 1]} ${d}`
+}
+
+function deltaSymbol(delta: number): string {
+  if (delta > 0) return `+${delta}`
+  if (delta < 0) return `${delta}`
+  return '0'
+}
+
+// ── SVG sparkline for e1RM timeline ──────────────────────────────
+
+function sparklineSvg(
+  points: { date: string; e1RM: number }[],
+  width: number,
+  height: number,
+): string {
+  if (points.length < 2) return ''
+  const min = Math.min(...points.map(p => p.e1RM))
+  const max = Math.max(...points.map(p => p.e1RM))
+  const range = max - min || 1
+  const padding = 2
+
+  const coords = points.map((p, i) => {
+    const x = padding + (i / (points.length - 1)) * (width - 2 * padding)
+    const y = padding + (1 - (p.e1RM - min) / range) * (height - 2 * padding)
+    return { x, y }
+  })
+
+  return `<svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" style="vertical-align: middle;">
+    <polyline points="${coords.map(c => `${c.x.toFixed(1)},${c.y.toFixed(1)}`).join(' ')}" fill="none" stroke="#4A90D9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="${coords[coords.length - 1].x.toFixed(1)}" cy="${coords[coords.length - 1].y.toFixed(1)}" r="2.5" fill="#4A90D9"/>
+  </svg>`
+}
+
+// ── Weekly bar chart ─────────────────────────────────────────────
+
+function weeklyBarsSvg(
+  weeks: { weekStart: string; daysTrained: number }[],
+  maxDays: number,
+  width: number,
+  height: number,
+): string {
+  if (weeks.length === 0) return ''
+  const barWidth = Math.min(24, (width - 20) / weeks.length - 4)
+  const barGap = 4
+  const totalBarWidth = weeks.length * (barWidth + barGap) - barGap
+  const startX = (width - totalBarWidth) / 2
+  const maxH = height - 20
+
+  const bars = weeks.map((w, i) => {
+    const x = startX + i * (barWidth + barGap)
+    const h = maxDays > 0 ? (w.daysTrained / maxDays) * maxH : 0
+    const y = height - 14 - h
+    const fill = w.daysTrained > 0 ? '#4A90D9' : '#E5E7EB'
+    return `<rect x="${x.toFixed(1)}" y="${y.toFixed(1)}" width="${barWidth}" height="${h.toFixed(1)}" rx="2" fill="${fill}"/>
+      <text x="${(x + barWidth / 2).toFixed(1)}" y="${height - 2}" text-anchor="middle" font-size="7" fill="#9CA3AF">${w.daysTrained}</text>`
+  }).join('\n')
+
+  return `<svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}">
+    ${bars}
+  </svg>`
+}
+
+// ── Exercise table section ───────────────────────────────────────
+
+function exerciseRow(ex: ExerciseE1RMProgression, unit: string): string {
+  const deltaClass = ex.delta > 0 ? 'positive' : ex.delta < 0 ? 'negative' : ''
+  return `<tr>
+    <td class="exercise-name">
+      ${escapeHtml(ex.name)}
+      <span class="exercise-tags">${ex.tags.map(t => escapeHtml(t)).join(', ')}</span>
+    </td>
+    <td class="num">${ex.totalSets}</td>
+    <td class="num">${formatVolume(ex.totalVolume, unit)}</td>
+    <td class="num">${ex.startE1RM} → ${ex.peakE1RM} ${unit}</td>
+    <td class="num ${deltaClass}">${deltaSymbol(ex.delta)}</td>
+    <td class="sparkline">${sparklineSvg(ex.timeline, 100, 28)}</td>
+  </tr>`
+}
+
+// ── PR timeline section ──────────────────────────────────────────
+
+function prRow(pr: PREvent, unit: string): string {
+  return `<tr>
+    <td>${formatDate(pr.date)}</td>
+    <td>${escapeHtml(pr.exerciseName)}</td>
+    <td class="num">${pr.weight} ${unit} × ${pr.reps}</td>
+    <td class="num">${pr.e1RM} ${unit}</td>
+  </tr>`
+}
+
+// ── Main render function ─────────────────────────────────────────
+
+export function renderReport(report: TrainingReport): string {
+  const u = report.unitLabel
+  const maxConsistencyDays = Math.max(...report.weeklyConsistency.map(w => w.daysTrained), 7)
+
+  const exerciseRows = report.exerciseProgressions
+    .slice(0, 20) // Cap at top 20 exercises by volume
+    .map(ex => exerciseRow(ex, u))
+    .join('\n')
+
+  const prRows = report.prTimeline
+    .map(pr => prRow(pr, u))
+    .join('\n')
+
+  const tagRows = report.tagVolume
+    .map(t => `<tr><td>${escapeHtml(t.tag)}</td><td class="num">${t.sets}</td><td class="num">${formatVolume(t.volume, u)}</td></tr>`)
+    .join('\n')
+
+  const bwSection = report.bodyweight.timeline.length > 0
+    ? `<section class="report-section">
+        <h2>Body Weight</h2>
+        <div class="stat-row">
+          <div class="stat"><span class="stat-label">Start</span><span class="stat-value">${report.bodyweight.startWeight} ${u}</span></div>
+          <div class="stat"><span class="stat-label">End</span><span class="stat-value">${report.bodyweight.endWeight} ${u}</span></div>
+          <div class="stat"><span class="stat-label">Change</span><span class="stat-value ${(report.bodyweight.delta ?? 0) > 0 ? 'positive' : (report.bodyweight.delta ?? 0) < 0 ? 'negative' : ''}">${deltaSymbol(report.bodyweight.delta ?? 0)} ${u}</span></div>
+        </div>
+      </section>`
+    : ''
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lift Training Report — ${escapeHtml(report.periodLabel)}</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    color: #1a1a1a;
+    background: #fff;
+    padding: 40px;
+    max-width: 900px;
+    margin: 0 auto;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  .report-header {
+    text-align: center;
+    margin-bottom: 32px;
+    padding-bottom: 16px;
+    border-bottom: 2px solid #1a1a1a;
+  }
+  .report-header h1 {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+    margin-bottom: 4px;
+  }
+  .report-header .period {
+    font-size: 16px;
+    color: #666;
+    font-weight: 400;
+  }
+  .report-header .date-range {
+    font-size: 11px;
+    color: #999;
+    margin-top: 2px;
+  }
+  .summary-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 16px;
+    margin-bottom: 32px;
+  }
+  .summary-card {
+    text-align: center;
+    padding: 16px 8px;
+    background: #f9fafb;
+    border-radius: 8px;
+    border: 1px solid #e5e7eb;
+  }
+  .summary-card .card-value {
+    font-size: 28px;
+    font-weight: 700;
+    color: #1a1a1a;
+    display: block;
+  }
+  .summary-card .card-label {
+    font-size: 11px;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-top: 4px;
+    display: block;
+  }
+  .report-section {
+    margin-bottom: 28px;
+    page-break-inside: avoid;
+  }
+  .report-section h2 {
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #e5e7eb;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #444;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  th {
+    text-align: left;
+    font-weight: 600;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #888;
+    padding: 6px 8px;
+    border-bottom: 1px solid #e5e7eb;
+  }
+  th.num, td.num { text-align: right; }
+  td {
+    padding: 8px;
+    border-bottom: 1px solid #f3f4f6;
+    vertical-align: middle;
+  }
+  .exercise-name {
+    font-weight: 500;
+  }
+  .exercise-tags {
+    display: block;
+    font-size: 10px;
+    color: #999;
+    font-weight: 400;
+  }
+  .sparkline { text-align: center; }
+  .positive { color: #16a34a; }
+  .negative { color: #dc2626; }
+  .stat-row {
+    display: flex;
+    gap: 24px;
+    margin-bottom: 12px;
+  }
+  .stat {
+    display: flex;
+    flex-direction: column;
+  }
+  .stat-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #888;
+  }
+  .stat-value {
+    font-size: 16px;
+    font-weight: 600;
+  }
+  .consistency-chart {
+    text-align: center;
+    margin: 12px 0;
+  }
+  .footer {
+    margin-top: 32px;
+    padding-top: 12px;
+    border-top: 1px solid #e5e7eb;
+    text-align: center;
+    font-size: 10px;
+    color: #bbb;
+  }
+  .print-hint {
+    text-align: center;
+    margin-bottom: 24px;
+    padding: 12px;
+    background: #eff6ff;
+    border-radius: 8px;
+    font-size: 12px;
+    color: #3b82f6;
+  }
+  @media print {
+    body { padding: 20px; }
+    .print-hint { display: none; }
+    .summary-card { border: 1px solid #ddd; }
+    .report-section { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+  <div class="print-hint">
+    Press <strong>Cmd+P</strong> (Mac) or <strong>Ctrl+P</strong> (Windows) to save as PDF
+  </div>
+
+  <div class="report-header">
+    <h1>Training Report</h1>
+    <div class="period">${escapeHtml(report.periodLabel)}</div>
+    <div class="date-range">${formatDate(report.startDate)} – ${formatDate(report.endDate)}</div>
+  </div>
+
+  <div class="summary-grid">
+    <div class="summary-card">
+      <span class="card-value">${report.totalWorkoutDays}</span>
+      <span class="card-label">Workout Days</span>
+    </div>
+    <div class="summary-card">
+      <span class="card-value">${formatNumber(report.totalSets)}</span>
+      <span class="card-label">Total Sets</span>
+    </div>
+    <div class="summary-card">
+      <span class="card-value">${formatNumber(report.totalVolume)}</span>
+      <span class="card-label">Volume (${escapeHtml(u)})</span>
+    </div>
+    <div class="summary-card">
+      <span class="card-value">${report.uniqueExercises}</span>
+      <span class="card-label">Exercises</span>
+    </div>
+    <div class="summary-card">
+      <span class="card-value">${report.prCount}</span>
+      <span class="card-label">PRs</span>
+    </div>
+  </div>
+
+  ${report.weeklyConsistency.length > 0 ? `
+  <section class="report-section">
+    <h2>Weekly Consistency</h2>
+    <div class="consistency-chart">
+      ${weeklyBarsSvg(report.weeklyConsistency, maxConsistencyDays, Math.min(report.weeklyConsistency.length * 28 + 20, 800), 80)}
+    </div>
+    <table>
+      <thead><tr>
+        <th>Week of</th>
+        <th class="num">Days</th>
+        <th class="num">Sets</th>
+        <th class="num">Volume</th>
+      </tr></thead>
+      <tbody>
+        ${report.weeklyConsistency.map(w => `<tr>
+          <td>${formatWeekLabel(w.weekStart)}</td>
+          <td class="num">${w.daysTrained}</td>
+          <td class="num">${w.sets}</td>
+          <td class="num">${formatVolume(w.volume, u)}</td>
+        </tr>`).join('\n')}
+      </tbody>
+    </table>
+  </section>` : ''}
+
+  ${report.tagVolume.length > 0 ? `
+  <section class="report-section">
+    <h2>Volume by Muscle Group</h2>
+    <table>
+      <thead><tr>
+        <th>Tag</th>
+        <th class="num">Sets</th>
+        <th class="num">Volume</th>
+      </tr></thead>
+      <tbody>${tagRows}</tbody>
+    </table>
+  </section>` : ''}
+
+  ${report.exerciseProgressions.length > 0 ? `
+  <section class="report-section">
+    <h2>Exercise Progressions</h2>
+    <table>
+      <thead><tr>
+        <th>Exercise</th>
+        <th class="num">Sets</th>
+        <th class="num">Volume</th>
+        <th class="num">e1RM</th>
+        <th class="num">Δ</th>
+        <th class="sparkline">Trend</th>
+      </tr></thead>
+      <tbody>${exerciseRows}</tbody>
+    </table>
+  </section>` : ''}
+
+  ${report.prTimeline.length > 0 ? `
+  <section class="report-section">
+    <h2>PR Timeline</h2>
+    <table>
+      <thead><tr>
+        <th>Date</th>
+        <th>Exercise</th>
+        <th class="num">Set</th>
+        <th class="num">e1RM</th>
+      </tr></thead>
+      <tbody>${prRows}</tbody>
+    </table>
+  </section>` : ''}
+
+  ${bwSection}
+
+  <div class="footer">
+    Generated by Lift — ${new Date().toISOString().slice(0, 10)}
+  </div>
+</body>
+</html>`
+}
+
+/**
+ * Open the report in a new browser window for printing.
+ * Returns the window reference for testing.
+ */
+export function openReportWindow(html: string): Window | null {
+  const win = window.open('', '_blank')
+  if (!win) return null
+  win.document.write(html)
+  win.document.close()
+  return win
+}

--- a/src/lib/trainingReport.ts
+++ b/src/lib/trainingReport.ts
@@ -1,0 +1,333 @@
+/**
+ * Training Report — pure data aggregation for PDF/print reports.
+ *
+ * Computes period-level stats from workout and bodyweight data.
+ * Framework-free: no Vue, no Pinia, no DOM. Consumed by reportRenderer.ts.
+ */
+
+import type { Exercise, WorkoutSet } from '../stores/workout'
+import type { BodyweightEntry } from '../stores/bodyweight'
+import { toLocalDateKey } from './sessionSummary'
+
+// ── Types ────────────────────────────────────────────────────────
+
+export type ReportPeriod = 'month' | 'quarter' | 'year'
+
+export interface ReportInput {
+  exercises: Exercise[]
+  bodyweight: BodyweightEntry[]
+  period: ReportPeriod
+  /** Reference date — report covers the period ending on this date's period boundary. */
+  referenceDate?: string // YYYY-MM-DD, defaults to today
+  /** Convert stored lbs to display units. Defaults to identity. */
+  toDisplayUnits?: (lbs: number) => number
+  unitLabel?: string
+}
+
+export interface ExerciseE1RMProgression {
+  name: string
+  tags: string[]
+  /** Chronological e1RM entries (one per workout day, the day's best). */
+  timeline: { date: string; e1RM: number }[]
+  /** Best e1RM in the period. */
+  peakE1RM: number
+  /** e1RM at the start of the period (first entry). */
+  startE1RM: number
+  /** Change in e1RM from start to peak. */
+  delta: number
+  totalSets: number
+  totalVolume: number
+}
+
+export interface TagVolumeEntry {
+  tag: string
+  /** Total sets in the period. */
+  sets: number
+  /** Total volume (weight × reps) in the period, in display units. */
+  volume: number
+}
+
+export interface WeeklyConsistency {
+  /** ISO Monday date string. */
+  weekStart: string
+  /** Number of distinct training days in that week. */
+  daysTrained: number
+  /** Total sets that week. */
+  sets: number
+  /** Total volume that week, in display units. */
+  volume: number
+}
+
+export interface BodyweightProgression {
+  timeline: { date: string; weight: number }[]
+  startWeight: number | null
+  endWeight: number | null
+  delta: number | null
+}
+
+export interface PREvent {
+  date: string
+  exerciseName: string
+  weight: number
+  reps: number
+  e1RM: number
+}
+
+export interface TrainingReport {
+  /** Human-readable period label, e.g. "April 2026" or "Q1 2026". */
+  periodLabel: string
+  startDate: string
+  endDate: string
+  unitLabel: string
+
+  // Summary stats
+  totalWorkoutDays: number
+  totalSets: number
+  totalVolume: number
+  uniqueExercises: number
+  prCount: number
+
+  // Breakdowns
+  exerciseProgressions: ExerciseE1RMProgression[]
+  tagVolume: TagVolumeEntry[]
+  weeklyConsistency: WeeklyConsistency[]
+  bodyweight: BodyweightProgression
+  prTimeline: PREvent[]
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+function periodBounds(period: ReportPeriod, ref: string): { start: string; end: string; label: string } {
+  const [y, m] = ref.split('-').map(Number)
+  switch (period) {
+    case 'month': {
+      const start = `${y}-${String(m).padStart(2, '0')}-01`
+      const lastDay = new Date(y, m, 0).getDate()
+      const end = `${y}-${String(m).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+      const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+      return { start, end, label: `${monthNames[m - 1]} ${y}` }
+    }
+    case 'quarter': {
+      const q = Math.ceil(m / 3)
+      const startMonth = (q - 1) * 3 + 1
+      const endMonth = q * 3
+      const start = `${y}-${String(startMonth).padStart(2, '0')}-01`
+      const lastDay = new Date(y, endMonth, 0).getDate()
+      const end = `${y}-${String(endMonth).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+      return { start, end, label: `Q${q} ${y}` }
+    }
+    case 'year': {
+      return { start: `${y}-01-01`, end: `${y}-12-31`, label: `${y}` }
+    }
+  }
+}
+
+function mondayOfWeek(dateStr: string): string {
+  const [y, m, d] = dateStr.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  const dow = date.getDay()
+  const daysSinceMonday = dow === 0 ? 6 : dow - 1
+  date.setDate(date.getDate() - daysSinceMonday)
+  const yy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, '0')
+  const dd = String(date.getDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
+// ── Main ─────────────────────────────────────────────────────────
+
+export function buildTrainingReport(input: ReportInput): TrainingReport {
+  const toDisplay = input.toDisplayUnits ?? ((lb: number) => lb)
+  const unitLabel = input.unitLabel ?? 'lbs'
+
+  const today = input.referenceDate ?? new Date().toISOString().slice(0, 10)
+  const { start, end, label } = periodBounds(input.period, today)
+
+  // Filter sets within the period
+  type SetWithExercise = WorkoutSet & { exerciseName: string; exerciseTags: string[]; exerciseId: string }
+  const periodSets: SetWithExercise[] = []
+
+  for (const ex of input.exercises) {
+    for (const set of ex.sets) {
+      const dateKey = toLocalDateKey(set.date)
+      if (dateKey >= start && dateKey <= end) {
+        periodSets.push({
+          ...set,
+          exerciseName: ex.name,
+          exerciseTags: ex.tags,
+          exerciseId: ex.id,
+        })
+      }
+    }
+  }
+
+  // Summary stats
+  const workoutDays = new Set(periodSets.map(s => toLocalDateKey(s.date)))
+  const totalSets = periodSets.length
+  const totalVolume = Math.round(periodSets.reduce((sum, s) => sum + toDisplay(s.weight) * s.reps, 0))
+  const exerciseNames = new Set(periodSets.map(s => s.exerciseName))
+
+  // ── Exercise e1RM progressions ──
+  const byExercise = new Map<string, { name: string; tags: string[]; sets: SetWithExercise[] }>()
+  for (const s of periodSets) {
+    if (!byExercise.has(s.exerciseId)) {
+      byExercise.set(s.exerciseId, { name: s.exerciseName, tags: s.exerciseTags, sets: [] })
+    }
+    byExercise.get(s.exerciseId)!.sets.push(s)
+  }
+
+  // Also collect ALL sets per exercise (including before the period) for PR detection
+  const allSetsByExercise = new Map<string, WorkoutSet[]>()
+  for (const ex of input.exercises) {
+    allSetsByExercise.set(ex.id, ex.sets)
+  }
+
+  const exerciseProgressions: ExerciseE1RMProgression[] = []
+  const prTimeline: PREvent[] = []
+
+  for (const [exId, { name, tags, sets }] of byExercise) {
+    // Best e1RM per day
+    const dayBest = new Map<string, number>()
+    for (const s of sets) {
+      const dk = toLocalDateKey(s.date)
+      const current = dayBest.get(dk) ?? 0
+      if (s.estimated1RM > current) dayBest.set(dk, s.estimated1RM)
+    }
+
+    const timeline = [...dayBest.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, e1RM]) => ({ date, e1RM: Math.round(toDisplay(e1RM)) }))
+
+    if (timeline.length === 0) continue
+
+    const peakE1RM = Math.max(...timeline.map(t => t.e1RM))
+    const startE1RM = timeline[0].e1RM
+
+    const exVolume = Math.round(sets.reduce((sum, s) => sum + toDisplay(s.weight) * s.reps, 0))
+
+    exerciseProgressions.push({
+      name,
+      tags,
+      timeline,
+      peakE1RM,
+      startE1RM,
+      delta: peakE1RM - startE1RM,
+      totalSets: sets.length,
+      totalVolume: exVolume,
+    })
+
+    // PR detection: find sets in this period that beat all prior sets for this exercise
+    const allSets = allSetsByExercise.get(exId) ?? []
+    const priorSets = allSets.filter(s => toLocalDateKey(s.date) < start)
+    const priorMaxE1RM = priorSets.length > 0 ? Math.max(...priorSets.map(s => s.estimated1RM)) : 0
+
+    // Track running max within the period too
+    let runningMax = priorMaxE1RM
+    const periodSetsSorted = [...sets].sort((a, b) => toLocalDateKey(a.date).localeCompare(toLocalDateKey(b.date)))
+    for (const s of periodSetsSorted) {
+      if (s.estimated1RM > runningMax) {
+        runningMax = s.estimated1RM
+        prTimeline.push({
+          date: toLocalDateKey(s.date),
+          exerciseName: name,
+          weight: Math.round(toDisplay(s.weight)),
+          reps: s.reps,
+          e1RM: Math.round(toDisplay(s.estimated1RM)),
+        })
+      }
+    }
+  }
+
+  // Sort progressions by total volume descending
+  exerciseProgressions.sort((a, b) => b.totalVolume - a.totalVolume)
+  prTimeline.sort((a, b) => a.date.localeCompare(b.date))
+
+  // ── Tag volume breakdown ──
+  const tagMap = new Map<string, { sets: number; volume: number }>()
+  for (const s of periodSets) {
+    const vol = toDisplay(s.weight) * s.reps
+    for (const tag of s.exerciseTags) {
+      const entry = tagMap.get(tag) ?? { sets: 0, volume: 0 }
+      entry.sets++
+      entry.volume += vol
+      tagMap.set(tag, entry)
+    }
+  }
+  const tagVolume: TagVolumeEntry[] = [...tagMap.entries()]
+    .map(([tag, { sets, volume }]) => ({ tag, sets, volume: Math.round(volume) }))
+    .sort((a, b) => b.sets - a.sets)
+
+  // ── Weekly consistency ──
+  const weekMap = new Map<string, { days: Set<string>; sets: number; volume: number }>()
+  for (const s of periodSets) {
+    const dk = toLocalDateKey(s.date)
+    const wk = mondayOfWeek(dk)
+    const entry = weekMap.get(wk) ?? { days: new Set(), sets: 0, volume: 0 }
+    entry.days.add(dk)
+    entry.sets++
+    entry.volume += toDisplay(s.weight) * s.reps
+    weekMap.set(wk, entry)
+  }
+
+  // Fill in empty weeks
+  const allWeeks: string[] = []
+  const startMonday = mondayOfWeek(start)
+  const endMonday = mondayOfWeek(end)
+  let cursor = startMonday
+  while (cursor <= endMonday) {
+    allWeeks.push(cursor)
+    const [cy, cm, cd] = cursor.split('-').map(Number)
+    const d = new Date(cy, cm - 1, cd)
+    d.setDate(d.getDate() + 7)
+    cursor = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }
+
+  const weeklyConsistency: WeeklyConsistency[] = allWeeks.map(wk => {
+    const entry = weekMap.get(wk)
+    return {
+      weekStart: wk,
+      daysTrained: entry?.days.size ?? 0,
+      sets: entry?.sets ?? 0,
+      volume: Math.round(entry?.volume ?? 0),
+    }
+  })
+
+  // ── Bodyweight progression ──
+  const bwInPeriod = input.bodyweight
+    .filter(e => {
+      const dk = e.date.slice(0, 10)
+      return dk >= start && dk <= end
+    })
+    .sort((a, b) => a.date.localeCompare(b.date))
+
+  const bwTimeline = bwInPeriod.map(e => ({
+    date: e.date.slice(0, 10),
+    weight: Math.round(toDisplay(e.weight) * 10) / 10,
+  }))
+
+  const startWeight = bwTimeline.length > 0 ? bwTimeline[0].weight : null
+  const endWeight = bwTimeline.length > 0 ? bwTimeline[bwTimeline.length - 1].weight : null
+  const bwDelta = startWeight !== null && endWeight !== null ? Math.round((endWeight - startWeight) * 10) / 10 : null
+
+  return {
+    periodLabel: label,
+    startDate: start,
+    endDate: end,
+    unitLabel,
+    totalWorkoutDays: workoutDays.size,
+    totalSets,
+    totalVolume,
+    uniqueExercises: exerciseNames.size,
+    prCount: prTimeline.length,
+    exerciseProgressions,
+    tagVolume,
+    weeklyConsistency,
+    bodyweight: {
+      timeline: bwTimeline,
+      startWeight,
+      endWeight,
+      delta: bwDelta,
+    },
+    prTimeline,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a training report feature that generates a comprehensive, printable HTML report covering a selectable period (month, quarter, or year)
- Report includes: summary stats, e1RM progression sparklines, PR timeline, volume by muscle group, weekly consistency charts, and bodyweight progression
- Zero external dependencies — uses pure HTML/CSS in a new window with @media print for clean PDF output via native Print dialog

## Architecture
- `src/lib/trainingReport.ts` — pure data aggregation (framework-free)
- `src/lib/reportRenderer.ts` — HTML/SVG renderer with inline print styles
- Settings > Data > Report row with period selector (Month/Quarter/Year) + Generate button

## Test plan
- [x] 33 new unit tests covering period boundaries, stat computation, PR detection, unit conversion, HTML output, and XSS prevention
- [x] Build passes (no new bundle dependencies)
- [x] Lint passes (no new warnings)
- [ ] Manual: generate a monthly report, verify stats match app data
- [ ] Manual: print to PDF via Cmd+P, verify clean formatting
- [ ] Manual: test on iPhone Safari (print opens share sheet)

Closes #307
