### PR TITLE
fix(#503): wrap Supabase fetches in try/catch to preserve local data offline

### DIFF
--- a/src/stores/__tests__/supabaseApiError.test.ts
+++ b/src/stores/__tests__/supabaseApiError.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression test for #503 (P2): Supabase API errors (non-throwing) must not
+ * clobber local data.
+ *
+ * The Supabase JS client resolves with { data: null, error: {...} } for
+ * API-level errors (500s, RLS failures, etc.) instead of rejecting. The stores
+ * must check .error and bail out, preserving local state.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+// ── Supabase mock: resolves with error object (no throw) ────────────
+vi.mock('../../lib/supabase', () => {
+  function errorChain(): Record<string, unknown> {
+    const result = { data: null, error: { message: 'permission denied for table exercises', code: '42501' } }
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      is: () => chain,
+      order: () => chain,
+      single: () => chain,
+      then: (resolve: (val: typeof result) => void) => Promise.resolve(result).then(resolve),
+    }
+    return chain
+  }
+
+  return {
+    supabase: { from: () => errorChain() },
+    isPreviewMode: { value: false },
+  }
+})
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },
+}))
+
+vi.mock('../../lib/logger', () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+import { useWorkoutStore } from '../workout'
+import { useBodyweightStore } from '../bodyweight'
+import { logWarn } from '../../lib/logger'
+
+describe('Supabase API error resilience (#503)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('workout store preserves local data when Supabase returns API error', async () => {
+    const cachedExercises = [
+      {
+        id: 'ex-1',
+        name: 'Squat',
+        tags: ['Legs'],
+        sets: [{ id: 's-1', date: '2026-05-01T23:59:59.000Z', weight: 315, reps: 3, estimated1RM: 344 }],
+        updated_at: '2026-05-01T00:00:00.000Z',
+      },
+    ]
+    localStorageMock.setItem('workout-exercises', JSON.stringify(cachedExercises))
+
+    setActivePinia(createPinia())
+    const store = useWorkoutStore()
+    expect(store.exercises).toHaveLength(1)
+
+    await store.init('user-456')
+
+    // Local data must survive API error
+    expect(store.exercises).toHaveLength(1)
+    expect(store.exercises[0].name).toBe('Squat')
+
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Supabase fetch failed in workout store'),
+      expect.any(Object),
+    )
+  })
+
+  it('bodyweight store preserves local data when Supabase returns API error', async () => {
+    const cachedEntries = [
+      { id: 'bw-1', date: '2026-05-01T23:59:59.000Z', weight: 185, updated_at: '2026-05-01T00:00:00.000Z' },
+    ]
+    localStorageMock.setItem('bodyweight-entries', JSON.stringify(cachedEntries))
+
+    setActivePinia(createPinia())
+    const store = useBodyweightStore()
+    expect(store.entries).toHaveLength(1)
+
+    await store.init('user-456')
+
+    // Local data must survive API error
+    expect(store.entries).toHaveLength(1)
+    expect(store.entries[0].weight).toBe(185)
+
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Supabase fetch failed in bodyweight store'),
+      expect.any(Object),
+    )
+  })
+})

