### PR TITLE
fix(#501): add IndexedDB backup to preferences store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1856,6 +1856,7 @@ onMounted(async () => {
     ensureLocalStorage('workout-exercises'),
     ensureLocalStorage('bodyweight-entries'),
     ensureLocalStorage('user-progression'),
+    ensureLocalStorage('user-preferences'),
   ])
   if (restored.some(r => r)) {
     // Data was restored from backup — reload stores

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { usePreferencesStore } from '../preferences'
 import { getLocalStorageMock } from '../../__tests__/helpers'
+
+vi.mock('../../lib/durableStorage', () => ({
+  backupToIDB: vi.fn(),
+}))
 
 const localStorageMock = getLocalStorageMock()
 
@@ -67,6 +71,18 @@ describe('usePreferencesStore', () => {
       store.toggleFeature('calendar')
       const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
       expect(stored.features.calendar).toBe(false)
+    })
+
+    it('backs up to IndexedDB on persist', async () => {
+      const { backupToIDB } = await import('../../lib/durableStorage')
+      vi.mocked(backupToIDB).mockClear()
+
+      store.toggleFeature('calendar')
+
+      expect(backupToIDB).toHaveBeenCalledWith(
+        'user-preferences',
+        expect.stringContaining('"calendar":false'),
+      )
     })
 
     it('loads persisted state from localStorage on init', async () => {

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -139,10 +139,9 @@ export const usePreferencesStore = defineStore('preferences', {
             if (prefs.experience) {
               this.experience = { ...DEFAULT_EXPERIENCE, ...(prefs.experience as Partial<ExperienceFlags>) }
             }
-            localStorage.setItem(
-              STORAGE_KEY,
-              JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
-            )
+            const synced = JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience })
+            localStorage.setItem(STORAGE_KEY, synced)
+            backupToIDB(STORAGE_KEY, synced)
           }
         } catch { /* table may not exist yet or no row */ }
       }

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { supabase } from '../lib/supabase'
 import { syncQueue } from '../lib/syncQueue'
 import { logError } from '../lib/logger'
+import { backupToIDB } from '../lib/durableStorage'
 
 const STORAGE_KEY = 'user-preferences'
 
@@ -80,14 +81,13 @@ export const usePreferencesStore = defineStore('preferences', {
 
   actions: {
     _persist() {
+      const data = JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience })
       try {
-        localStorage.setItem(
-          STORAGE_KEY,
-          JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience }),
-        )
+        localStorage.setItem(STORAGE_KEY, data)
       } catch (e) {
         logError(e, { source: 'preferences._persist' })
       }
+      backupToIDB(STORAGE_KEY, data)
       if (supabase && this._userId) {
         const features = { ...this.features }
         const weightGoal = this.weightGoal


### PR DESCRIPTION
## Summary
- Add `backupToIDB()` call in preferences store `_persist()` method, matching the existing pattern in workout, bodyweight, and progression stores
- Add `ensureLocalStorage('user-preferences')` to App.vue IDB restore block so preferences are recovered if localStorage is evicted
- Also backup to IDB after Supabase sync in `init()` (caught by Gemini review)
- Add regression test verifying `backupToIDB` is called on persist

Closes #501

## Root cause
`preferences._persist()` only wrote to localStorage. The other three stores all had IndexedDB backup via `backupToIDB()` as a durable fallback, but preferences was missed — an inconsistency in the store resilience contract.

## Test plan
- [x] New test: `backs up to IndexedDB on persist` — verifies `backupToIDB` is called with correct key and data
- [x] All 1499 tests pass (28 existing + 1 new)
- [x] Build succeeds
- [x] Gemini review clean (P2 finding from first pass addressed in follow-up commit)
