### PR TITLE
fix(#500): add manual $reset to workout store to fix sign-out data leakage

### DIFF
--- a/src/stores/__tests__/workoutReset.test.ts
+++ b/src/stores/__tests__/workoutReset.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration test: workout store $reset works on a real Pinia instance.
+ *
+ * Regression for #500: the workout store uses the composition/setup API,
+ * which means Pinia does NOT auto-generate $reset(). Without a manual
+ * override, $reset() throws at runtime, causing sign-out to silently
+ * fail to clear workout data — a privacy/security issue.
+ *
+ * The useAuth.test.ts mocks $reset as vi.fn(), which masked this bug.
+ * This test uses a real Pinia instance to verify $reset actually clears state.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: null,
+  isPreviewMode: { value: false },
+}))
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },
+}))
+vi.mock('../../lib/durableStorage', () => ({
+  backupToIDB: vi.fn(),
+}))
+
+describe('workout store $reset (real Pinia, not mocked)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('$reset exists and is callable on the setup store', async () => {
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+    expect(typeof store.$reset).toBe('function')
+  })
+
+  it('$reset clears exercises, custom tags, and recovery settings', async () => {
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+
+    // Populate state
+    store.addExercise('Bench Press', ['Push'])
+    store.addCustomTag('Upper Body')
+    store.setTagRecoveryDays('Push', 3)
+    store.setTagRecoveryExcluded('Push', true)
+
+    expect(store.exercises.length).toBeGreaterThan(0)
+    expect(store.customTags.length).toBeGreaterThan(0)
+    expect(Object.keys(store.tagRecoveryDays).length).toBeGreaterThan(0)
+    expect(store.tagRecoveryExcluded.length).toBeGreaterThan(0)
+
+    // Reset
+    store.$reset()
+
+    expect(store.exercises).toEqual([])
+    expect(store.customTags).toEqual([])
+    expect(store.tagRecoveryDays).toEqual({})
+    expect(store.tagRecoveryExcluded).toEqual([])
+  })
+
+  it('$reset persists the cleared state to localStorage', async () => {
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+
+    store.addExercise('Squat', ['Legs'])
+    expect(JSON.parse(localStorage.getItem('workout-exercises') || '[]').length).toBeGreaterThan(0)
+
+    store.$reset()
+
+    expect(JSON.parse(localStorage.getItem('workout-exercises') || '[]')).toEqual([])
+    expect(JSON.parse(localStorage.getItem('lift-custom-tags') || '[]')).toEqual([])
+    expect(JSON.parse(localStorage.getItem('lift-tag-recovery-days') || '{}')).toEqual({})
+    expect(JSON.parse(localStorage.getItem('lift-tag-recovery-excluded') || '[]')).toEqual([])
+  })
+
+  it('$reset does not throw (unlike the default Pinia setup store $reset)', async () => {
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+
+    expect(() => store.$reset()).not.toThrow()
+  })
+})

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -1010,6 +1010,24 @@ export const useWorkoutStore = defineStore('workout', () => {
     }
   }
 
+  /**
+   * Reset all store state to defaults and clear persisted data.
+   * Required because setup/composition stores don't get auto-$reset from Pinia.
+   * Called by useAuth on sign-out and account deletion.
+   */
+  function $reset() {
+    exercises.value = []
+    customTags.value = []
+    tagRecoveryDays.value = {}
+    tagRecoveryExcluded.value = []
+    _userId = null
+    triggerRef(exercises)
+    triggerRef(customTags)
+    triggerRef(tagRecoveryDays)
+    triggerRef(tagRecoveryExcluded)
+    _persist()
+  }
+
   return {
     // State
     exercises,
@@ -1017,6 +1035,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     tagRecoveryDays,
     tagRecoveryExcluded,
     // Actions
+    $reset,
     init,
     addExercise,
     setExercisePlateCountMode,


### PR DESCRIPTION
## Summary
- Fixes sign-out data leakage caused by workout store using Pinia composition/setup API
- Adds explicit $reset() method that clears all state and persists empty state
- Adds integration test using real Pinia instance (not mocked)

## Root Cause
useAuth.resetStores() calls $reset() on all four stores during sign-out. Three stores use the options API (auto-$reset works). The workout store uses the setup API for shallowRef performance so $reset() throws at runtime. The existing test mocked $reset as vi.fn(), masking the bug.

## Test plan
- All 1487 tests pass (was 1483)
- Production build succeeds
- 4 new integration tests verify $reset on real Pinia instance

Closes #500