--- a/src/stores/__tests__/supabaseFetchResilience.test.ts
+++ b/src/stores/__tests__/supabaseFetchResilience.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Regression test for #503: Supabase fetch failures must not clobber local data.
+ *
+ * When Supabase is unreachable (offline, auth expired, DNS failure), the
+ * workout and bodyweight stores must preserve locally-cached data rather
+ * than replacing it with empty state.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+// ── Supabase mock: rejects all queries ──────────────────────────────
+vi.mock('../../lib/supabase', () => {
+  function rejectingChain(): Record<string, unknown> {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      is: () => chain,
+      order: () => chain,
+      single: () => chain,
+      then: (_resolve: unknown, reject: (err: Error) => void) => {
+        const err = new Error('Network request failed')
+        return Promise.reject(err).catch(reject || ((e: unknown) => { throw e }))
+      },
+    }
+    return chain
+  }
+
+  return {
+    supabase: { from: () => rejectingChain() },
+    isPreviewMode: { value: false },
+  }
+})
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },
+}))
+
+vi.mock('../../lib/logger', () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+import { useWorkoutStore } from '../workout'
+import { useBodyweightStore } from '../bodyweight'
+import { logWarn } from '../../lib/logger'
+
+describe('Supabase fetch resilience (#503)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('workout store preserves local exercises when Supabase fetch throws', async () => {
+    // Seed localStorage with cached workout data
+    const cachedExercises = [
+      {
+        id: 'ex-1',
+        name: 'Bench Press',
+        tags: ['Push'],
+        sets: [{ id: 's-1', date: '2026-05-01T23:59:59.000Z', weight: 185, reps: 5, estimated1RM: 216 }],
+        updated_at: '2026-05-01T00:00:00.000Z',
+      },
+    ]
+    localStorageMock.setItem('workout-exercises', JSON.stringify(cachedExercises))
+
+    // Re-create pinia so the store reads from seeded localStorage
+    setActivePinia(createPinia())
+    const store = useWorkoutStore()
+
+    // Verify local data loaded
+    expect(store.exercises).toHaveLength(1)
+    expect(store.exercises[0].name).toBe('Bench Press')
+
+    // init() calls _fetchFromSupabase() which will reject — should NOT throw
+    await store.init('user-123')
+
+    // Local data must survive
+    expect(store.exercises).toHaveLength(1)
+    expect(store.exercises[0].name).toBe('Bench Press')
+    expect(store.exercises[0].sets).toHaveLength(1)
+
+    // Warning should be logged
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Supabase fetch failed in workout store'),
+      expect.objectContaining({ error: expect.any(String) }),
+    )
+  })
+
+  it('bodyweight store preserves local entries when Supabase fetch throws', async () => {
+    // Seed localStorage with cached bodyweight data
+    const cachedEntries = [
+      { id: 'bw-1', date: '2026-05-01T23:59:59.000Z', weight: 180, updated_at: '2026-05-01T00:00:00.000Z' },
+      { id: 'bw-2', date: '2026-05-02T23:59:59.000Z', weight: 179, updated_at: '2026-05-02T00:00:00.000Z' },
+    ]
+    localStorageMock.setItem('bodyweight-entries', JSON.stringify(cachedEntries))
+
+    // Re-create pinia so the store reads from seeded localStorage
+    setActivePinia(createPinia())
+    const store = useBodyweightStore()
+
+    // Verify local data loaded
+    expect(store.entries).toHaveLength(2)
+
+    // init() calls _fetchFromSupabase() which will reject — should NOT throw
+    await store.init('user-123')
+
+    // Local data must survive
+    expect(store.entries).toHaveLength(2)
+    expect(store.entries[0].weight).toBe(180)
+    expect(store.entries[1].weight).toBe(179)
+
+    // Warning should be logged
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Supabase fetch failed in bodyweight store'),
+      expect.objectContaining({ error: expect.any(String) }),
+    )
+  })
+
+  it('workout init() does not reject (caller does not need try/catch)', async () => {
+    localStorageMock.setItem('workout-exercises', JSON.stringify([]))
+    setActivePinia(createPinia())
+    const store = useWorkoutStore()
+
+    // Must resolve, not reject — this is the critical behavioral contract
+    await expect(store.init('user-123')).resolves.toBeUndefined()
+  })
+
+  it('bodyweight init() does not reject (caller does not need try/catch)', async () => {
+    localStorageMock.setItem('bodyweight-entries', JSON.stringify([]))
+    setActivePinia(createPinia())
+    const store = useBodyweightStore()
+
+    // Must resolve, not reject
+    await expect(store.init('user-123')).resolves.toBeUndefined()
+  })
+})

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -65,6 +65,10 @@ export const useBodyweightStore = defineStore('bodyweight', {
           .eq('user_id', this._userId)
           .is('deleted_at', null)
           .order('created_at')
+        if (result.error) {
+          logWarn('Supabase fetch failed in bodyweight store — using local data', { error: String(result.error) })
+          return
+        }
         data = result.data
       } catch (err) {
         logWarn('Supabase fetch failed in bodyweight store — using local data', { error: String(err) })

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -57,12 +57,19 @@ export const useBodyweightStore = defineStore('bodyweight', {
     async _fetchFromSupabase() {
       if (!supabase || !this._userId) return
 
-      const { data } = await supabase
-        .from('bodyweight_entries')
-        .select('*')
-        .eq('user_id', this._userId)
-        .is('deleted_at', null)
-        .order('created_at')
+      let data: Record<string, unknown>[] | null
+      try {
+        const result = await supabase
+          .from('bodyweight_entries')
+          .select('*')
+          .eq('user_id', this._userId)
+          .is('deleted_at', null)
+          .order('created_at')
+        data = result.data
+      } catch (err) {
+        logWarn('Supabase fetch failed in bodyweight store — using local data', { error: String(err) })
+        return
+      }
 
       if (!data) return
 

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -207,10 +207,19 @@ export const useWorkoutStore = defineStore('workout', () => {
   async function _fetchFromSupabase() {
     if (!supabase || !_userId) return
 
-    const [{ data: remoteExData }, { data: sets }] = await Promise.all([
-      supabase.from('exercises').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at'),
-      supabase.from('sets').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at')
-    ])
+    let remoteExData: Record<string, unknown>[] | null
+    let sets: Record<string, unknown>[] | null
+    try {
+      const [exResult, setsResult] = await Promise.all([
+        supabase.from('exercises').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at'),
+        supabase.from('sets').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at')
+      ])
+      remoteExData = exResult.data
+      sets = setsResult.data
+    } catch (err) {
+      logWarn('Supabase fetch failed in workout store — using local data', { error: String(err) })
+      return
+    }
 
     if (!remoteExData) return
 

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -214,6 +214,13 @@ export const useWorkoutStore = defineStore('workout', () => {
         supabase.from('exercises').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at'),
         supabase.from('sets').select('*').eq('user_id', _userId).is('deleted_at', null).order('created_at')
       ])
+      if (exResult.error || setsResult.error) {
+        logWarn('Supabase fetch failed in workout store — using local data', {
+          exerciseError: String(exResult.error),
+          setsError: String(setsResult.error),
+        })
+        return
+      }
       remoteExData = exResult.data
       sets = setsResult.data
     } catch (err) {
@@ -221,7 +228,7 @@ export const useWorkoutStore = defineStore('workout', () => {
       return
     }
 
-    if (!remoteExData) return
+    if (!remoteExData || !sets) return
 
     // Filter out tombstoned exercises (deleted offline, not yet synced)
     const remoteIds = new Set(remoteExData.map((ex: Record<string, unknown>) => ex.id as string))


### PR DESCRIPTION
## Summary
- Wraps _fetchFromSupabase() in both workout.ts and bodyweight.ts with try/catch to handle network-level failures (offline, DNS, auth expired)
- Adds explicit .error checks on Supabase responses to handle API-level failures (500s, RLS denial)
- Fixes partial failure data corruption: if exercises fetch succeeds but sets fetch fails, tombstones were being destroyed by cleanupTombstones receiving an empty set
- Matches the resilient pattern already used in preferences.ts

Root cause: Promise.all in _fetchFromSupabase() had no error handling. When Supabase was unreachable, the rejection propagated through init() to initStores(), and the user saw empty state instead of their cached local data.

Why existing tests missed it: All store tests mock supabase as null (local-first architecture), so the fetch path was never exercised.

## Test plan
- [x] 4 new regression tests for network-level failures (throwing)
- [x] 2 new regression tests for API-level errors (non-throwing, .error object)
- [x] All 1489 tests pass
- [x] Build succeeds

Closes #503
