### PR TITLE
a11y(#551): add skip-to-content link for keyboard/screen reader navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@
 
     <!-- Authenticated app -->
     <template v-else>
+      <a href="#main-content" class="srOnly srOnlyFocusable">Skip to content</a>
       <main class="appContainer">
         <div v-if="isPreviewDeploy" class="previewBanner" role="status">
           <template v-if="isPreviewMode">
@@ -78,7 +79,7 @@
             </button>
           </div>
         </div>
-        <div ref="tabContentEl" class="tabContent">
+        <div id="main-content" ref="tabContentEl" class="tabContent" tabindex="-1">
           <KeepAlive>
             <WorkoutTracker v-if="activeTab === 'workouts'" ref="workoutTrackerRef" />
             <CalendarView v-else-if="activeTab === 'calendar'" />

--- a/src/index.css
+++ b/src/index.css
@@ -765,6 +765,28 @@ button, [role="tab"], [role="switch"], a {
   border: 0;
 }
 
+.srOnly.srOnlyFocusable:focus {
+  position: fixed;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  width: auto;
+  height: auto;
+  padding: 12px 24px;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: nowrap;
+  background: var(--bg-primary);
+  color: var(--accent);
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
 /* ─── App shell ─────────────────────────────────────────────────────────── */
 
 #app {

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -279,6 +279,35 @@ describe('CSS regression tests', () => {
       expect(lines.some(l => l.startsWith('clip: rect(0, 0, 0, 0)'))).toBe(true)
       expect(lines.some(l => l.startsWith('overflow: hidden'))).toBe(true)
     })
+
+    it('.srOnlyFocusable becomes visible on focus with proper styling', () => {
+      const lines = getRuleLines('.srOnly.srOnlyFocusable:focus')
+      expect(lines.length).toBeGreaterThan(0)
+      expect(lines.some(l => l.startsWith('position: fixed'))).toBe(true)
+      expect(lines.some(l => l.startsWith('clip: auto'))).toBe(true)
+      expect(lines.some(l => l.startsWith('overflow: visible'))).toBe(true)
+      expect(lines.some(l => l.startsWith('z-index: 10000'))).toBe(true)
+      expect(lines.some(l => l.startsWith('width: auto'))).toBe(true)
+      expect(lines.some(l => l.startsWith('height: auto'))).toBe(true)
+    })
+  })
+
+  describe('WCAG 2.4.1 skip-to-content (LIFT-551)', () => {
+    const appVue = readFileSync(resolve(__dirname, '../../App.vue'), 'utf-8')
+
+    it('App.vue has a skip-to-content link targeting #main-content', () => {
+      expect(appVue).toContain('href="#main-content"')
+      expect(appVue).toContain('Skip to content')
+    })
+
+    it('App.vue has a main-content target element with tabindex=-1', () => {
+      expect(appVue).toContain('id="main-content"')
+      expect(appVue).toMatch(/id="main-content"[^>]*tabindex="-1"/)
+    })
+
+    it('skip link uses srOnly srOnlyFocusable classes', () => {
+      expect(appVue).toMatch(/class="srOnly srOnlyFocusable"[^>]*>Skip to content</)
+    })
   })
 
   describe('spacing scale compliance (4/8/12/16/24/32)', () => {


### PR DESCRIPTION
## Summary
**Issue:** [#551](https://github.com/aschung212/Lift/issues/551)

Adds a WCAG 2.4.1-compliant skip-to-content link for keyboard and screen reader users. The link is visually hidden by default, appears as a styled pill on Tab focus, and transfers focus to \`#main-content\`.

## Changes
- \`src/App.vue\` — adds skip link, \`#main-content\` landmark
- \`src/index.css\` — \`.srOnlyFocusable\` styles
- \`src/lib/__tests__/cssRegression.test.ts\` — regression tests

## Note on origin
Same bug as #547's twin recovery PR: Claude in run 6 wrote \`ISSUE_DONE:551:...\` (number-only, wrong separator), the iteration branch never got renamed, and the empty \`enhance/run6-2026-05-11\` was what \`gh pr create\` saw. Actual work landed here on \`enhance/LIFT-551-2026-05-11\`.

CI may fail on the \`classifyWarmupSets\` test until one of #554/#555/#556 merges.

---
_Manually opened by Claude on 2026-05-12 to recover stranded work._