### PR TITLE
feat(#358): add warmup set filtering to timeline and exercise detail

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -398,6 +398,37 @@
               </div>
             </div>
 
+            <div class="settingsGroup">
+              <div class="settingsHeader">Filters</div>
+              <div class="settingsRow">
+                <div class="settingsLabelGroup">
+                  <span class="settingsLabel">Warmup threshold</span>
+                  <span class="settingsHint">Sets below {{ Math.round(prefs.filters.warmupThreshold * 100) }}% of top e1RM are warmups</span>
+                </div>
+              </div>
+              <div class="settingsRow">
+                <input
+                  type="range"
+                  class="settingsRange"
+                  min="50"
+                  max="95"
+                  step="5"
+                  :value="Math.round(prefs.filters.warmupThreshold * 100)"
+                  @input="prefs.setWarmupThreshold(Number(($event.target as HTMLInputElement).value) / 100)"
+                  :aria-label="`Warmup threshold: ${Math.round(prefs.filters.warmupThreshold * 100)}%`"
+                  aria-valuemin="50"
+                  aria-valuemax="95"
+                  :aria-valuenow="Math.round(prefs.filters.warmupThreshold * 100)"
+                />
+                <span class="settingsRangeValue">{{ Math.round(prefs.filters.warmupThreshold * 100) }}%</span>
+              </div>
+              <div class="settingsRow">
+                <span class="settingsHint">
+                  Use the "Hide warmups" toggle in the timeline or exercise detail to filter classified warmup sets from view.
+                </span>
+              </div>
+            </div>
+
             <!-- Dev tools — only on localhost/LAN -->
             <div v-if="isDev" class="settingsGroup">
               <div class="settingsHeader">Dev Tools</div>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -165,6 +165,18 @@
 
     <!-- Timeline view -->
     <template v-else-if="listView === 'timeline'">
+      <div class="wtTimelineControls">
+        <button
+          :class="['wtWarmupToggle', { wtWarmupToggleActive: hideWarmups }]"
+          @click="hideWarmups = !hideWarmups"
+          role="switch"
+          :aria-checked="hideWarmups"
+          :aria-label="hideWarmups ? 'Show warmup sets' : 'Hide warmup sets'"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18M7 12h10M10 18h4"/></svg>
+          <span>{{ hideWarmups ? 'Warmups hidden' : 'Hide warmups' }}</span>
+        </button>
+      </div>
       <div v-if="timelineSets.length === 0" class="wtEmpty">
         No sets logged yet.
       </div>
@@ -192,8 +204,8 @@
             </div>
           </div>
         </template>
-        <button v-if="timelineLimit < timelineSets.length" class="wtTimelineShowMore" @click="timelineLimit += 50">
-          Show more ({{ timelineSets.length - timelineLimit }} remaining)
+        <button v-if="timelineLimit < filteredTimelineSets.length" class="wtTimelineShowMore" @click="timelineLimit += 50">
+          Show more ({{ filteredTimelineSets.length - timelineLimit }} remaining)
         </button>
       </div>
     </template>
@@ -229,6 +241,18 @@
 
           <!-- All Sets view -->
           <template v-if="detailTab === 'sets'">
+            <div v-if="detailExercise.sets.length > 1" class="wtTimelineControls">
+              <button
+                :class="['wtWarmupToggle', { wtWarmupToggleActive: hideWarmups }]"
+                @click="hideWarmups = !hideWarmups"
+                role="switch"
+                :aria-checked="hideWarmups"
+                :aria-label="hideWarmups ? 'Show warmup sets' : 'Hide warmup sets'"
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18M7 12h10M10 18h4"/></svg>
+                <span>{{ hideWarmups ? 'Warmups hidden' : 'Hide warmups' }}</span>
+              </button>
+            </div>
             <div class="wtSetList">
               <p v-if="detailExercise.sets.length === 0" class="wtSetEmpty">No sets logged yet.</p>
               <template v-for="group in groupedSets" :key="group.key">
@@ -1060,8 +1084,19 @@ const { wasBackgrounded, startTracking: startBgTracking, stopTracking: stopBgTra
 // Screen Wake Lock — keep display on during active workouts
 import { useWakeLock } from '../composables/useWakeLock'
 import { usePreferencesStore } from '../stores/preferences'
+import { buildWarmupSetIds } from '../lib/classifyWarmupSets'
 const _prefs = usePreferencesStore()
 const wakeLockEnabled = computed(() => _prefs.experience.screenWakeLock !== false)
+
+// ── Warmup set filtering (session-only toggle, not persisted) ───
+const hideWarmups = ref(false)
+const warmupSetIds = computed(() => {
+  if (!hideWarmups.value) return new Set<string>()
+  const exercises = store.exercises.map(ex => ({
+    sets: ex.sets.map(s => ({ id: s.id, date: s.date, estimated1RM: s.estimated1RM })),
+  }))
+  return buildWarmupSetIds(exercises, _prefs.filters.warmupThreshold)
+})
 
 // Filter sets to those on/after the user-set PR baseline.
 // When no baseline is set, returns sets unchanged (legacy all-time behavior).
@@ -1253,8 +1288,14 @@ const timelinePRMap = computed((): Record<string, 'pr' | 'repPR'> => {
   return map
 })
 
+const filteredTimelineSets = computed(() => {
+  if (!hideWarmups.value) return timelineSets.value
+  const ids = warmupSetIds.value
+  return timelineSets.value.filter(e => !ids.has(e.set.id))
+})
+
 const visibleTimelineGroups = computed(() => {
-  const limited = timelineSets.value.slice(0, timelineLimit.value)
+  const limited = filteredTimelineSets.value.slice(0, timelineLimit.value)
   const groups: { key: string; label: string; sets: TimelineEntry[] }[] = []
   for (const entry of limited) {
     const k = toLocalDateKey(entry.set.date)
@@ -1709,7 +1750,11 @@ function visibleSets(exercise: Exercise): WorkoutSet[] {
 
 const groupedSets = computed(() => {
   if (!detailExercise.value) return []
-  const sets = visibleSets(detailExercise.value)
+  let sets = visibleSets(detailExercise.value)
+  if (hideWarmups.value) {
+    const ids = warmupSetIds.value
+    sets = sets.filter(s => !ids.has(s.id))
+  }
   const groups: { date: string; key: string; sets: WorkoutSet[] }[] = []
   for (const set of sets) {
     const k = toLocalDateKey(set.date)

--- a/src/index.css
+++ b/src/index.css
@@ -1788,6 +1788,36 @@ html.theme-fading .settingsSheet {
   color: var(--text-muted);
 }
 
+.settingsRange {
+  flex: 1;
+  height: 4px;
+  -webkit-appearance: none;
+  appearance: none;
+  background: var(--border);
+  border-radius: 2px;
+  outline: none;
+}
+
+.settingsRange::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  background: var(--accent);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.settingsRangeValue {
+  font-size: var(--font-subhead);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  min-width: 40px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
 .exportBtnGroup {
   display: flex;
   gap: 8px;
@@ -2275,6 +2305,39 @@ html.theme-fading .settingsSheet {
 /* ─── Exercise list ─────────────────────────────────────────────────────── */
 
 /* ─── Timeline view ─────────────────────────────────────────────────────── */
+
+.wtTimelineControls {
+  display: flex;
+  justify-content: flex-end;
+  padding: 4px 16px 0;
+}
+
+.wtWarmupToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  min-height: 32px;
+  font-size: var(--font-caption1);
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-hover);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.wtWarmupToggle:active {
+  opacity: 0.7;
+}
+
+.wtWarmupToggleActive {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
 
 .wtTimeline {
   padding: 0 16px 16px;

--- a/src/lib/classifyWarmupSets.ts
+++ b/src/lib/classifyWarmupSets.ts
@@ -1,0 +1,72 @@
+/**
+ * Warmup set classification.
+ *
+ * A set is a "warmup" if, within the same session (same date) for the same
+ * exercise, it comes before the top set (highest estimated 1RM) AND its own
+ * estimated 1RM is below `threshold × top_e1RM`. Sets at or after the top
+ * set, or above the threshold, are considered working sets.
+ */
+
+interface SetLike {
+  id: string
+  date: string
+  estimated1RM: number
+}
+
+interface ExerciseLike {
+  sets: SetLike[]
+}
+
+/** Extract the YYYY-MM-DD portion of an ISO date string for session grouping. */
+function sessionKey(date: string): string {
+  return date.slice(0, 10)
+}
+
+/**
+ * Build the set of set IDs that are warmups across the given exercises.
+ *
+ * @param exercises   exercises with their sets in the order they were logged
+ * @param threshold   e1RM ratio (0–1); sets below `threshold × session_top_e1RM`
+ *                    that occur before the top set are classified as warmups
+ */
+export function buildWarmupSetIds(
+  exercises: ExerciseLike[],
+  threshold: number,
+): Set<string> {
+  const warmupIds = new Set<string>()
+  if (threshold <= 0 || threshold > 1) return warmupIds
+
+  for (const ex of exercises) {
+    // Group set indices by session date so we can find the top set per session.
+    const sessions = new Map<string, number[]>()
+    ex.sets.forEach((set, idx) => {
+      const key = sessionKey(set.date)
+      const list = sessions.get(key)
+      if (list) list.push(idx)
+      else sessions.set(key, [idx])
+    })
+
+    for (const indices of sessions.values()) {
+      // Find the first index that achieves the session's max e1RM.
+      let topIdx = indices[0]
+      let topE1RM = ex.sets[topIdx].estimated1RM
+      for (const i of indices) {
+        if (ex.sets[i].estimated1RM > topE1RM) {
+          topE1RM = ex.sets[i].estimated1RM
+          topIdx = i
+        }
+      }
+      if (topE1RM <= 0) continue
+
+      const cutoff = topE1RM * threshold
+      for (const i of indices) {
+        if (i >= topIdx) break
+        if (ex.sets[i].estimated1RM < cutoff) {
+          warmupIds.add(ex.sets[i].id)
+        }
+      }
+    }
+  }
+
+  return warmupIds
+}

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -56,6 +56,15 @@ const DEFAULT_EXPERIENCE: ExperienceFlags = {
   restTimerNotification: true,
 }
 
+export interface FilterSettings {
+  /** e1RM ratio threshold (0–1) below which a pre-top set is classified as warmup. Default 0.75 */
+  warmupThreshold: number
+}
+
+const DEFAULT_FILTERS: FilterSettings = {
+  warmupThreshold: 0.75,
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _migrateWeightGoal(raw: any): WeightGoalConfig {
   // v1: string ('lose' | 'gain' | 'maintain')
@@ -77,6 +86,7 @@ export const usePreferencesStore = defineStore('preferences', {
     features: { ...DEFAULTS } as FeatureFlags,
     weightGoal: { ...DEFAULT_WEIGHT_GOAL } as WeightGoalConfig,
     experience: { ...DEFAULT_EXPERIENCE } as ExperienceFlags,
+    filters: { ...DEFAULT_FILTERS } as FilterSettings,
     prBaselineDate: null as string | null,
     _userId: null as string | null,
   }),
@@ -87,6 +97,7 @@ export const usePreferencesStore = defineStore('preferences', {
         features: this.features,
         weightGoal: this.weightGoal,
         experience: this.experience,
+        filters: this.filters,
         prBaselineDate: this.prBaselineDate,
       }
       const data = JSON.stringify(payload)
@@ -119,6 +130,7 @@ export const usePreferencesStore = defineStore('preferences', {
         if (parsed.features) this.features = { ...DEFAULTS, ...parsed.features }
         if (parsed.weightGoal) this.weightGoal = _migrateWeightGoal(parsed.weightGoal)
         if (parsed.experience) this.experience = { ...DEFAULT_EXPERIENCE, ...parsed.experience }
+        if (parsed.filters) this.filters = { ...DEFAULT_FILTERS, ...parsed.filters }
       } catch { /* ignore corrupt data */ }
     },
 
@@ -136,6 +148,9 @@ export const usePreferencesStore = defineStore('preferences', {
           }
           if (parsed.experience) {
             this.experience = { ...DEFAULT_EXPERIENCE, ...parsed.experience }
+          }
+          if (parsed.filters) {
+            this.filters = { ...DEFAULT_FILTERS, ...parsed.filters }
           }
           if (typeof parsed.prBaselineDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(parsed.prBaselineDate)) {
             this.prBaselineDate = parsed.prBaselineDate
@@ -172,12 +187,15 @@ export const usePreferencesStore = defineStore('preferences', {
             if (prefs.experience) {
               this.experience = { ...DEFAULT_EXPERIENCE, ...(prefs.experience as Partial<ExperienceFlags>) }
             }
+            if (prefs.filters) {
+              this.filters = { ...DEFAULT_FILTERS, ...(prefs.filters as Partial<FilterSettings>) }
+            }
             if (typeof prefs.prBaselineDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(prefs.prBaselineDate as string)) {
               this.prBaselineDate = prefs.prBaselineDate as string
             } else if ('prBaselineDate' in prefs && prefs.prBaselineDate === null) {
               this.prBaselineDate = null
             }
-            const synced = JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience, prBaselineDate: this.prBaselineDate })
+            const synced = JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience, filters: this.filters, prBaselineDate: this.prBaselineDate })
             localStorage.setItem(STORAGE_KEY, synced)
             backupToIDB(STORAGE_KEY, synced)
           }
@@ -194,6 +212,11 @@ export const usePreferencesStore = defineStore('preferences', {
 
     setExperienceFlag<K extends keyof ExperienceFlags>(key: K, value: ExperienceFlags[K]) {
       this.experience[key] = value
+      this._persist()
+    },
+
+    setWarmupThreshold(threshold: number) {
+      this.filters.warmupThreshold = Math.max(0.5, Math.min(0.95, threshold))
       this._persist()
     },
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-358](https://github.com/aschung212/Lift/issues/358)



## Changes




## Commits
- [`8d5c5d3`](https://github.com/aschung212/Lift/commit/8d5c5d3) feat(#358): add warmup set filtering to timeline and exercise detail

## Test Results
- Before: 1574 passing
- After: 1574 passing (0 delta)

---
_Automated by overnight pipeline — Sat May  9 00:17:28 PDT 2026_