### PR TITLE
fix(#565): handle edge cases in bundle size reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           # Total JS bundle budget: 500 KB (currently ~410 KB)
           TOTAL_JS=$(find dist/assets -name '*.js' ! -name 'workbox-*' ! -name 'sw.*' -exec wc -c {} + | tail -1 | awk '{print $1}')
           TOTAL_CSS=$(find dist/assets -name '*.css' -exec wc -c {} + | tail -1 | awk '{print $1}')
+          TOTAL_CSS=${TOTAL_CSS:-0}
           BUDGET=512000
 
           echo "js_bytes=$TOTAL_JS" >> "$GITHUB_OUTPUT"
@@ -157,27 +158,32 @@ jobs:
             const marker = '<!-- bundle-size-report -->';
             body = marker + '\n' + body;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find(c => c.body.startsWith(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
               });
+
+              const existing = comments.find(c => c.body.startsWith(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (err) {
+              // Fork PRs have read-only tokens — log but don't fail the build
+              core.warning(`Could not post bundle size comment: ${err.message}`);
             }
 
       - run: npx vitest run --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     needs: [lint, typecheck]
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -75,8 +78,8 @@ jobs:
           restore-keys: bundle-sizes-master-
 
       - name: Preserve base bundle sizes
-        if: github.event_name == 'pull_request' && steps.base-bundle.outputs.cache-hit == 'true'
-        run: mv bundle-sizes.json base-bundle-sizes.json
+        if: github.event_name == 'pull_request'
+        run: if [ -f bundle-sizes.json ]; then mv bundle-sizes.json base-bundle-sizes.json; fi
 
       - name: Measure bundle sizes
         id: bundle
@@ -107,7 +110,7 @@ jobs:
           key: bundle-sizes-master-${{ github.sha }}
 
       - name: Post bundle size delta comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.bundle.outputs.js_bytes
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: bundle-sizes.json
-          key: bundle-sizes-master
+          key: bundle-sizes-master-${{ github.event.pull_request.base.sha }}
+          restore-keys: bundle-sizes-master-
 
       - name: Preserve base bundle sizes
         if: github.event_name == 'pull_request' && steps.base-bundle.outputs.cache-hit == 'true'
@@ -103,7 +104,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: bundle-sizes.json
-          key: bundle-sizes-master
+          key: bundle-sizes-master-${{ github.sha }}
 
       - name: Post bundle size delta comment
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,16 +65,116 @@ jobs:
           path: dist/
           retention-days: ${{ github.event_name == 'push' && 7 || 3 }}
 
-      - name: Check bundle size budget
+      - name: Restore base bundle sizes (PR)
+        if: github.event_name == 'pull_request'
+        id: base-bundle
+        uses: actions/cache/restore@v4
+        with:
+          path: bundle-sizes.json
+          key: bundle-sizes-master
+
+      - name: Preserve base bundle sizes
+        if: github.event_name == 'pull_request' && steps.base-bundle.outputs.cache-hit == 'true'
+        run: mv bundle-sizes.json base-bundle-sizes.json
+
+      - name: Measure bundle sizes
+        id: bundle
         run: |
           # Total JS bundle budget: 500 KB (currently ~410 KB)
           TOTAL_JS=$(find dist/assets -name '*.js' ! -name 'workbox-*' ! -name 'sw.*' -exec wc -c {} + | tail -1 | awk '{print $1}')
+          TOTAL_CSS=$(find dist/assets -name '*.css' -exec wc -c {} + | tail -1 | awk '{print $1}')
           BUDGET=512000
+
+          echo "js_bytes=$TOTAL_JS" >> "$GITHUB_OUTPUT"
+          echo "css_bytes=$TOTAL_CSS" >> "$GITHUB_OUTPUT"
           echo "JS bundle size: $(( TOTAL_JS / 1024 )) KB (budget: $(( BUDGET / 1024 )) KB)"
+          echo "CSS bundle size: $(( TOTAL_CSS / 1024 )) KB"
+
           if [ "$TOTAL_JS" -gt "$BUDGET" ]; then
             echo "::error::Bundle size ($((TOTAL_JS / 1024)) KB) exceeds budget ($((BUDGET / 1024)) KB)"
             exit 1
           fi
+
+          # Save sizes for cross-build comparison
+          echo "{\"js\": $TOTAL_JS, \"css\": $TOTAL_CSS}" > bundle-sizes.json
+
+      - name: Save bundle sizes (master)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v4
+        with:
+          path: bundle-sizes.json
+          key: bundle-sizes-master
+
+      - name: Post bundle size delta comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const jsBytes = parseInt('${{ steps.bundle.outputs.js_bytes }}', 10);
+            const cssBytes = parseInt('${{ steps.bundle.outputs.css_bytes }}', 10);
+            const budget = 512000;
+
+            let body = '## 📦 Bundle Size Report\n\n';
+
+            // Try to load base branch sizes
+            let baseJs = null, baseCss = null;
+            try {
+              const base = JSON.parse(fs.readFileSync('base-bundle-sizes.json', 'utf8'));
+              baseJs = base.js;
+              baseCss = base.css;
+            } catch {
+              // No cached baseline — first run or cache expired
+            }
+
+            const fmt = (bytes) => `${(bytes / 1024).toFixed(1)} KB`;
+            const delta = (cur, prev) => {
+              const diff = cur - prev;
+              const sign = diff > 0 ? '+' : '';
+              const icon = diff > 0 ? '🔺' : diff < 0 ? '🔽' : '✅';
+              return `${icon} ${sign}${fmt(diff)}`;
+            };
+
+            body += '| Asset | Size | Budget | Delta |\n';
+            body += '|-------|------|--------|-------|\n';
+
+            const jsDelta = baseJs != null ? delta(jsBytes, baseJs) : '—';
+            const cssDelta = baseCss != null ? delta(cssBytes, baseCss) : '—';
+            const jsPct = ((jsBytes / budget) * 100).toFixed(0);
+
+            body += `| JS | ${fmt(jsBytes)} | ${fmt(budget)} (${jsPct}%) | ${jsDelta} |\n`;
+            body += `| CSS | ${fmt(cssBytes)} | — | ${cssDelta} |\n`;
+
+            if (baseJs == null) {
+              body += '\n> _No baseline from master yet. Delta will appear after the next master build._\n';
+            }
+
+            // Upsert: find existing comment by marker, update or create
+            const marker = '<!-- bundle-size-report -->';
+            body = marker + '\n' + body;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       - run: npx vitest run --coverage
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-565](https://github.com/aschung212/Lift/issues/565)



## Changes




## Commits
- [`4d8e523`](https://github.com/aschung212/Lift/commit/4d8e523) fix(#565): handle edge cases in bundle size reporting
- [`1b04df3`](https://github.com/aschung212/Lift/commit/1b04df3) fix(#565): address review findings for bundle size reporting
- [`6357175`](https://github.com/aschung212/Lift/commit/6357175) fix(#565): use unique cache keys for bundle size snapshots
- [`3ccf98a`](https://github.com/aschung212/Lift/commit/3ccf98a) ci(#565): show bundle size delta on PR comments

## Test Results
- Before: 1674 passing
- After: 1674 passing (0 delta)

---
_Automated by overnight pipeline — Wed May 13 00:54:50 PDT 2026_