### PR TITLE
fix(#505): sync PR baseline date to Supabase via preferences store

### DIFF
--- a/src/components/__tests__/CalendarView.test.ts
+++ b/src/components/__tests__/CalendarView.test.ts
@@ -6,6 +6,11 @@ const localStorageMock = getLocalStorageMock()
 
 vi.mock('../../composables/useAnalytics', () => mockAnalytics())
 vi.mock('../../composables/useTheme', () => mockTheme())
+vi.mock('../../composables/usePRBaseline', () => ({
+  usePRBaseline: () => ({
+    prBaselineDate: { value: null },
+  })
+}))
 
 // Build reactive mock store
 interface MockSet {

--- a/src/components/__tests__/ExerciseGraph.test.ts
+++ b/src/components/__tests__/ExerciseGraph.test.ts
@@ -10,6 +10,12 @@ vi.mock('../../composables/useTheme', () => ({
   })
 }))
 
+vi.mock('../../composables/usePRBaseline', () => ({
+  usePRBaseline: () => ({
+    prBaselineDate: { value: null },
+  })
+}))
+
 function makeExercise(sets: WorkoutSet[]): Exercise {
   return { id: 'ex-1', name: 'Bench Press', tags: [], sets }
 }

--- a/src/composables/__tests__/usePRBaseline.test.ts
+++ b/src/composables/__tests__/usePRBaseline.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { nextTick } from 'vue'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { usePRBaseline } from '../usePRBaseline'
+import { usePreferencesStore } from '../../stores/preferences'
 import { getLocalStorageMock } from '../../__tests__/helpers'
 
-const localStorageMock = getLocalStorageMock()
+vi.mock('../../lib/supabase', () => ({ supabase: null }))
 
