### PR TITLE
fix(#503): wrap Supabase fetches in try/catch for offline resilience

### DIFF
--- a/src/stores/__tests__/offlineResilience.test.ts
+++ b/src/stores/__tests__/offlineResilience.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression test for #503: Supabase fetch failures in workout and bodyweight
+ * stores must not wipe local data.
+ *
+ * Before this fix, a network failure during _fetchFromSupabase would propagate
+ * an unhandled rejection through init() → useAuth.initStores(), leaving the
+ * user staring at an empty exercise list even though localStorage had their data.
+ *
+ * These tests mount the real stores against a fake Supabase that throws on
+ * select, seeded with local data in localStorage, and verify that:
+ * 1. init() does not throw
+ * 2. Local data remains intact after the failed fetch
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// ── Fake Supabase that rejects every query ──────────────────────
+const { failingSupabase } = vi.hoisted(() => {
+  class FailingBuilder implements PromiseLike<never> {
+    select() { return this }
+    delete() { return this }
+    upsert() { return this }
+    update() { return this }
+    eq() { return this }
+    is() { return this }
+    order() { return this }
+    single() { return this }
+
+    then<TResult1 = never, TResult2 = never>(
+      _onfulfilled?: (v: never) => TResult1 | PromiseLike<TResult1>,
+      onrejected?: (r: unknown) => TResult2 | PromiseLike<TResult2>,
+    ): PromiseLike<TResult1 | TResult2> {
+      return Promise.reject(new Error('Network unreachable')).then(_onfulfilled, onrejected)
+    }
+  }
+
+  const client = {
+    from(_table: string) {
+      return new FailingBuilder()
+    },
+  }
+
+  return { failingSupabase: client }
+})
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: failingSupabase,
+  isPreviewMode: { value: false },
+}))
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },
+  syncStatus: { value: 'synced' as const },
+  _resetRateLimit: vi.fn(),
+  _resetCircuitBreaker: vi.fn(),
+}))
+
+vi.mock('../../lib/logger', () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+import { useWorkoutStore } from '../workout'
+import { useBodyweightStore } from '../bodyweight'
+import { logWarn } from '../../lib/logger'
+
+const LOCAL_EXERCISES = [
+  {
+    id: 'ex-1',
+    name: 'Bench Press',
+    tags: ['Push'],
+    sets: [{ id: 's-1', date: '2026-05-01T23:59:59.000Z', weight: 225, reps: 5, estimated1RM: 253 }],
+    updated_at: '2026-05-01T00:00:00.000Z',
+  },
+]
+
+const LOCAL_BW_ENTRIES = [
+  {
+    id: 'bw-1',
+    date: '2026-05-01T23:59:59.000Z',
+    weight: 185,
+    updated_at: '2026-05-01T00:00:00.000Z',
+  },
+]
+
+describe('offline resilience: Supabase fetch failure (#503)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('workout store', () => {
+    it('preserves local exercises when Supabase is unreachable', async () => {
+      localStorage.setItem('workout-exercises', JSON.stringify(LOCAL_EXERCISES))
+
+      const store = useWorkoutStore()
+      // init should not throw even though Supabase rejects
+      await expect(store.init('user-123')).resolves.toBeUndefined()
+
+      expect(store.exercises).toHaveLength(1)
+      expect(store.exercises[0].name).toBe('Bench Press')
+      expect(store.exercises[0].sets).toHaveLength(1)
+    })
+
+    it('logs a warning when Supabase fetch fails', async () => {
+      localStorage.setItem('workout-exercises', '[]')
+      const store = useWorkoutStore()
+      await store.init('user-123')
+
+      expect(logWarn).toHaveBeenCalledWith(
+        'Supabase fetch failed in workout store, using local data',
+        expect.objectContaining({ error: expect.stringContaining('Network unreachable') }),
+      )
+    })
+  })
+
+  describe('bodyweight store', () => {
+    it('preserves local entries when Supabase is unreachable', async () => {
+      localStorage.setItem('bodyweight-entries', JSON.stringify(LOCAL_BW_ENTRIES))
+
+      const store = useBodyweightStore()
+      // Re-seed entries since the store's load() ran before we set localStorage
+      store.entries = [...LOCAL_BW_ENTRIES]
+
+      await expect(store.init('user-123')).resolves.toBeUndefined()
+
+      expect(store.entries).toHaveLength(1)
+      expect(store.entries[0].weight).toBe(185)
+    })
+
+    it('logs a warning when Supabase fetch fails', async () => {
+      localStorage.setItem('bodyweight-entries', '[]')
+      const store = useBodyweightStore()
+
+      await store.init('user-123')
+
+      expect(logWarn).toHaveBeenCalledWith(
+        'Supabase fetch failed in bodyweight store, using local data',
+        expect.objectContaining({ error: expect.stringContaining('Network unreachable') }),
+      )
+    })
+  })
+})

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -57,12 +57,19 @@ export const useBodyweightStore = defineStore('bodyweight', {
     async _fetchFromSupabase() {
       if (!supabase || !this._userId) return
 
-      const { data } = await supabase
-        .from('bodyweight_entries')
-        .select('*')
-        .eq('user_id', this._userId)
-        .is('deleted_at', null)
-        .order('created_at')
+      let data: Record<string, unknown>[] | null
+      try {
+        const result = await supabase
+          .from('bodyweight_entries')
+          .select('*')
+          .eq('user_id', this._userId)
+          .is('deleted_at', null)
+          .order('created_at')
+        data = result.data
+      } catch (e) {
+        logWarn('Supabase fetch failed in bodyweight store, using local data', { error: String(e) })
+        return
+      }
 
       if (!data) return
 

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -207,10 +207,19 @@ export const useWorkoutStore = defineStore('workout', () => {
   async function _fetchFromSupabase() {
     if (!supabase || !_userId) return
 
-    const [{ data: remoteExData }, { data: sets }] = await Promise.all([
-      supabase.from('exercises').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at'),
-      supabase.from('sets').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at')
-    ])
+    let remoteExData: Record<string, unknown>[] | null
+    let sets: Record<string, unknown>[] | null
+    try {
+      const [exResult, setsResult] = await Promise.all([
+        supabase.from('exercises').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at'),
+        supabase.from('sets').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at')
+      ])
+      remoteExData = exResult.data
+      sets = setsResult.data
+    } catch (e) {
+      logWarn('Supabase fetch failed in workout store, using local data', { error: String(e) })
+      return
+    }
 
     if (!remoteExData) return
 


### PR DESCRIPTION
## Summary
- Wraps _fetchFromSupabase in both workout.ts and bodyweight.ts with try/catch to handle network failures gracefully
- When Supabase is unreachable (offline, auth expired, DNS failure), stores now log a warning and preserve local data instead of propagating an unhandled rejection that leaves the user with an empty exercise list
- Matches the existing pattern in preferences.init() which already handles this correctly

## Root cause
workout._fetchFromSupabase and bodyweight._fetchFromSupabase both await Supabase queries with no error handling. When the Promise rejects, the error propagates to init() then to useAuth.initStores(), which has a generic .catch(logError) that sets loading=false but never applies the local state already loaded from localStorage.

## Test plan
- [x] New offlineResilience.test.ts with a fake Supabase that rejects every query
- [x] Verifies workout store preserves local exercises on fetch failure
- [x] Verifies bodyweight store preserves local entries on fetch failure
- [x] Verifies both stores log a warning with the error message
- [x] Full test suite passes (1487 tests, 70 files)
- [x] Build succeeds

Closes #503

Generated with Claude Code
