### PR TITLE
feat(#434): add exercise archival

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1320,9 +1320,13 @@ const activeTagFilters = ref<string[]>([])
  * back off without clearing the search first.
  */
 const filteredTags = computed<string[]>(() => {
+  // Only surface tags that exist on at least one active (non-archived)
+  // exercise. Otherwise tapping a chip filters to an empty list because the
+  // archived section is hidden whenever a filter is active.
+  const activeTags = store.allTags.filter(t => (tagCounts.value[t] || 0) > 0)
   const q = searchQuery.value.trim().toLowerCase()
-  if (!q) return store.allTags
-  return store.allTags.filter(t =>
+  if (!q) return activeTags
+  return activeTags.filter(t =>
     t.toLowerCase().includes(q) || activeTagFilters.value.includes(t)
   )
 })
@@ -1427,10 +1431,15 @@ const weeklyGoalInfo = computed(() => {
   return computeWeeklyGoal(store.exercises, progressionStore.weeklyTarget)
 })
 
-/** Count of exercises carrying each tag — powers the "Push 23" suffix on tag chips. */
+/**
+ * Count of exercises carrying each tag — powers the "Push 23" suffix on tag
+ * chips. Counts only active (non-archived) exercises so that the chip count
+ * matches what the tag filter will actually show. Tags that exist solely on
+ * archived exercises are filtered out by `filteredTags` below.
+ */
 const tagCounts = computed<Record<string, number>>(() => {
   const map: Record<string, number> = {}
-  for (const e of store.exercises) {
+  for (const e of store.activeExercises) {
     for (const t of e.tags || []) {
       map[t] = (map[t] || 0) + 1
     }

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -94,11 +94,14 @@
     </p>
 
     <template v-else-if="listView === 'exercises'">
-    <p v-if="filteredExercises.length === 0" class="wtEmpty">
+    <p v-if="filteredExercises.length === 0 && !isFilteringActive && store.archivedExercises.length > 0" class="wtEmpty">
+      All your exercises are archived. Expand "Archived" below to bring one back, or tap "+ New Exercise".
+    </p>
+    <p v-else-if="filteredExercises.length === 0" class="wtEmpty">
       No exercises match your search.
     </p>
 
-    <ul v-else class="wtExerciseList" ref="exerciseListEl">
+    <ul v-if="filteredExercises.length > 0" class="wtExerciseList" ref="exerciseListEl">
       <li
         v-for="(exercise, index) in filteredExercises"
         :key="exercise.id"
@@ -161,6 +164,41 @@
         </div>
       </li>
     </ul>
+
+    <!-- Archived exercises disclosure -->
+    <div v-if="store.archivedExercises.length > 0 && !isFilteringActive" class="wtArchivedSection">
+      <button
+        class="wtArchivedToggle"
+        :aria-expanded="archivedOpen"
+        :aria-controls="archivedListId"
+        @click="archivedOpen = !archivedOpen"
+      >
+        <span class="wtArchivedToggleIcon" :class="{ expanded: archivedOpen }" aria-hidden="true">›</span>
+        <span class="wtArchivedToggleLabel">Archived</span>
+        <span class="wtArchivedToggleCount">{{ store.archivedExercises.length }}</span>
+      </button>
+      <ul v-if="archivedOpen" :id="archivedListId" class="wtArchivedList">
+        <li
+          v-for="ex in store.archivedExercises"
+          :key="ex.id"
+          class="wtArchivedItem"
+        >
+          <button
+            class="wtArchivedRow"
+            @click="openDetailModal(ex.id)"
+            :aria-label="`View ${ex.name} (archived)`"
+          >
+            <span class="wtArchivedName">{{ ex.name }}</span>
+            <span class="wtArchivedMeta">{{ ex.sets.length }} {{ ex.sets.length === 1 ? 'set' : 'sets' }}</span>
+          </button>
+          <button
+            class="wtArchivedActionBtn"
+            @click="unarchiveExerciseFromList(ex.id)"
+            :aria-label="`Unarchive ${ex.name}`"
+          >Unarchive</button>
+        </li>
+      </ul>
+    </div>
     </template>
 
     <!-- Timeline view -->
@@ -900,6 +938,17 @@
           <button class="repMaxBtn repMaxBtnClose" @click="editTarget = null">Cancel</button>
         </div>
         <button
+          v-if="editTargetIsArchived"
+          class="wtEditArchiveBtn"
+          @click="handleUnarchiveFromEdit"
+        >Unarchive Exercise</button>
+        <button
+          v-else
+          class="wtEditArchiveBtn"
+          @click="handleArchiveFromEdit"
+        >Archive Exercise</button>
+        <p class="wtEditArchiveHint">Hides this exercise from the main list — sets and PRs are preserved.</p>
+        <button
           v-if="!confirmDeleteExercise"
           class="wtEditDeleteBtn"
           @click="confirmDeleteExercise = true"
@@ -923,7 +972,7 @@
         <h2 id="timeline-picker-title">Choose Exercise</h2>
         <div class="wtExPickerList">
           <button
-            v-for="ex in store.exercises"
+            v-for="ex in store.activeExercises"
             :key="ex.id"
             class="wtExPickerRow"
             @click="pickExerciseForLog(ex.id)"
@@ -1297,7 +1346,7 @@ function clearSearchAndTags() {
 }
 
 const filteredExercises = computed(() => {
-  let result = store.exercises
+  let result = store.activeExercises
   // Text search — check both name and tags so "Push" matches tag-filtered rows.
   const q = searchQuery.value.trim().toLowerCase()
   if (q) {
@@ -1334,7 +1383,7 @@ const isFilteringActive = computed(() =>
 )
 
 /** Total exercise count, shown in the "Workouts" header stats. */
-const totalExercises = computed(() => store.exercises.length)
+const totalExercises = computed(() => store.activeExercises.length)
 
 /** Sets logged on the local "today" date — drives the Finish workout affordance. */
 const setsLoggedToday = computed(() => {
@@ -1662,8 +1711,20 @@ function beginDrag(index: number) {
     document.removeEventListener('mouseup', onEnd)
 
     if (dragState.fromIndex !== dragState.overIndex) {
-      store.reorderExercise(dragState.fromIndex, dragState.overIndex)
-      logEvent('exercise_reorder')
+      // dragState indices are positions in `filteredExercises` (active-only),
+      // but `store.reorderExercise` operates on the full `exercises` array.
+      // Map via exercise IDs so archived rows preserve their relative position
+      // and don't get accidentally reordered.
+      const fromEx = filteredExercises.value[dragState.fromIndex]
+      const toEx = filteredExercises.value[dragState.overIndex]
+      if (fromEx && toEx) {
+        const fromStoreIdx = store.exercises.findIndex(e => e.id === fromEx.id)
+        const toStoreIdx = store.exercises.findIndex(e => e.id === toEx.id)
+        if (fromStoreIdx !== -1 && toStoreIdx !== -1) {
+          store.reorderExercise(fromStoreIdx, toStoreIdx)
+          logEvent('exercise_reorder')
+        }
+      }
     }
 
     dragState.dragging = false
@@ -2974,6 +3035,47 @@ function undoDeleteExercise(exercise: Exercise) {
       saved.sets.forEach(s => progressionStore.removeSetXP(s.id))
     },
   )
+}
+
+// ── Archive ────────────────────────────────────────────────────
+const archivedOpen = ref(false)
+const archivedListId = 'wt-archived-list'
+
+const editTargetIsArchived = computed(() => {
+  if (!editTarget.value) return false
+  const ex = store.exercises.find(e => e.id === editTarget.value)
+  return !!ex?.archived_at
+})
+
+function handleArchiveFromEdit() {
+  const id = editTarget.value
+  if (!id) return
+  const ex = store.exercises.find(e => e.id === id)
+  if (!ex) return
+  const name = ex.name
+  if (detailExerciseId.value === id) detailExerciseId.value = null
+  store.archiveExercise(id)
+  editTarget.value = null
+  logEvent('exercise_archive')
+  showUndo(
+    `"${name}" archived`,
+    () => store.unarchiveExercise(id),
+    () => { /* commit: archive already applied — no-op */ },
+  )
+}
+
+function handleUnarchiveFromEdit() {
+  const id = editTarget.value
+  if (!id) return
+  store.unarchiveExercise(id)
+  editTarget.value = null
+  archivedOpen.value = false
+  logEvent('exercise_unarchive')
+}
+
+function unarchiveExerciseFromList(exerciseId: string) {
+  store.unarchiveExercise(exerciseId)
+  logEvent('exercise_unarchive')
 }
 
 // ── Edit exercise state (rename + tags) ──────────────────────────

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -291,6 +291,19 @@ describe('WorkoutTracker', () => {
       await wrapper.find('.wtArchivedActionBtn').trigger('click')
       expect(mockUnarchiveExercise).toHaveBeenCalledWith('ex-1')
     })
+
+    it('omits tags that exist only on archived exercises from the chip bar', () => {
+      // 'Legs' lives only on Squat. Archive Squat and 'Legs' should disappear
+      // from the chips — otherwise tapping it would filter to an empty list.
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      exercises[1].archived_at = '2026-05-01T00:00:00.000Z'
+      const wrapper = mountTracker()
+      const chips = wrapper.findAll('.wtTagChip').map(c => c.text())
+      const chipText = chips.join(' ')
+      expect(chipText).not.toContain('Legs')
+      expect(chipText).toContain('Chest')
+      expect(chipText).toContain('Push')
+    })
   })
 
   describe('tag filtering', () => {

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -122,10 +122,15 @@ const mockRenameExercise = vi.fn()
 const mockUpdateExerciseTags = vi.fn()
 const mockReorderExercise = vi.fn()
 
+const mockArchiveExercise = vi.fn()
+const mockUnarchiveExercise = vi.fn()
+
 vi.mock('../../stores/workout', () => ({
   useWorkoutStore: () => ({
     get exercises() { return exercises },
     set exercises(v: Exercise[]) { exercises = v },
+    get activeExercises() { return exercises.filter(e => !e.archived_at) },
+    get archivedExercises() { return exercises.filter(e => !!e.archived_at) },
     get allTags() { return getAllTags() },
     getExercisePR,
     getExercisePRSet,
@@ -139,6 +144,8 @@ vi.mock('../../stores/workout', () => ({
     syncDeleteSet: mockSyncDeleteSet,
     restoreExercise: mockRestoreExercise,
     syncDeleteExercise: mockSyncDeleteExercise,
+    archiveExercise: mockArchiveExercise,
+    unarchiveExercise: mockUnarchiveExercise,
     renameExercise: mockRenameExercise,
     updateExerciseTags: mockUpdateExerciseTags,
     reorderExercise: mockReorderExercise,
@@ -249,6 +256,40 @@ describe('WorkoutTracker', () => {
       const wrapper = mountTracker()
       const handles = wrapper.findAll('.wtDragHandle')
       expect(handles.length).toBe(3)
+    })
+  })
+
+  // ── archived exercises section (LIFT-434) ─────────────────────
+  describe('archived exercises', () => {
+    it('does not render the archived section when there are no archived exercises', () => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      const wrapper = mountTracker()
+      expect(wrapper.find('.wtArchivedSection').exists()).toBe(false)
+    })
+
+    it('hides archived exercises from the main list and shows them in the Archived section', async () => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      exercises[1].archived_at = '2026-05-01T00:00:00.000Z'
+      const wrapper = mountTracker()
+      const items = wrapper.findAll('.wtExerciseItem')
+      expect(items.length).toBe(2)
+      const section = wrapper.find('.wtArchivedSection')
+      expect(section.exists()).toBe(true)
+      expect(section.find('.wtArchivedToggleCount').text()).toBe('1')
+      // Archived list is collapsed by default — click the disclosure to reveal it.
+      await section.find('.wtArchivedToggle').trigger('click')
+      const archivedRows = wrapper.findAll('.wtArchivedRow')
+      expect(archivedRows.length).toBe(1)
+      expect(archivedRows[0].text()).toContain('Squat')
+    })
+
+    it('calls unarchiveExercise when the Unarchive button is clicked', async () => {
+      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      exercises[0].archived_at = '2026-05-01T00:00:00.000Z'
+      const wrapper = mountTracker()
+      await wrapper.find('.wtArchivedToggle').trigger('click')
+      await wrapper.find('.wtArchivedActionBtn').trigger('click')
+      expect(mockUnarchiveExercise).toHaveBeenCalledWith('ex-1')
     })
   })
 

--- a/src/index.css
+++ b/src/index.css
@@ -3300,6 +3300,140 @@ html.theme-fading .settingsSheet {
   cursor: pointer;
 }
 
+.wtEditArchiveBtn {
+  width: 100%;
+  padding: 12px;
+  min-height: 44px;
+  margin-top: 24px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-size: var(--font-callout);
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.wtEditArchiveHint {
+  margin: 8px 4px 0;
+  font-size: var(--font-caption1);
+  color: var(--text-secondary);
+  text-align: center;
+  line-height: 1.4;
+}
+
+.wtArchivedSection {
+  margin-top: 24px;
+  padding: 0 4px;
+}
+
+.wtArchivedToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: var(--font-callout);
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.wtArchivedToggle:hover {
+  background: var(--bg-hover);
+}
+
+.wtArchivedToggleIcon {
+  display: inline-block;
+  width: 16px;
+  text-align: center;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--text-secondary);
+  transition: transform 150ms ease;
+}
+
+.wtArchivedToggleIcon.expanded {
+  transform: rotate(90deg);
+}
+
+.wtArchivedToggleLabel {
+  flex: 1;
+  text-align: left;
+}
+
+.wtArchivedToggleCount {
+  padding: 2px 8px;
+  background: var(--bg-secondary);
+  border-radius: 10px;
+  font-size: var(--font-caption1);
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.wtArchivedList {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+
+.wtArchivedItem {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.wtArchivedRow {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  min-height: 44px;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: none;
+  border-radius: 10px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.wtArchivedName {
+  font-size: var(--font-callout);
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.wtArchivedMeta {
+  font-size: var(--font-caption1);
+  color: var(--text-secondary);
+}
+
+.wtArchivedActionBtn {
+  min-height: 44px;
+  padding: 0 16px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-family: inherit;
+  font-size: var(--font-footnote);
+  font-weight: 500;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.wtArchivedActionBtn:hover {
+  background: var(--bg-hover);
+}
+
 .wtEditDeleteConfirm {
   margin-top: 24px;
   text-align: center;
@@ -4866,7 +5000,7 @@ html.theme-fading .settingsSheet {
   min-height: 44px;
   background: none;
   border: none;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   font-size: var(--font-footnote);
   font-weight: 500;
   font-family: inherit;
@@ -6923,7 +7057,7 @@ html.theme-fading .settingsSheet {
 }
 
 .deleteConfirmInput::placeholder {
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
 }
 
 .deleteConfirmInput:focus {

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -68,6 +68,7 @@ export type Database = {
       }
       exercises: {
         Row: {
+          archived_at: string | null
           bar_weight: number
           created_at: string
           deleted_at: string | null
@@ -79,6 +80,7 @@ export type Database = {
           user_id: string
         }
         Insert: {
+          archived_at?: string | null
           bar_weight?: number
           created_at?: string
           deleted_at?: string | null
@@ -90,6 +92,7 @@ export type Database = {
           user_id: string
         }
         Update: {
+          archived_at?: string | null
           bar_weight?: number
           created_at?: string
           deleted_at?: string | null

--- a/src/stores/__tests__/syncFuzz.test.ts
+++ b/src/stores/__tests__/syncFuzz.test.ts
@@ -522,4 +522,65 @@ describe('sync fuzz: SEV1 2026-04-12 regression', () => {
       expect(store.entries.map(e => e.id)).toEqual(['bw-active'])
     })
   })
+
+  // ── Exercise archival (LIFT-434) ───────────────────────────────
+  describe('archive sync survives subsequent mutations and offline races', () => {
+    it('archiveExercise upsert payload includes archived_at and propagates to the server', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ])
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      store.archiveExercise('ex-1')
+      await tick()
+
+      const upserts = fakeSupabase.upsertsFor('exercises')
+      const archivePayload = (upserts[upserts.length - 1].data as Record<string, unknown>)
+      expect(archivePayload.archived_at).toBeTypeOf('string')
+      expect(fakeSupabase.tables.exercises[0].archived_at).toBeTypeOf('string')
+    })
+
+    it('subsequent rename after archive preserves archived_at on the server', async () => {
+      // Critical regression: the syncQueue dedupes by `exercise:${id}` key, so
+      // a rename queued right after archive used to overwrite the archive
+      // upsert with a payload missing archived_at, clearing it server-side.
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ])
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      store.archiveExercise('ex-1')
+      store.renameExercise('ex-1', 'Bench Press')
+      await tick()
+
+      expect(fakeSupabase.tables.exercises[0].name).toBe('Bench Press')
+      expect(fakeSupabase.tables.exercises[0].archived_at).toBeTypeOf('string')
+    })
+
+    it('unarchiveExercise clears archived_at on the server', async () => {
+      const userId = 'test-user'
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          archived_at: '2026-04-15T12:00:00Z',
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' },
+      ])
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+      expect(store.exercises[0].archived_at).toBeTypeOf('string')
+
+      store.unarchiveExercise('ex-1')
+      await tick()
+
+      expect(fakeSupabase.tables.exercises[0].archived_at).toBeNull()
+    })
+  })
 })

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -273,6 +273,80 @@ describe('workout store', () => {
     })
   })
 
+  // ── archiveExercise / unarchiveExercise (LIFT-434) ─────────────
+  describe('archiveExercise / unarchiveExercise', () => {
+    it('marks an exercise as archived without removing it', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      const id = store.exercises[0].id
+      store.archiveExercise(id)
+      expect(store.exercises).toHaveLength(1)
+      expect(store.exercises[0].archived_at).toBeTruthy()
+    })
+
+    it('removes the exercise from activeExercises but keeps it in archivedExercises', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      store.addExercise('Squat')
+      const benchId = store.exercises[0].id
+      store.archiveExercise(benchId)
+      expect(store.activeExercises.map(e => e.name)).toEqual(['Squat'])
+      expect(store.archivedExercises.map(e => e.name)).toEqual(['Bench'])
+    })
+
+    it('preserves sets on an archived exercise', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      const id = store.exercises[0].id
+      store.logSet(id, 135, 5)
+      store.logSet(id, 145, 5)
+      store.archiveExercise(id)
+      expect(store.exercises[0].sets).toHaveLength(2)
+      expect(store.getExercisePR(id)).toBeGreaterThan(0)
+    })
+
+    it('unarchives an exercise by clearing archived_at', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      const id = store.exercises[0].id
+      store.archiveExercise(id)
+      expect(store.archivedExercises).toHaveLength(1)
+      store.unarchiveExercise(id)
+      expect(store.archivedExercises).toHaveLength(0)
+      expect(store.activeExercises).toHaveLength(1)
+      expect(store.exercises[0].archived_at).toBeUndefined()
+    })
+
+    it('is idempotent — archiving an already-archived exercise does not overwrite the timestamp', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      const id = store.exercises[0].id
+      store.archiveExercise(id)
+      const firstStamp = store.exercises[0].archived_at
+      store.archiveExercise(id)
+      expect(store.exercises[0].archived_at).toBe(firstStamp)
+    })
+
+    it('persists archive state to localStorage', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      const id = store.exercises[0].id
+      store.archiveExercise(id)
+      const raw = localStorageMock.getItem('workout-exercises')
+      expect(raw).toBeTruthy()
+      const parsed = JSON.parse(raw!) as Exercise[]
+      expect(parsed[0].archived_at).toBeTruthy()
+    })
+
+    it('no-ops on unknown exercise id', () => {
+      const store = useWorkoutStore()
+      store.addExercise('Bench')
+      expect(() => store.archiveExercise('nonexistent')).not.toThrow()
+      expect(() => store.unarchiveExercise('nonexistent')).not.toThrow()
+      expect(store.exercises[0].archived_at).toBeUndefined()
+    })
+  })
+
   // ── reorderExercise ─────────────────────────────────────────────
   describe('reorderExercise', () => {
     it('reorders exercise from one index to another', () => {

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -192,16 +192,34 @@ export const useWorkoutStore = defineStore('workout', () => {
   }
 
   // ── Internal helpers ─────────────────────────────────────────────
+  /**
+   * Build a comprehensive upsert payload for an exercise row.
+   *
+   * Always include every mutable column the client owns — including
+   * `archived_at` — so that the sync queue's dedup-by-key behavior cannot
+   * accidentally drop archival state. (The queue collapses repeated
+   * `exercise:${id}` enqueues into the last one; a partial payload from a
+   * later rename would otherwise silently clear archived_at on the server.)
+   */
+  function _buildExerciseUpsert(exercise: Exercise, userId: string) {
+    return {
+      id: exercise.id,
+      user_id: userId,
+      name: exercise.name,
+      tags: exercise.tags,
+      archived_at: exercise.archived_at ?? null,
+      ...(exercise.inputMode ? { input_mode: exercise.inputMode } : {}),
+      ...(exercise.barWeight != null ? { bar_weight: exercise.barWeight } : {}),
+    }
+  }
+
   /** Clear sample flag and push exercise + all its sets to Supabase. */
   function _adoptExercise(exercise: Exercise) {
     delete exercise.sample
     if (supabase && !isPreviewMode.value && _userId) {
       const userId = _userId
       syncQueue.enqueue(`exercise:${exercise.id}`, () =>
-        supabase!.from('exercises').upsert({
-          id: exercise.id, user_id: userId, name: exercise.name, tags: exercise.tags,
-          ...(exercise.inputMode ? { input_mode: exercise.inputMode } : {}), ...(exercise.barWeight != null ? { bar_weight: exercise.barWeight } : {})
-        })
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
       for (const set of exercise.sets) {
         syncQueue.enqueue(`set:${set.id}`, () =>
@@ -370,11 +388,7 @@ export const useWorkoutStore = defineStore('workout', () => {
       const userId = _userId
       for (const ex of filteredLocalOnly) {
         syncQueue.enqueue(`exercise:${ex.id}`, () =>
-          supabase!.from('exercises').upsert({
-            id: ex.id, user_id: userId, name: ex.name, tags: ex.tags,
-            archived_at: ex.archived_at ?? null,
-            ...(ex.inputMode ? { input_mode: ex.inputMode } : {}), ...(ex.barWeight != null ? { bar_weight: ex.barWeight } : {})
-          })
+          supabase!.from('exercises').upsert(_buildExerciseUpsert(ex, userId))
         )
         for (const set of ex.sets) {
           syncQueue.enqueue(`set:${set.id}`, () =>
@@ -397,11 +411,7 @@ export const useWorkoutStore = defineStore('workout', () => {
       const userId = _userId
       for (const ex of filteredLocalWins) {
         syncQueue.enqueue(`exercise:${ex.id}`, () =>
-          supabase!.from('exercises').upsert({
-            id: ex.id, user_id: userId, name: ex.name, tags: ex.tags,
-            archived_at: ex.archived_at ?? null,
-            ...(ex.inputMode ? { input_mode: ex.inputMode } : {}), ...(ex.barWeight != null ? { bar_weight: ex.barWeight } : {})
-          })
+          supabase!.from('exercises').upsert(_buildExerciseUpsert(ex, userId))
         )
         // Only push sets that are new or have changed content (offline edits)
         const remoteSets = new Map(
@@ -464,9 +474,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (sync && supabase && !isPreviewMode.value && _userId) {
       const userId = _userId
       syncQueue.enqueue(`exercise:${id}`, () =>
-        supabase!.from('exercises').upsert({
-          id, user_id: userId, name: trimmed, tags: [...tags]
-        })
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
     return id
@@ -491,12 +499,8 @@ export const useWorkoutStore = defineStore('workout', () => {
 
     if (supabase && _userId) {
       const userId = _userId
-      const { name, tags, inputMode } = exercise
       syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert({
-          id: exerciseId, user_id: userId, name, tags,
-          ...(inputMode ? { input_mode: inputMode } : {}), bar_weight: barWeight,
-        })
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
   }
@@ -512,12 +516,8 @@ export const useWorkoutStore = defineStore('workout', () => {
 
     if (supabase && _userId) {
       const userId = _userId
-      const { name, tags, inputMode, barWeight } = exercise
       syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert({
-          id: exerciseId, user_id: userId, name, tags,
-          ...(inputMode ? { input_mode: inputMode } : {}), ...(barWeight != null ? { bar_weight: barWeight } : {})
-        })
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
   }
@@ -633,12 +633,8 @@ export const useWorkoutStore = defineStore('workout', () => {
 
     if (supabase && _userId) {
       const userId = _userId
-      const { name: n, tags: t, inputMode, barWeight } = exercise
       syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert({
-          id: exerciseId, user_id: userId, name: n, tags: t,
-          ...(inputMode ? { input_mode: inputMode } : {}), ...(barWeight != null ? { bar_weight: barWeight } : {})
-        })
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
   }
@@ -654,13 +650,8 @@ export const useWorkoutStore = defineStore('workout', () => {
 
     if (supabase && _userId) {
       const userId = _userId
-      const { name, inputMode, barWeight } = exercise
-      const tagsCopy = [...tags]
       syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert({
-          id: exerciseId, user_id: userId, name, tags: tagsCopy,
-          ...(inputMode ? { input_mode: inputMode } : {}), ...(barWeight != null ? { bar_weight: barWeight } : {})
-        })
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
   }
@@ -733,12 +724,13 @@ export const useWorkoutStore = defineStore('workout', () => {
     triggerRef(exercises)
     _persist()
 
+    // Use a full upsert (not a partial update) so this enqueue is safe even
+    // when the row hasn't yet been created on the server (e.g., an adopted
+    // sample exercise whose creating upsert sits in the same queue slot).
     if (supabase && !isPreviewMode.value && _userId) {
       const userId = _userId
       syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises')
-          .update({ archived_at: archivedAt })
-          .eq('id', exerciseId).eq('user_id', userId)
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
   }
@@ -755,9 +747,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (supabase && !isPreviewMode.value && _userId) {
       const userId = _userId
       syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises')
-          .update({ archived_at: null })
-          .eq('id', exerciseId).eq('user_id', userId)
+        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
       )
     }
   }
@@ -855,12 +845,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (_userId && modified.length > 0) {
       const userId = _userId
       for (const e of modified.filter(e => !e.sample)) {
-        const { name, tags, inputMode, barWeight } = e
         syncQueue.enqueue(`exercise:${e.id}`, () =>
-          supabase!.from('exercises').upsert({
-            id: e.id, user_id: userId, name, tags: [...tags],
-            ...(inputMode ? { input_mode: inputMode } : {}), ...(barWeight != null ? { bar_weight: barWeight } : {})
-          })
+          supabase!.from('exercises').upsert(_buildExerciseUpsert(e, userId))
         )
       }
     }
@@ -890,12 +876,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (_userId && modified.length > 0) {
       const userId = _userId
       for (const e of modified.filter(e => !e.sample)) {
-        const { name, tags, inputMode, barWeight } = e
         syncQueue.enqueue(`exercise:${e.id}`, () =>
-          supabase!.from('exercises').upsert({
-            id: e.id, user_id: userId, name, tags: [...tags],
-            ...(inputMode ? { input_mode: inputMode } : {}), ...(barWeight != null ? { bar_weight: barWeight } : {})
-          })
+          supabase!.from('exercises').upsert(_buildExerciseUpsert(e, userId))
         )
       }
     }

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -35,6 +35,7 @@ export interface Exercise {
   barWeight?: number               // bar weight in lbs, default 45
   plateCountMode?: PlateCountMode  // how plates are counted, default 'per-side'
   updated_at?: string              // ISO 8601, used for last-write-wins merge
+  archived_at?: string             // ISO 8601, soft-hide from main list; data is preserved
   sample?: boolean                 // true for onboarding sample data — never synced to Supabase
 }
 
@@ -263,6 +264,7 @@ export const useWorkoutStore = defineStore('workout', () => {
       }
       if (ex.input_mode) exercise.inputMode = ex.input_mode as ExerciseInputMode
       if (ex.bar_weight != null) exercise.barWeight = ex.bar_weight as number
+      if (ex.archived_at) exercise.archived_at = ex.archived_at as string
       return exercise
     })
 
@@ -718,6 +720,46 @@ export const useWorkoutStore = defineStore('workout', () => {
     }
   }
 
+  function archiveExercise(exerciseId: string) {
+    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
+    if (!exercise) return
+    if (exercise.archived_at) return
+    if (exercise.sample) _adoptExercise(exercise)
+    const archivedAt = new Date().toISOString()
+    exercise.archived_at = archivedAt
+    exercise.updated_at = archivedAt
+    triggerRef(exercises)
+    _persist()
+
+    if (supabase && !isPreviewMode.value && _userId) {
+      const userId = _userId
+      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
+        supabase!.from('exercises')
+          .update({ archived_at: archivedAt })
+          .eq('id', exerciseId).eq('user_id', userId)
+      )
+    }
+  }
+
+  function unarchiveExercise(exerciseId: string) {
+    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
+    if (!exercise) return
+    if (!exercise.archived_at) return
+    delete exercise.archived_at
+    exercise.updated_at = new Date().toISOString()
+    triggerRef(exercises)
+    _persist()
+
+    if (supabase && !isPreviewMode.value && _userId) {
+      const userId = _userId
+      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
+        supabase!.from('exercises')
+          .update({ archived_at: null })
+          .eq('id', exerciseId).eq('user_id', userId)
+      )
+    }
+  }
+
   function syncDeleteSet(setId: string) {
     if (supabase && _userId) {
       const userId = _userId
@@ -904,6 +946,16 @@ export const useWorkoutStore = defineStore('workout', () => {
     return [...tagSet].sort()
   })
 
+  /** Exercises the user is actively training — main list and pickers use this. */
+  const activeExercises = computed((): Exercise[] =>
+    exercises.value.filter((e: Exercise) => !e.archived_at)
+  )
+
+  /** Exercises the user has archived — hidden from the main list but data is preserved. */
+  const archivedExercises = computed((): Exercise[] =>
+    exercises.value.filter((e: Exercise) => !!e.archived_at)
+  )
+
   /** Sorted unique workout dates (YYYY-MM-DD), derived from all sets. */
   const workoutDates = computed((): string[] => {
     const dates = new Set<string>()
@@ -1082,6 +1134,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     updateExerciseTags,
     deleteExercise,
     restoreExercise,
+    archiveExercise,
+    unarchiveExercise,
     syncDeleteSet,
     syncDeleteExercise,
     reorderExercise,
@@ -1093,6 +1147,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     removeCustomTag,
     // Getters
     allTags,
+    activeExercises,
+    archivedExercises,
     workoutDates,
     getExercisePR,
     getExercisePRSet,

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -372,6 +372,7 @@ export const useWorkoutStore = defineStore('workout', () => {
         syncQueue.enqueue(`exercise:${ex.id}`, () =>
           supabase!.from('exercises').upsert({
             id: ex.id, user_id: userId, name: ex.name, tags: ex.tags,
+            archived_at: ex.archived_at ?? null,
             ...(ex.inputMode ? { input_mode: ex.inputMode } : {}), ...(ex.barWeight != null ? { bar_weight: ex.barWeight } : {})
           })
         )
@@ -398,6 +399,7 @@ export const useWorkoutStore = defineStore('workout', () => {
         syncQueue.enqueue(`exercise:${ex.id}`, () =>
           supabase!.from('exercises').upsert({
             id: ex.id, user_id: userId, name: ex.name, tags: ex.tags,
+            archived_at: ex.archived_at ?? null,
             ...(ex.inputMode ? { input_mode: ex.inputMode } : {}), ...(ex.barWeight != null ? { bar_weight: ex.barWeight } : {})
           })
         )

--- a/supabase/migrations/20260512000000_add_archived_at_to_exercises.sql
+++ b/supabase/migrations/20260512000000_add_archived_at_to_exercises.sql
@@ -1,0 +1,17 @@
+-- Add archived_at to exercises (LIFT-434)
+--
+-- "Archived" is a soft-hide for exercises the user has stopped training
+-- in the current block but does NOT want to delete. The row stays in the
+-- table — sets continue to count toward lifetime PR/volume queries — but
+-- the UI filters archived rows out of the main list and exercise pickers
+-- unless the user explicitly asks to see them.
+--
+-- Purely additive: NULL = active, non-NULL = archived-at-that-time.
+-- Existing queries (`is('deleted_at', null)`) keep working unchanged; the
+-- client filters on archived_at locally so that unarchive can restore
+-- without round-tripping.
+
+alter table exercises add column if not exists archived_at timestamptz;
+
+-- No partial index — archive lookups happen on the client after the same
+-- `is('deleted_at', null)` fetch already covered by idx_exercises_user_active.


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-434](https://github.com/aschung212/Lift/issues/434)

Archive lets users park exercises they aren't currently training without losing PRs or set history. Archived rows are hidden from the main list and exercise pickers but remain visible in a collapsed "Archived" section at the bottom of the workouts tab, where they can be restored with one tap. Archive state syncs to Supabase via a new `archived_at` column.

## Changes
- New `archived_at` field on Exercise (ISO timestamp, NULL = active)
- `archiveExercise` / `unarchiveExercise` actions with sync queue integration
- `activeExercises` / `archivedExercises` computed getters
- Archive / Unarchive button in the exercise edit modal (with undo toast)
- Archived disclosure section listing archived exercises with restore action
- Drag reorder now maps filtered-index to store-index via exercise ID so reordering only affects active exercises
- `_buildExerciseUpsert` helper routes all 10+ upsert paths through a single full-state payload (prevents syncQueue collapsing from clobbering `archived_at` during rename/tag/etc. ops)
- Tag chips derive from `activeExercises` (tags only on archived exercises no longer show empty chips)
- New Supabase migration: `20260512000000_add_archived_at_to_exercises.sql`

## Commits
- [`91ac615`](https://github.com/aschung212/Lift/commit/91ac615) feat(#434): add exercise archival (soft-hide preserving data)
- [`179626a`](https://github.com/aschung212/Lift/commit/179626a) fix(#434): preserve archived_at on sync upserts, hide empty tag chips
- [`09eda8a`](https://github.com/aschung212/Lift/commit/09eda8a) fix(#434): route all exercise upserts through full-state helper

The two follow-up commits address P1/P2 findings from the Gemini pre-push review.

## Test Results
- 1660 tests passing before; new coverage adds `workout.test.ts` (74 lines), `WorkoutTracker.test.ts` (54 lines), `syncFuzz.test.ts` (61 lines) for archive/unarchive/sync-roundtrip scenarios

---
_Manual PR after builder iteration completed implementation + push but the wrapper script crashed before creating the PR (worktree was deleted mid-run). Closes #434._