### PR TITLE
fix(#501): add IndexedDB backup to preferences store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1856,6 +1856,7 @@ onMounted(async () => {
     ensureLocalStorage('workout-exercises'),
     ensureLocalStorage('bodyweight-entries'),
     ensureLocalStorage('user-progression'),
+    ensureLocalStorage('user-preferences'),
   ])
   if (restored.some(r => r)) {
     // Data was restored from backup — reload stores

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { usePreferencesStore } from '../preferences'
 import { getLocalStorageMock } from '../../__tests__/helpers'
+import { backupToIDB } from '../../lib/durableStorage'
+
+vi.mock('../../lib/durableStorage', () => ({
+  backupToIDB: vi.fn(),
+}))
 
 const localStorageMock = getLocalStorageMock()
 
@@ -67,6 +72,15 @@ describe('usePreferencesStore', () => {
       store.toggleFeature('calendar')
       const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
       expect(stored.features.calendar).toBe(false)
+    })
+
+    it('backs up to IndexedDB on every persist (regression: #501)', () => {
+      vi.mocked(backupToIDB).mockClear()
+      store.toggleFeature('calendar')
+      expect(backupToIDB).toHaveBeenCalledWith(
+        'user-preferences',
+        expect.stringContaining('"calendar":false'),
+      )
     })
 
     it('loads persisted state from localStorage on init', async () => {

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { supabase } from '../lib/supabase'
 import { syncQueue } from '../lib/syncQueue'
+import { backupToIDB } from '../lib/durableStorage'
 import { logError } from '../lib/logger'
 
 const STORAGE_KEY = 'user-preferences'
@@ -80,14 +81,13 @@ export const usePreferencesStore = defineStore('preferences', {
 
   actions: {
     _persist() {
+      const data = JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience })
       try {
-        localStorage.setItem(
-          STORAGE_KEY,
-          JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
-        )
+        localStorage.setItem(STORAGE_KEY, data)
       } catch (e) {
         logError(e, { source: 'preferences._persist' })
       }
+      backupToIDB(STORAGE_KEY, data)
       if (supabase && this._userId) {
         const features = { ...this.features }
         const weightGoal = this.weightGoal


### PR DESCRIPTION
## Summary

- Add backupToIDB() call in preferences store _persist() method, matching the pattern used by workout, bodyweight, and progression stores
- Add ensureLocalStorage('user-preferences') to App.vue startup restore sequence so preferences are recovered from IndexedDB when localStorage is cleared
- Add regression test verifying backupToIDB is called on persist

## Motivation

The preferences store was the only store missing the IndexedDB durable backup. When localStorage is cleared (incognito expiry, storage pressure eviction, iOS WebKit quota), feature flags, weight goals, and experience settings were lost and fell back to defaults — inconsistent with the resilience contract of the other three stores.

## Root Cause Analysis

- **Root cause:** preferences.ts was written before the IDB backup pattern was established in the other stores, and was never retrofitted
- **Why tests didn't catch it:** No test asserted the IDB backup contract for preferences
- **Prevention:** Added a regression test that will fail if the backup call is removed

## Test plan

- [x] npx vitest run — all 1484 tests pass (69 files)
- [x] npm run build — production build succeeds
- [x] New regression test: verifies backupToIDB is called with correct key and data shape
- [ ] Manual: clear localStorage in DevTools, reload app, verify preferences restore from IDB

Closes #501