-// Import after mocks are set up (module runs side effects at import)
-const { usePRBaseline } = await import('../usePRBaseline')
+const localStorageMock = getLocalStorageMock()
 
 describe('usePRBaseline', () => {
   beforeEach(() => {
     localStorageMock.clear()
-    localStorageMock.setItem.mockClear()
-    localStorageMock.getItem.mockClear()
+    setActivePinia(createPinia())
   })
 
   it('defaults to null (legacy all-time behavior)', () => {
@@ -19,39 +19,77 @@ describe('usePRBaseline', () => {
     expect(prBaselineDate.value).toBeNull()
   })
 
-  it('setPRBaseline persists a valid ISO date to localStorage', async () => {
+  it('setPRBaseline persists a valid ISO date', () => {
     const { setPRBaseline, prBaselineDate } = usePRBaseline()
     setPRBaseline('2026-01-01')
-    await nextTick()
     expect(prBaselineDate.value).toBe('2026-01-01')
-    expect(localStorageMock.setItem).toHaveBeenCalledWith('pr-baseline-date', '2026-01-01')
+    const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+    expect(stored.prBaselineDate).toBe('2026-01-01')
   })
 
-  it('rejects malformed dates without touching state', async () => {
+  it('rejects malformed dates without touching state', () => {
     const { setPRBaseline, prBaselineDate } = usePRBaseline()
     setPRBaseline('2026-01-01')
-    await nextTick()
     setPRBaseline('not-a-date')
-    await nextTick()
     expect(prBaselineDate.value).toBe('2026-01-01')
   })
 
-  it('clearPRBaseline removes persistence and reverts to null', async () => {
+  it('clearPRBaseline reverts to null', () => {
     const { setPRBaseline, clearPRBaseline, prBaselineDate } = usePRBaseline()
     setPRBaseline('2026-01-01')
-    await nextTick()
     clearPRBaseline()
-    await nextTick()
     expect(prBaselineDate.value).toBeNull()
-    expect(localStorageMock.removeItem).toHaveBeenCalledWith('pr-baseline-date')
+    const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+    expect(stored.prBaselineDate).toBeNull()
   })
 
-  it('startNewTrainingBlock sets today', async () => {
+  it('startNewTrainingBlock sets today', () => {
     const { startNewTrainingBlock, prBaselineDate } = usePRBaseline()
     startNewTrainingBlock()
-    await nextTick()
     const today = new Date()
     const expected = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
     expect(prBaselineDate.value).toBe(expected)
+  })
+
+  it('migrates from old pr-baseline-date localStorage key on init', async () => {
+    localStorageMock.setItem('pr-baseline-date', '2026-03-15')
+    const store = usePreferencesStore()
+    await store.init('test-user')
+
+    const { prBaselineDate } = usePRBaseline()
+    expect(prBaselineDate.value).toBe('2026-03-15')
+    // Old key should be cleaned up
+    expect(localStorageMock.getItem('pr-baseline-date')).toBeNull()
+  })
+
+  it('does not migrate invalid legacy values', async () => {
+    localStorageMock.setItem('pr-baseline-date', 'garbage')
+    const store = usePreferencesStore()
+    await store.init('test-user')
+
+    const { prBaselineDate } = usePRBaseline()
+    expect(prBaselineDate.value).toBeNull()
+  })
+
+  it('loads prBaselineDate from preferences localStorage', async () => {
+    localStorageMock.setItem('user-preferences', JSON.stringify({
+      features: { workouts: true, calendar: true, weight: true },
+      prBaselineDate: '2026-04-01',
+    }))
+    const store = usePreferencesStore()
+    await store.init('test-user')
+
+    const { prBaselineDate } = usePRBaseline()
+    expect(prBaselineDate.value).toBe('2026-04-01')
+  })
+
+  it('syncs prBaselineDate in Supabase payload', () => {
+    const { setPRBaseline } = usePRBaseline()
+    setPRBaseline('2026-02-14')
+    const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+    expect(stored.prBaselineDate).toBe('2026-02-14')
+    expect(stored.features).toBeDefined()
+    expect(stored.weightGoal).toBeDefined()
+    expect(stored.experience).toBeDefined()
   })
 })

--- a/src/composables/usePRBaseline.ts
+++ b/src/composables/usePRBaseline.ts
@@ -12,67 +12,32 @@
  * awarded stays awarded. The baseline only affects:
  *   1. Future set evaluations (XP + zone detection at log time).
  *   2. Display badges computed on-the-fly (timeline, calendar, graph).
+ *
+ * Storage: prBaselineDate lives in the preferences store, which syncs to
+ * Supabase via the user_preferences JSONB column. This ensures the baseline
+ * persists across devices.
  */
 
-import { ref, watch, type Ref } from 'vue'
-
-const STORAGE_KEY = 'pr-baseline-date'
-
-function loadStored(): string | null {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return null
-    // Validate shape (YYYY-MM-DD). Reject anything else to avoid propagating bad state.
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return null
-    return raw
-  } catch {
-    return null
-  }
-}
-
-const prBaselineDate: Ref<string | null> = ref(loadStored())
-
-watch(prBaselineDate, (v) => {
-  try {
-    if (v === null) localStorage.removeItem(STORAGE_KEY)
-    else localStorage.setItem(STORAGE_KEY, v)
-  } catch {
-    /* quota / private mode — silent */
-  }
-})
-
-function todayISO(): string {
-  const d = new Date()
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
-
-/**
- * Set the PR baseline. Pass null to revert to legacy (all-time) behavior.
- * Pass a YYYY-MM-DD string to anchor PR evaluation.
- */
-function setPRBaseline(date: string | null): void {
-  if (date === null) {
-    prBaselineDate.value = null
-    return
-  }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return
-  prBaselineDate.value = date
-}
-
-/** Anchor the PR baseline to today — typical "starting a new training block" action. */
-function startNewTrainingBlock(): void {
-  prBaselineDate.value = todayISO()
-}
-
-/** Revert to all-time PR evaluation. */
-function clearPRBaseline(): void {
-  prBaselineDate.value = null
-}
+import { computed } from 'vue'
+import { usePreferencesStore } from '../stores/preferences'
 
 export function usePRBaseline() {
+  const prefs = usePreferencesStore()
+
+  const prBaselineDate = computed(() => prefs.prBaselineDate)
+
+  function setPRBaseline(date: string | null): void {
+    prefs.setPRBaselineDate(date)
+  }
+
+  function startNewTrainingBlock(): void {
+    prefs.startNewTrainingBlock()
+  }
+
+  function clearPRBaseline(): void {
+    prefs.clearPRBaseline()
+  }
+
   return {
     prBaselineDate,
     setPRBaseline,

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -313,4 +313,88 @@ describe('usePreferencesStore', () => {
       expect(freshStore.experience.haptics).toBe(true)
     })
   })
+
+  describe('prBaselineDate', () => {
+    it('defaults to null', () => {
+      expect(store.prBaselineDate).toBeNull()
+    })
+
+    it('setPRBaselineDate sets and persists a valid date', () => {
+      store.setPRBaselineDate('2026-01-15')
+      expect(store.prBaselineDate).toBe('2026-01-15')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.prBaselineDate).toBe('2026-01-15')
+    })
+
+    it('setPRBaselineDate rejects invalid dates', () => {
+      store.setPRBaselineDate('2026-01-15')
+      store.setPRBaselineDate('bad-date')
+      expect(store.prBaselineDate).toBe('2026-01-15')
+    })
+
+    it('setPRBaselineDate accepts null to clear', () => {
+      store.setPRBaselineDate('2026-01-15')
+      store.setPRBaselineDate(null)
+      expect(store.prBaselineDate).toBeNull()
+    })
+
+    it('startNewTrainingBlock sets today', () => {
+      store.startNewTrainingBlock()
+      const d = new Date()
+      const expected = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+      expect(store.prBaselineDate).toBe(expected)
+    })
+
+    it('clearPRBaseline sets to null', () => {
+      store.setPRBaselineDate('2026-01-15')
+      store.clearPRBaseline()
+      expect(store.prBaselineDate).toBeNull()
+    })
+
+    it('init loads prBaselineDate from localStorage', async () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        prBaselineDate: '2026-04-01',
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.prBaselineDate).toBe('2026-04-01')
+    })
+
+    it('init migrates from old pr-baseline-date localStorage key', async () => {
+      localStorageMock.setItem('pr-baseline-date', '2026-03-15')
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.prBaselineDate).toBe('2026-03-15')
+      expect(localStorageMock.getItem('pr-baseline-date')).toBeNull()
+    })
+
+    it('init does not migrate invalid legacy values', async () => {
+      localStorageMock.setItem('pr-baseline-date', 'not-a-date')
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.prBaselineDate).toBeNull()
+    })
+
+    it('prBaselineDate is included in persist payload', () => {
+      store.setPRBaselineDate('2026-05-01')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.prBaselineDate).toBe('2026-05-01')
+      expect(stored.features).toBeDefined()
+      expect(stored.weightGoal).toBeDefined()
+      expect(stored.experience).toBeDefined()
+    })
+  })
 })

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -75,29 +75,30 @@ export const usePreferencesStore = defineStore('preferences', {
     features: { ...DEFAULTS } as FeatureFlags,
     weightGoal: { ...DEFAULT_WEIGHT_GOAL } as WeightGoalConfig,
     experience: { ...DEFAULT_EXPERIENCE } as ExperienceFlags,
+    prBaselineDate: null as string | null,
     _userId: null as string | null,
   }),
 
   actions: {
     _persist() {
+      const payload = {
+        features: this.features,
+        weightGoal: this.weightGoal,
+        experience: this.experience,
+        prBaselineDate: this.prBaselineDate,
+      }
       try {
-        localStorage.setItem(
-          STORAGE_KEY,
-          JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
-        )
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
       } catch (e) {
         logError(e, { source: 'preferences._persist' })
       }
       if (supabase && this._userId) {
-        const features = { ...this.features }
-        const weightGoal = this.weightGoal
-        const experience = { ...this.experience }
         const userId = this._userId
         syncQueue.enqueue(`preferences:${userId}`, () =>
           supabase!
             .from('user_preferences')
             .upsert(
-              { user_id: userId, preferences: { features, weightGoal, experience }, updated_at: new Date().toISOString() },
+              { user_id: userId, preferences: { ...payload }, updated_at: new Date().toISOString() },
               { onConflict: 'user_id' }
             )
         )
@@ -119,7 +120,22 @@ export const usePreferencesStore = defineStore('preferences', {
           if (parsed.experience) {
             this.experience = { ...DEFAULT_EXPERIENCE, ...parsed.experience }
           }
+          if (typeof parsed.prBaselineDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(parsed.prBaselineDate)) {
+            this.prBaselineDate = parsed.prBaselineDate
+          }
         } catch { /* ignore corrupt data */ }
+      }
+
+      // Migrate from old standalone localStorage key (pre-sync era)
+      if (this.prBaselineDate === null) {
+        try {
+          const legacy = localStorage.getItem('pr-baseline-date')
+          if (legacy && /^\d{4}-\d{2}-\d{2}$/.test(legacy)) {
+            this.prBaselineDate = legacy
+            localStorage.removeItem('pr-baseline-date')
+            this._persist()
+          }
+        } catch { /* ignore */ }
       }
 
       // Then try Supabase (overrides local if exists)
@@ -139,9 +155,12 @@ export const usePreferencesStore = defineStore('preferences', {
             if (prefs.experience) {
               this.experience = { ...DEFAULT_EXPERIENCE, ...(prefs.experience as Partial<ExperienceFlags>) }
             }
+            if (typeof prefs.prBaselineDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(prefs.prBaselineDate as string)) {
+              this.prBaselineDate = prefs.prBaselineDate as string
+            }
             localStorage.setItem(
               STORAGE_KEY,
-              JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
+              JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience, prBaselineDate: this.prBaselineDate }),
             )
           }
         } catch { /* table may not exist yet or no row */ }
@@ -183,6 +202,26 @@ export const usePreferencesStore = defineStore('preferences', {
       this.weightGoal.gainTarget = null
       this.weightGoal.maintainMin = null
       this.weightGoal.maintainMax = null
+      this._persist()
+    },
+
+    setPRBaselineDate(date: string | null) {
+      if (date !== null && !/^\d{4}-\d{2}-\d{2}$/.test(date)) return
+      this.prBaselineDate = date
+      this._persist()
+    },
+
+    startNewTrainingBlock() {
+      const d = new Date()
+      const y = d.getFullYear()
+      const m = String(d.getMonth() + 1).padStart(2, '0')
+      const day = String(d.getDate()).padStart(2, '0')
+      this.prBaselineDate = `${y}-${m}-${day}`
+      this._persist()
+    },
+
+    clearPRBaseline() {
+      this.prBaselineDate = null
       this._persist()
     },
   },

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -157,6 +157,8 @@ export const usePreferencesStore = defineStore('preferences', {
             }
             if (typeof prefs.prBaselineDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(prefs.prBaselineDate as string)) {
               this.prBaselineDate = prefs.prBaselineDate as string
+            } else if ('prBaselineDate' in prefs && prefs.prBaselineDate === null) {
+              this.prBaselineDate = null
             }
             localStorage.setItem(
               STORAGE_KEY,


### PR DESCRIPTION
Moves prBaselineDate from standalone localStorage (pr-baseline-date) into the preferences store, which syncs to Supabase user_preferences JSONB column. Ensures training block anchor date persists across devices. Migrates the legacy pr-baseline-date localStorage key on init. Handles null from Supabase correctly so clearing baseline on one device propagates to others. Closes #505