### PR TITLE
fix(#546): use exercise ID instead of template index to prevent rapid-key bounce

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -126,7 +126,7 @@
             tabindex="0"
             :aria-label="`Reorder ${exercise.name}, position ${index + 1} of ${filteredExercises.length}`"
             :aria-disabled="isFilteringActive ? 'true' : undefined"
-            @keydown="onReorderKeyDown(index, $event)"
+            @keydown="onReorderKeyDown(exercise.id, $event)"
           >⠿</span>
           <button
             class="wtExerciseRow"
@@ -1701,17 +1701,23 @@ function onItemClickCapture(event: MouseEvent) {
   }
 }
 
-function onReorderKeyDown(index: number, event: KeyboardEvent) {
+function onReorderKeyDown(exerciseId: string, event: KeyboardEvent) {
   if (isFilteringActive.value) return
   const key = event.key
   if (key !== 'ArrowUp' && key !== 'ArrowDown') return
   event.preventDefault()
 
-  const newIndex = key === 'ArrowUp' ? index - 1 : index + 1
-  if (newIndex < 0 || newIndex >= filteredExercises.value.length) return
+  // Compute index dynamically from the current filtered list to avoid stale
+  // template indices when the user holds a key and events fire rapidly.
+  const filtered = filteredExercises.value
+  const index = filtered.findIndex(e => e.id === exerciseId)
+  if (index === -1) return
 
-  const fromEx = filteredExercises.value[index]
-  const toEx = filteredExercises.value[newIndex]
+  const newIndex = key === 'ArrowUp' ? index - 1 : index + 1
+  if (newIndex < 0 || newIndex >= filtered.length) return
+
+  const fromEx = filtered[index]
+  const toEx = filtered[newIndex]
   if (!fromEx || !toEx) return
 
   const fromStoreIdx = store.exercises.findIndex(e => e.id === fromEx.id)

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -122,7 +122,11 @@
         <div class="wtExerciseHeader">
           <span
             :class="['wtDragHandle', { wtDragHandleDisabled: isFilteringActive }]"
-            aria-hidden="true"
+            role="button"
+            tabindex="0"
+            :aria-label="`Reorder ${exercise.name}, position ${index + 1} of ${filteredExercises.length}`"
+            :aria-disabled="isFilteringActive ? 'true' : undefined"
+            @keydown="onReorderKeyDown(index, $event)"
           >⠿</span>
           <button
             class="wtExerciseRow"
@@ -1695,6 +1699,37 @@ function onItemClickCapture(event: MouseEvent) {
     event.stopPropagation()
     event.preventDefault()
   }
+}
+
+function onReorderKeyDown(index: number, event: KeyboardEvent) {
+  if (isFilteringActive.value) return
+  const key = event.key
+  if (key !== 'ArrowUp' && key !== 'ArrowDown') return
+  event.preventDefault()
+
+  const newIndex = key === 'ArrowUp' ? index - 1 : index + 1
+  if (newIndex < 0 || newIndex >= filteredExercises.value.length) return
+
+  const fromEx = filteredExercises.value[index]
+  const toEx = filteredExercises.value[newIndex]
+  if (!fromEx || !toEx) return
+
+  const fromStoreIdx = store.exercises.findIndex(e => e.id === fromEx.id)
+  const toStoreIdx = store.exercises.findIndex(e => e.id === toEx.id)
+  if (fromStoreIdx === -1 || toStoreIdx === -1) return
+
+  store.reorderExercise(fromStoreIdx, toStoreIdx)
+  impactLight()
+  logEvent('exercise_reorder')
+
+  // After Vue re-renders, focus the drag handle at the item's new position
+  nextTick(() => {
+    const list = exerciseListEl.value
+    if (!list) return
+    const items = list.querySelectorAll('.wtExerciseItem')
+    const handle = items[newIndex]?.querySelector<HTMLElement>('.wtDragHandle')
+    handle?.focus()
+  })
 }
 
 function beginDrag(index: number) {

--- a/src/lib/__tests__/keyboardReorder.test.ts
+++ b/src/lib/__tests__/keyboardReorder.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const workoutTracker = readFileSync(
+  resolve(__dirname, '../../components/WorkoutTracker.vue'),
+  'utf-8',
+)
+
+/**
+ * Structural regression tests for keyboard-accessible exercise reordering.
+ *
+ * WCAG 2.1.1 requires all functionality be operable via keyboard.
+ * The drag-and-drop reorder was pointer-only — these tests ensure the
+ * keyboard alternative (ArrowUp/ArrowDown on the drag handle) stays in place.
+ *
+ * See: LIFT-546
+ */
+describe('keyboard reorder accessibility (LIFT-546)', () => {
+  it('drag handle has role="button" for keyboard operability', () => {
+    expect(workoutTracker).toMatch(/class=".*wtDragHandle.*"[\s\S]{1,300}?role="button"/)
+  })
+
+  it('drag handle has tabindex="0" to be focusable', () => {
+    expect(workoutTracker).toMatch(/class=".*wtDragHandle.*"[\s\S]{1,300}?tabindex="0"/)
+  })
+
+  it('drag handle has an aria-label describing position', () => {
+    expect(workoutTracker).toMatch(
+      /class=".*wtDragHandle.*"[\s\S]{1,300}?:aria-label="`Reorder \$\{exercise\.name\}/,
+    )
+  })
+
+  it('drag handle has aria-disabled when filtering is active', () => {
+    expect(workoutTracker).toMatch(
+      /class=".*wtDragHandle.*"[\s\S]{1,300}?:aria-disabled="isFilteringActive/,
+    )
+  })
+
+  it('drag handle has @keydown handler for reorder', () => {
+    expect(workoutTracker).toMatch(
+      /class=".*wtDragHandle.*"[\s\S]{1,300}?@keydown="onReorderKeyDown/,
+    )
+  })
+
+  it('onReorderKeyDown function exists in the script', () => {
+    expect(workoutTracker).toMatch(/function onReorderKeyDown\(index: number, event: KeyboardEvent\)/)
+  })
+
+  it('keyboard reorder handles ArrowUp and ArrowDown keys', () => {
+    expect(workoutTracker).toMatch(/key !== 'ArrowUp' && key !== 'ArrowDown'/)
+  })
+
+  it('keyboard reorder is blocked when filtering is active', () => {
+    // The function must bail out when filtering is active, same as pointer reorder
+    expect(workoutTracker).toMatch(/function onReorderKeyDown[\s\S]{1,100}?isFilteringActive\.value/)
+  })
+
+  it('keyboard reorder calls store.reorderExercise', () => {
+    // Extract the onReorderKeyDown function body
+    const fnMatch = workoutTracker.match(
+      /function onReorderKeyDown[\s\S]{1,800}?store\.reorderExercise/,
+    )
+    expect(fnMatch).not.toBeNull()
+  })
+
+  it('keyboard reorder moves focus to the new position after reorder', () => {
+    const fnMatch = workoutTracker.match(
+      /function onReorderKeyDown[\s\S]{1,1200}?handle\?\.focus\(\)/,
+    )
+    expect(fnMatch).not.toBeNull()
+  })
+})

--- a/src/lib/__tests__/keyboardReorder.test.ts
+++ b/src/lib/__tests__/keyboardReorder.test.ts
@@ -45,7 +45,7 @@ describe('keyboard reorder accessibility (LIFT-546)', () => {
   })
 
   it('onReorderKeyDown function exists in the script', () => {
-    expect(workoutTracker).toMatch(/function onReorderKeyDown\(index: number, event: KeyboardEvent\)/)
+    expect(workoutTracker).toMatch(/function onReorderKeyDown\(exerciseId: string, event: KeyboardEvent\)/)
   })
 
   it('keyboard reorder handles ArrowUp and ArrowDown keys', () => {
@@ -57,17 +57,21 @@ describe('keyboard reorder accessibility (LIFT-546)', () => {
     expect(workoutTracker).toMatch(/function onReorderKeyDown[\s\S]{1,100}?isFilteringActive\.value/)
   })
 
+  it('keyboard reorder computes index dynamically to avoid stale template indices', () => {
+    // Must look up the exercise by ID in the current filtered list, not use template index
+    expect(workoutTracker).toMatch(/function onReorderKeyDown[\s\S]{1,500}?filtered\.findIndex/)
+  })
+
   it('keyboard reorder calls store.reorderExercise', () => {
-    // Extract the onReorderKeyDown function body
     const fnMatch = workoutTracker.match(
-      /function onReorderKeyDown[\s\S]{1,800}?store\.reorderExercise/,
+      /function onReorderKeyDown[\s\S]{1,1000}?store\.reorderExercise/,
     )
     expect(fnMatch).not.toBeNull()
   })
 
   it('keyboard reorder moves focus to the new position after reorder', () => {
     const fnMatch = workoutTracker.match(
-      /function onReorderKeyDown[\s\S]{1,1200}?handle\?\.focus\(\)/,
+      /function onReorderKeyDown[\s\S]{1,1400}?handle\?\.focus\(\)/,
     )
     expect(fnMatch).not.toBeNull()
   })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-546](https://github.com/aschung212/Lift/issues/546)



## Changes




## Commits
- [`28f08d5`](https://github.com/aschung212/Lift/commit/28f08d5) fix(#546): use exercise ID instead of template index to prevent rapid-key bounce
- [`43398ac`](https://github.com/aschung212/Lift/commit/43398ac) a11y(#546): add keyboard reorder for exercise list

## Test Results
- Before: 1674 passing
- After: 1685 passing (11 delta)

---
_Automated by overnight pipeline — Sat May 16 01:46:10 PDT 2026_

## Preview
Test on your phone: https://lift-ex7rb88su-aschung212-1101s-projects.vercel.app