### PR TITLE
refactor(#575): make WorkoutCompleteView a pure presentational component

### DIFF
--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -73,15 +73,12 @@
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, nextTick, defineAsyncComponent } from 'vue'
-import { useWorkoutStore } from '../stores/workout'
-import { useProgressionStore } from '../stores/progression'
-import { buildSessionSummary } from '../lib/sessionSummary'
 import { useFocusTrap } from '../composables/useFocusTrap'
-import { useWeightUnit } from '../composables/useWeightUnit'
+import type { SessionSummary } from '../lib/sessionSummary'
 
 const SharePickerSheet = defineAsyncComponent(() => import('./share/SharePickerSheet.vue'))
 
-const props = defineProps<{ rawDate: string }>()
+const props = defineProps<{ summary: SessionSummary }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
 const pickerOpen = ref(false)
@@ -89,22 +86,10 @@ function openPicker() {
   pickerOpen.value = true
 }
 
-const store = useWorkoutStore()
-const progression = useProgressionStore()
 const focusTrap = useFocusTrap()
 const overlayEl = ref<HTMLElement | null>(null)
-const { displayWeight, weightUnit } = useWeightUnit()
 
-const summary = computed(() =>
-  buildSessionSummary({
-    rawDate: props.rawDate,
-    exercises: store.exercises,
-    xpPerSet: progression.xpPerSet,
-    streakWeeks: progression.streakWeeks,
-    toDisplayUnits: displayWeight,
-    unitLabel: weightUnit.value,
-  })
-)
+const summary = computed(() => props.summary)
 
 const hasSets = computed(() => summary.value.setsCompleted > 0)
 const formattedVolume = computed(() => summary.value.totalVolume.toLocaleString('en-US'))

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1083,8 +1083,8 @@
 
   <Teleport to="body">
     <WorkoutCompleteView
-      v-if="workoutCompleteDate"
-      :raw-date="workoutCompleteDate"
+      v-if="workoutCompleteSummary"
+      :summary="workoutCompleteSummary"
       @close="workoutCompleteDate = null"
     />
   </Teleport>
@@ -1093,7 +1093,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch, nextTick, onMounted, onUnmounted, defineAsyncComponent } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
-import { toLocalDateKey } from '../lib/sessionSummary'
+import { toLocalDateKey, buildSessionSummary } from '../lib/sessionSummary'
 
 const WorkoutCompleteView = defineAsyncComponent(() => import('./WorkoutCompleteView.vue'))
 import type { Exercise, WorkoutSet, PlateCountMode } from '../stores/workout'
@@ -1403,6 +1403,18 @@ const setsLoggedToday = computed(() => {
 
 /** When non-null, renders the WorkoutCompleteView overlay for that date. */
 const workoutCompleteDate = ref<string | null>(null)
+const workoutCompleteSummary = computed(() => {
+  const d = workoutCompleteDate.value
+  if (!d) return null
+  return buildSessionSummary({
+    rawDate: d,
+    exercises: store.exercises,
+    xpPerSet: progressionStore.xpPerSet,
+    streakWeeks: progressionStore.streakWeeks,
+    toDisplayUnits: displayWeight,
+    unitLabel: weightUnit.value,
+  })
+})
 function openWorkoutComplete() {
   workoutCompleteDate.value = todayISO()
   impactLight()


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-575](https://github.com/aschung212/Lift/issues/575)

Refactor WorkoutCompleteView (LIFT-575) to be a pure presentational component by removing direct store access. Move the `buildSessionSummary` call to the parent WorkoutTracker, which already has all the necessary store references, and pass the computed `SessionSummary` as a prop.

## Changes
- **`src/components/WorkoutCompleteView.vue`**: Removed imports of `useWorkoutStore`, `useProgressionStore`, `useWeightUnit`, and `buildSessionSummary`. Changed props from `{ rawDate: string }` to `{ summary: SessionSummary }`. The component is now fully presentational — it renders the summary it receives and emits `close` events.
- **`src/components/WorkoutTracker.vue`**: Added `buildSessionSummary` import. Added `workoutCompleteSummary` computed property that derives the session summary from existing store refs. Passes `:summary` prop instead of `:raw-date` to WorkoutCompleteView.

## Verification
- Build: passes (vite build, 3.89s)
- Tests: 82 files, 1674 tests, all passing
- Lint: clean (via lint-staged pre-commit hook)
- Gemini 3.1 Pro review: "No issues found"

ISSUE_DONE:575:WorkoutCompleteView refactored to pure presentational component — receives SessionSummary prop from parent instead of accessing stores directly

## Commits
- [`c550565`](https://github.com/aschung212/Lift/commit/c550565) refactor(#575): make WorkoutCompleteView a pure presentational component

## Test Results
- Before: 1674 passing
- After: 1674 passing (0 delta)

---
_Automated by overnight pipeline — Wed May 13 23:18:32 PDT 2026_

## Preview
Test on your phone: https://lift-iktlz7fu9-aschung212-1101s-projects.vercel.app