### PR TITLE
refactor(#574): make MuscleGroupRecovery fully presentational

### DIFF
--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -204,6 +204,10 @@
         v-if="hasRecoveryData"
         :recovery="tagRecovery"
         :hidden-count="recoveryHiddenCount"
+        :hidden-tags="recoveryHiddenTags"
+        @hide="onRecoveryHide"
+        @show="onRecoveryShow"
+        @days-change="onRecoveryDaysChange"
       />
 
       <!-- Weekly muscle group volume chart (collapsible) -->
@@ -601,6 +605,34 @@ const allExercisesRef = computed(() => store.exercises)
 const tagRecoveryDaysRef = computed(() => store.tagRecoveryDays)
 const tagRecoveryExcludedRef = computed(() => store.tagRecoveryExcluded)
 const { recovery: tagRecovery, hasData: hasRecoveryData, hiddenCount: recoveryHiddenCount } = useTagRecovery(allExercisesRef, tagRecoveryDaysRef, tagRecoveryExcludedRef)
+
+const recoveryHiddenTags = computed(() => {
+  const tagsWithSets = new Set<string>()
+  for (const exercise of store.exercises) {
+    if (!exercise.tags || exercise.tags.length === 0) continue
+    for (const set of exercise.sets) {
+      if (set.date) {
+        for (const tag of exercise.tags) {
+          tagsWithSets.add(tag)
+        }
+      }
+    }
+  }
+  return store.tagRecoveryExcluded.filter(t => tagsWithSets.has(t)).sort()
+})
+
+function onRecoveryHide(tag: string) {
+  store.setTagRecoveryExcluded(tag, true)
+}
+
+function onRecoveryShow(tag: string) {
+  store.setTagRecoveryExcluded(tag, false)
+}
+
+function onRecoveryDaysChange(tag: string, days: number | null) {
+  store.setTagRecoveryDays(tag, days)
+}
+
 const volumeCollapsed = ref(false)
 
 function formatSelectedDay(dateStr: string) {

--- a/src/components/MuscleGroupRecovery.vue
+++ b/src/components/MuscleGroupRecovery.vue
@@ -72,34 +72,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import type { TagRecovery } from '../composables/useTagRecovery'
-import { useWorkoutStore } from '../stores/workout'
 
 defineProps<{
   recovery: TagRecovery[]
   hiddenCount: number
+  hiddenTags: string[]
 }>()
 
-const store = useWorkoutStore()
+const emit = defineEmits<{
+  hide: [tag: string]
+  show: [tag: string]
+  'days-change': [tag: string, days: number | null]
+}>()
+
 const expandedTag = ref<string | null>(null)
 const showHidden = ref(false)
-
-const hiddenTags = computed(() => {
-  // Return excluded tags that actually have sets logged
-  const tagsWithSets = new Set<string>()
-  for (const exercise of store.exercises) {
-    if (!exercise.tags || exercise.tags.length === 0) continue
-    for (const set of exercise.sets) {
-      if (set.date) {
-        for (const tag of exercise.tags) {
-          tagsWithSets.add(tag)
-        }
-      }
-    }
-  }
-  return store.tagRecoveryExcluded.filter(t => tagsWithSets.has(t)).sort()
-})
 
 function formatDaysAgo(days: number): string {
   if (days === 0) return 'Today'
@@ -111,16 +100,16 @@ function onDaysChange(tag: string, event: Event) {
   const input = event.target as HTMLInputElement
   const val = input.value.trim()
   const parsed = parseInt(val, 10)
-  store.setTagRecoveryDays(tag, val && !Number.isNaN(parsed) ? parsed : null)
+  emit('days-change', tag, val && !Number.isNaN(parsed) ? parsed : null)
 }
 
 function onHide(tag: string) {
-  store.setTagRecoveryExcluded(tag, true)
+  emit('hide', tag)
   expandedTag.value = null
 }
 
 function onShow(tag: string) {
-  store.setTagRecoveryExcluded(tag, false)
+  emit('show', tag)
 }
 </script>
 

--- a/src/components/__tests__/MuscleGroupRecovery.test.ts
+++ b/src/components/__tests__/MuscleGroupRecovery.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import MuscleGroupRecovery from '../MuscleGroupRecovery.vue'
-import { useWorkoutStore } from '../../stores/workout'
 import type { TagRecovery } from '../../composables/useTagRecovery'
 
 const sampleRecovery: TagRecovery[] = [
@@ -11,14 +10,12 @@ const sampleRecovery: TagRecovery[] = [
   { tag: 'Shoulders', lastTrainedDate: '2026-04-10', hoursSince: 24, daysSince: 1, recoveryDays: 2, status: 'recovering' },
 ]
 
-function mountRecovery(props?: Partial<{ recovery: TagRecovery[]; hiddenCount: number }>) {
+function mountRecovery(props?: Partial<{ recovery: TagRecovery[]; hiddenCount: number; hiddenTags: string[] }>) {
   return mount(MuscleGroupRecovery, {
     props: {
       recovery: props?.recovery ?? sampleRecovery,
       hiddenCount: props?.hiddenCount ?? 0,
-    },
-    global: {
-      plugins: [createPinia()],
+      hiddenTags: props?.hiddenTags ?? [],
     },
   })
 }
@@ -109,6 +106,59 @@ describe('MuscleGroupRecovery', () => {
     })
   })
 
+  describe('events (prop-down / event-up)', () => {
+    it('emits hide when hide button is clicked', async () => {
+      const wrapper = mountRecovery()
+      await wrapper.findAll('.recRow')[0].trigger('click')
+      await wrapper.find('.recActionBtn').trigger('click')
+
+      expect(wrapper.emitted('hide')).toBeTruthy()
+      expect(wrapper.emitted('hide')![0]).toEqual(['Legs'])
+    })
+
+    it('emits show when show button is clicked for a hidden tag', async () => {
+      const wrapper = mountRecovery({ hiddenCount: 1, hiddenTags: ['Back'] })
+      await wrapper.find('.recHiddenFooter').trigger('click')
+      await wrapper.find('.recShowBtn').trigger('click')
+
+      expect(wrapper.emitted('show')).toBeTruthy()
+      expect(wrapper.emitted('show')![0]).toEqual(['Back'])
+    })
+
+    it('emits days-change when recovery window input changes', async () => {
+      const wrapper = mountRecovery()
+      await wrapper.findAll('.recRow')[0].trigger('click')
+
+      const input = wrapper.find('.recDaysInput')
+      await input.setValue('5')
+      await input.trigger('change')
+
+      expect(wrapper.emitted('days-change')).toBeTruthy()
+      expect(wrapper.emitted('days-change')![0]).toEqual(['Legs', 5])
+    })
+
+    it('emits days-change with null when input is cleared', async () => {
+      const wrapper = mountRecovery()
+      await wrapper.findAll('.recRow')[0].trigger('click')
+
+      const input = wrapper.find('.recDaysInput')
+      await input.setValue('')
+      await input.trigger('change')
+
+      expect(wrapper.emitted('days-change')).toBeTruthy()
+      expect(wrapper.emitted('days-change')![0]).toEqual(['Legs', null])
+    })
+
+    it('collapses expanded tag after hide', async () => {
+      const wrapper = mountRecovery()
+      await wrapper.findAll('.recRow')[0].trigger('click')
+      expect(wrapper.find('.recExpanded').exists()).toBe(true)
+
+      await wrapper.find('.recActionBtn').trigger('click')
+      expect(wrapper.find('.recExpanded').exists()).toBe(false)
+    })
+  })
+
   describe('hidden tags footer', () => {
     it('does not show footer when no tags are hidden', () => {
       const wrapper = mountRecovery({ hiddenCount: 0 })
@@ -128,7 +178,7 @@ describe('MuscleGroupRecovery', () => {
     })
 
     it('toggles hidden list on footer tap', async () => {
-      const wrapper = mountRecovery({ hiddenCount: 1 })
+      const wrapper = mountRecovery({ hiddenCount: 1, hiddenTags: ['Back'] })
       expect(wrapper.find('.recHiddenList').exists()).toBe(false)
 
       await wrapper.find('.recHiddenFooter').trigger('click')
@@ -136,6 +186,14 @@ describe('MuscleGroupRecovery', () => {
 
       await wrapper.find('.recHiddenFooter').trigger('click')
       expect(wrapper.find('.recHiddenList').exists()).toBe(false)
+    })
+
+    it('renders hidden tag names from prop', async () => {
+      const wrapper = mountRecovery({ hiddenCount: 2, hiddenTags: ['Back', 'Biceps'] })
+      await wrapper.find('.recHiddenFooter').trigger('click')
+
+      const names = wrapper.findAll('.recHiddenName')
+      expect(names.map(n => n.text())).toEqual(['Back', 'Biceps'])
     })
   })
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-574](https://github.com/aschung212/Lift/issues/574)

Refactor MuscleGroupRecovery (LIFT-574) from a mixed prop/store component into a fully presentational component. Move all store interactions to CalendarView (the parent), establishing a clean prop-down/event-up pattern.

## Changes
- **`src/components/MuscleGroupRecovery.vue`**: Removed `useWorkoutStore` import and direct store access. Added `hiddenTags` prop and `hide`/`show`/`days-change` emit declarations. The `hiddenTags` computed that iterated store.exercises is now a prop from the parent.
- **`src/components/CalendarView.vue`**: Added `recoveryHiddenTags` computed (moved from MuscleGroupRecovery), plus `onRecoveryHide`, `onRecoveryShow`, `onRecoveryDaysChange` handler functions. Updated template to pass new prop and bind event handlers.
- **`src/components/__tests__/MuscleGroupRecovery.test.ts`**: Removed Pinia dependency entirely — component is now testable without a store. Added 5 new tests for emitted events (hide, show, days-change with value, days-change with null) and hidden tag rendering from props.

## Verification
- 82 test files, 1679 tests passing
- Build succeeds
- ESLint clean
- Gemini review: no issues found

ISSUE_DONE:LIFT-574
  📊 Output tokens: 8602 | Nightly total: 24292/500000 | Run 4/12
✅ Run 4 finished at Thu May 14 00:09:24 PDT 2026 — 1 new commit(s)
Everything up-to-date
branch 'enhance/LIFT-574-2026-05-13' set up to track 'origin/enhance/LIFT-574-2026-05-13'.
✅ CI passed (build + tests)

## Commits
- [`b9596ae`](https://github.com/aschung212/Lift/commit/b9596ae) refactor(#574): make MuscleGroupRecovery fully presentational

## Test Results
- Before: 1674 passing
- After: 1679 passing (5 delta)

---
_Automated by overnight pipeline — Thu May 14 00:10:04 PDT 2026_

## Preview
Test on your phone: https://lift-lufotyd42-aschung212-1101s-projects.vercel.app