### PR TITLE
fix: add manual reset to workout store for sign-out data clearance (closes 500)

### DIFF
--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -895,4 +895,38 @@ describe('workout store', () => {
       expect(result[0].sets.map(s => s.id)).toEqual(['s1', 's2', 's3'])
     })
   })
+
+  // ── $reset (#500) ─────────────────────────────────────────────
+  describe('$reset', () => {
+    it('clears all state back to initial values', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench Press', ['Push'])
+      store.addCustomTag('Accessory')
+      expect(store.exercises.length).toBeGreaterThan(0)
+      expect(store.customTags.length).toBeGreaterThan(0)
+
+      store.$reset()
+
+      expect(store.exercises).toEqual([])
+      expect(store.customTags).toEqual([])
+      expect(store.tagRecoveryDays).toEqual({})
+      expect(store.tagRecoveryExcluded).toEqual([])
+    })
+
+    it('persists cleared state to localStorage', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Squat')
+      localStorageMock.setItem.mockClear()
+
+      store.$reset()
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('workout-exercises', '[]')
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('lift-custom-tags', '[]')
+    })
+
+    it('does not throw (regression: setup stores lack auto $reset)', () => {
+      const store = useWorkoutStore()
+      expect(() => store.$reset()).not.toThrow()
+    })
+  })
 })

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -850,6 +850,24 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
   }
 
+  /**
+   * Reset all state to initial values. Pinia's $reset() only works with
+   * options-API stores; this setup store needs a manual implementation.
+   * Called by useAuth on sign-out and account deletion (#500).
+   */
+  function $reset() {
+    exercises.value = []
+    customTags.value = []
+    tagRecoveryDays.value = {}
+    tagRecoveryExcluded.value = []
+    _userId = null
+    triggerRef(exercises)
+    triggerRef(customTags)
+    triggerRef(tagRecoveryDays)
+    triggerRef(tagRecoveryExcluded)
+    _persist()
+  }
+
   function addCustomTag(name: string) {
     const trimmed = name.trim()
     if (!trimmed || customTags.value.includes(trimmed)) return
@@ -1039,6 +1057,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     setTagRecoveryExcluded,
     addCustomTag,
     removeCustomTag,
+    $reset,
     // Getters
     allTags,
     workoutDates,


### PR DESCRIPTION
Adds explicit reset method to workout store. Setup/composition API stores lack auto-generated reset. Sign-out and account deletion silently failed to clear workout data. Includes 3 regression tests on real Pinia instance. Full test suite passes (1486 tests). Build succeeds.