### PR TITLE
test(#590): eliminate shared mutable state in WorkoutTracker tests

### DIFF
--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -49,63 +49,69 @@ vi.mock('../ExerciseGraph.vue', () => ({
   default: { name: 'ExerciseGraph', template: '<div class="mock-graph" />' }
 }))
 
-const EXERCISES: Exercise[] = [
-  {
-    id: 'ex-1',
-    name: 'Bench Press',
-    tags: ['Chest', 'Push'],
-    sets: [
-      { id: 's-1', date: '2026-01-15T12:00:00', weight: 185, reps: 5, estimated1RM: 216 },
-      { id: 's-2', date: '2026-01-20T12:00:00', weight: 195, reps: 5, estimated1RM: 228 },
-    ]
-  },
-  {
-    id: 'ex-2',
-    name: 'Squat',
-    tags: ['Legs'],
-    sets: [
-      { id: 's-3', date: '2026-01-16T12:00:00', weight: 225, reps: 5, estimated1RM: 263 },
-    ]
-  },
-  {
-    id: 'ex-3',
-    name: 'Overhead Press',
-    tags: ['Push'],
-    sets: []
-  },
-]
+// Fixture factories — each call returns a fresh deep copy so tests never share object references.
+function createExercises(): Exercise[] {
+  return [
+    {
+      id: 'ex-1',
+      name: 'Bench Press',
+      tags: ['Chest', 'Push'],
+      sets: [
+        { id: 's-1', date: '2026-01-15T12:00:00', weight: 185, reps: 5, estimated1RM: 216 },
+        { id: 's-2', date: '2026-01-20T12:00:00', weight: 195, reps: 5, estimated1RM: 228 },
+      ]
+    },
+    {
+      id: 'ex-2',
+      name: 'Squat',
+      tags: ['Legs'],
+      sets: [
+        { id: 's-3', date: '2026-01-16T12:00:00', weight: 225, reps: 5, estimated1RM: 263 },
+      ]
+    },
+    {
+      id: 'ex-3',
+      name: 'Overhead Press',
+      tags: ['Push'],
+      sets: []
+    },
+  ]
+}
 
-const PR_EXERCISES: Exercise[] = [
-  {
-    id: 'ex-1',
-    name: 'Bench Press',
-    tags: [],
-    sets: [
-      { id: 's-1', date: '2026-01-01T12:00:00', weight: 135, reps: 5, estimated1RM: 158 },
-      { id: 's-2', date: '2026-01-15T12:00:00', weight: 155, reps: 5, estimated1RM: 181 },
-      { id: 's-3', date: '2026-02-01T12:00:00', weight: 175, reps: 5, estimated1RM: 204 },
-    ]
-  }
-]
+function createPRExercises(): Exercise[] {
+  return [
+    {
+      id: 'ex-1',
+      name: 'Bench Press',
+      tags: [],
+      sets: [
+        { id: 's-1', date: '2026-01-01T12:00:00', weight: 135, reps: 5, estimated1RM: 158 },
+        { id: 's-2', date: '2026-01-15T12:00:00', weight: 155, reps: 5, estimated1RM: 181 },
+        { id: 's-3', date: '2026-02-01T12:00:00', weight: 175, reps: 5, estimated1RM: 204 },
+      ]
+    }
+  ]
+}
 
-// Build a reactive mock store
-let exercises: Exercise[] = []
+// Mock store state — isolated in an object so tests interact with an explicit container
+// rather than a bare module-level `let` that can be accidentally shadowed or leaked.
+const mockState = { exercises: [] as Exercise[] }
 
 function getExercisePR(id: string): number {
-  const ex = exercises.find(e => e.id === id)
+  const ex = mockState.exercises.find(e => e.id === id)
   if (!ex || ex.sets.length === 0) return 0
   return Math.max(...ex.sets.map(s => s.estimated1RM))
 }
 
 function getExercisePRSet(id: string): WorkoutSet | null {
-  const ex = exercises.find(e => e.id === id)
+  const ex = mockState.exercises.find(e => e.id === id)
   if (!ex || ex.sets.length === 0) return null
   return ex.sets.reduce((best, s) => s.estimated1RM > best.estimated1RM ? s : best)
 }
 
 function getAllTags(): string[] {
   const tags = new Set<string>()
-  exercises.forEach(e => (e.tags || []).forEach(t => tags.add(t)))
+  mockState.exercises.forEach(e => (e.tags || []).forEach(t => tags.add(t)))
   return [...tags].sort()
 }
 
@@ -127,10 +133,10 @@ const mockUnarchiveExercise = vi.fn()
 
 vi.mock('../../stores/workout', () => ({
   useWorkoutStore: () => ({
-    get exercises() { return exercises },
-    set exercises(v: Exercise[]) { exercises = v },
-    get activeExercises() { return exercises.filter(e => !e.archived_at) },
-    get archivedExercises() { return exercises.filter(e => !!e.archived_at) },
+    get exercises() { return mockState.exercises },
+    set exercises(v: Exercise[]) { mockState.exercises = v },
+    get activeExercises() { return mockState.exercises.filter(e => !e.archived_at) },
+    get archivedExercises() { return mockState.exercises.filter(e => !!e.archived_at) },
     get allTags() { return getAllTags() },
     getExercisePR,
     getExercisePRSet,
@@ -168,7 +174,7 @@ function mountTracker(): VueWrapper {
 
 describe('WorkoutTracker', () => {
   beforeEach(() => {
-    exercises = []
+    mockState.exercises = []
     localStorageMock.clear()
     vi.clearAllMocks()
   })
@@ -209,7 +215,7 @@ describe('WorkoutTracker', () => {
 
   describe('exercise list', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     it('renders all exercises', () => {
@@ -262,14 +268,14 @@ describe('WorkoutTracker', () => {
   // ── archived exercises section (LIFT-434) ─────────────────────
   describe('archived exercises', () => {
     it('does not render the archived section when there are no archived exercises', () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       expect(wrapper.find('.wtArchivedSection').exists()).toBe(false)
     })
 
     it('hides archived exercises from the main list and shows them in the Archived section', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
-      exercises[1].archived_at = '2026-05-01T00:00:00.000Z'
+      mockState.exercises = createExercises()
+      mockState.exercises[1].archived_at = '2026-05-01T00:00:00.000Z'
       const wrapper = mountTracker()
       const items = wrapper.findAll('.wtExerciseItem')
       expect(items.length).toBe(2)
@@ -284,8 +290,8 @@ describe('WorkoutTracker', () => {
     })
 
     it('calls unarchiveExercise when the Unarchive button is clicked', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
-      exercises[0].archived_at = '2026-05-01T00:00:00.000Z'
+      mockState.exercises = createExercises()
+      mockState.exercises[0].archived_at = '2026-05-01T00:00:00.000Z'
       const wrapper = mountTracker()
       await wrapper.find('.wtArchivedToggle').trigger('click')
       await wrapper.find('.wtArchivedActionBtn').trigger('click')
@@ -295,8 +301,8 @@ describe('WorkoutTracker', () => {
     it('omits tags that exist only on archived exercises from the chip bar', () => {
       // 'Legs' lives only on Squat. Archive Squat and 'Legs' should disappear
       // from the chips — otherwise tapping it would filter to an empty list.
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
-      exercises[1].archived_at = '2026-05-01T00:00:00.000Z'
+      mockState.exercises = createExercises()
+      mockState.exercises[1].archived_at = '2026-05-01T00:00:00.000Z'
       const wrapper = mountTracker()
       const chips = wrapper.findAll('.wtTagChip').map(c => c.text())
       const chipText = chips.join(' ')
@@ -308,7 +314,7 @@ describe('WorkoutTracker', () => {
 
   describe('tag filtering', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     function tagChips(wrapper: VueWrapper) {
@@ -388,7 +394,7 @@ describe('WorkoutTracker', () => {
 
   describe('exercise detail modal', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     it('opens detail modal when exercise row is clicked', async () => {
@@ -456,7 +462,7 @@ describe('WorkoutTracker', () => {
 
     it('groups same-date sets into one card', async () => {
       // Add a second set on the same date as the latest (Jan 20)
-      exercises[0].sets.push(
+      mockState.exercises[0].sets.push(
         { id: 's-extra', date: '2026-01-20T14:00:00', weight: 190, reps: 3, estimated1RM: 210 }
       )
       const wrapper = mountTracker()
@@ -472,7 +478,7 @@ describe('WorkoutTracker', () => {
     it('groups sets by local date, not UTC date', async () => {
       // Two sets with the same UTC date prefix but at different times
       // Both should group under the same local date
-      exercises[0].sets = [
+      mockState.exercises[0].sets = [
         { id: 's-a', date: '2026-03-16T10:00:00', weight: 185, reps: 5, estimated1RM: 216 },
         { id: 's-b', date: '2026-03-16T14:30:00', weight: 195, reps: 5, estimated1RM: 228 },
       ]
@@ -538,7 +544,7 @@ describe('WorkoutTracker', () => {
 
   describe('PR history tab', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(PR_EXERCISES))
+      mockState.exercises = createPRExercises()
     })
 
     it('shows PRs tab when multiple PRs exist', async () => {
@@ -631,7 +637,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('calls addExercise with name and tags on save', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       mockAddExercise.mockReturnValue('ex-new')
       const wrapper = mountTracker()
 
@@ -649,7 +655,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('calls addExercise with selected tags', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       mockAddExercise.mockReturnValue('ex-new')
       const wrapper = mountTracker()
 
@@ -686,7 +692,7 @@ describe('WorkoutTracker', () => {
 
   describe('set logging flow', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     it('opens log modal for specific exercise via "+ Log" button', async () => {
@@ -768,11 +774,11 @@ describe('WorkoutTracker', () => {
      * plate calc to *both* render in plate mode.
      */
     it('shows WEIGHT/REPS cards alongside the plate calc in plate mode', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       // Switch the first exercise into plate mode
-      exercises[0].inputMode = 'plates'
-      exercises[0].plateCountMode = 'per-side'
-      exercises[0].barWeight = 45
+      mockState.exercises[0].inputMode = 'plates'
+      mockState.exercises[0].plateCountMode = 'per-side'
+      mockState.exercises[0].barWeight = 45
 
       const wrapper = mountTracker()
       const logBtns = wrapper.findAll('.wtExerciseLogBtn')
@@ -788,7 +794,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('shows plate calculator hint for numpad-mode exercises (LIFT-388)', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       // ex-1 is in default numpad mode (no inputMode set)
       const wrapper = mountTracker()
       const logBtns = wrapper.findAll('.wtExerciseLogBtn')
@@ -800,8 +806,8 @@ describe('WorkoutTracker', () => {
     })
 
     it('hides plate calculator hint when exercise is in plate mode (LIFT-388)', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
-      exercises[0].inputMode = 'plates'
+      mockState.exercises = createExercises()
+      mockState.exercises[0].inputMode = 'plates'
       const wrapper = mountTracker()
       const logBtns = wrapper.findAll('.wtExerciseLogBtn')
       await logBtns[0].trigger('click')
@@ -812,7 +818,7 @@ describe('WorkoutTracker', () => {
 
     it('hides plate calculator hint after dismissal via localStorage (LIFT-388)', async () => {
       localStorageMock.setItem('plate-calc-hint-dismissed', 'true')
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       const logBtns = wrapper.findAll('.wtExerciseLogBtn')
       await logBtns[0].trigger('click')
@@ -822,7 +828,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('dismiss button persists hint dismissal to localStorage (LIFT-388)', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       const logBtns = wrapper.findAll('.wtExerciseLogBtn')
       await logBtns[0].trigger('click')
@@ -846,7 +852,7 @@ describe('WorkoutTracker', () => {
     ]
 
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(FIVE_EXERCISES))
+      mockState.exercises = JSON.parse(JSON.stringify(FIVE_EXERCISES))
     })
 
     it('shows search bar when 5+ exercises exist', () => {
@@ -855,7 +861,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('hides search bar when fewer than 5 exercises', () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES)) // only 3
+      mockState.exercises = createExercises() // only 3
       const wrapper = mountTracker()
       expect(wrapper.find('.wtSearchBar').exists()).toBe(false)
     })
@@ -921,7 +927,7 @@ describe('WorkoutTracker', () => {
 
   describe('delete set with undo', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     it('calls deleteSet when delete button is clicked', async () => {
@@ -964,7 +970,7 @@ describe('WorkoutTracker', () => {
 
   describe('edit set flow', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     it('opens edit modal with pre-filled values when Edit is clicked', async () => {
@@ -1063,7 +1069,7 @@ describe('WorkoutTracker', () => {
 
   describe('accessibility', () => {
     it('log modal has aria-modal and role dialog', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       await wrapper.findAll('.wtExerciseLogBtn')[0].trigger('click')
       await wrapper.vm.$nextTick()
@@ -1074,7 +1080,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('search input has aria-label', () => {
-      exercises = [
+      mockState.exercises = [
         { id: '1', name: 'A', tags: [], sets: [] },
         { id: '2', name: 'B', tags: [], sets: [] },
         { id: '3', name: 'C', tags: [], sets: [] },
@@ -1087,14 +1093,14 @@ describe('WorkoutTracker', () => {
     })
 
     it('log button aria-label renders exercise name dynamically', () => {
-      exercises = [{ id: '1', name: 'Bench Press', tags: [], sets: [] }]
+      mockState.exercises = [{ id: '1', name: 'Bench Press', tags: [], sets: [] }]
       const wrapper = mountTracker()
       const logBtn = wrapper.find('.wtExerciseLogBtn')
       expect(logBtn.attributes('aria-label')).toBe('Log a set for Bench Press')
     })
 
     it('detail modal has aria-modal and role dialog', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       await wrapper.findAll('.wtExerciseRow')[0].trigger('click')
       await wrapper.vm.$nextTick()
@@ -1105,7 +1111,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('tag filter buttons have aria-pressed reflecting active state', () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       // Only actual tag chips have aria-pressed — skip "All", "× Clear",
       // and the tag-manager chip added in the 03-workouts.png restyle.
@@ -1117,7 +1123,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('tag add buttons have aria-label', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       // Open new exercise modal via the exposed helper (retired wtLogBtn).
       const exposed = wrapper.vm as unknown as { openNewExerciseModal?: () => void }
@@ -1128,7 +1134,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('timer visual display has aria-hidden (not aria-live) to prevent per-second announcements', () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       const timerInner = wrapper.find('.wtTimerRingInner')
       if (timerInner.exists()) {
@@ -1138,7 +1144,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('timer has a screen-reader-only aria-live region for milestone announcements', () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       const wrapper = mountTracker()
       const srAnnouncement = wrapper.find('.srOnly[aria-live="polite"]')
       if (srAnnouncement.exists()) {
@@ -1149,7 +1155,7 @@ describe('WorkoutTracker', () => {
 
   describe('rest timer drift correction', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       localStorage.setItem('rest-timer', 'on')
       localStorage.setItem('rest-duration', '90')
       const mockOsc = { connect: vi.fn(), frequency: { value: 0, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() }, start: vi.fn(), stop: vi.fn() }
@@ -1216,7 +1222,7 @@ describe('WorkoutTracker', () => {
 
   describe('view toggle', () => {
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
     })
 
     it('renders Exercises and Timeline toggle buttons when exercises exist', () => {
@@ -1228,7 +1234,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('does not render toggle when no exercises exist', () => {
-      exercises = []
+      mockState.exercises = []
       const wrapper = mountTracker()
       expect(wrapper.find('.wtViewToggle').exists()).toBe(false)
     })
@@ -1330,7 +1336,7 @@ describe('WorkoutTracker', () => {
     }
 
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(TIMELINE_EXERCISES))
+      mockState.exercises = JSON.parse(JSON.stringify(TIMELINE_EXERCISES))
     })
 
     it('renders all sets across exercises sorted by date (newest first)', async () => {
@@ -1370,7 +1376,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('shows empty message when no sets exist', async () => {
-      exercises = [{ id: 'ex-1', name: 'Bench', tags: [], sets: [] }]
+      mockState.exercises = [{ id: 'ex-1', name: 'Bench', tags: [], sets: [] }]
       const wrapper = await mountTimeline()
       expect(wrapper.text()).toContain('No sets logged yet')
     })
@@ -1393,7 +1399,7 @@ describe('WorkoutTracker', () => {
 
     it('hides search bar in timeline view', async () => {
       // Need 5+ exercises for search bar
-      exercises = [
+      mockState.exercises = [
         { id: '1', name: 'A', tags: [], sets: [{ id: 's1', date: '2026-01-01T10:00:00', weight: 100, reps: 5, estimated1RM: 117 }] },
         { id: '2', name: 'B', tags: [], sets: [] },
         { id: '3', name: 'C', tags: [], sets: [] },
@@ -1415,7 +1421,7 @@ describe('WorkoutTracker', () => {
         reps: 5,
         estimated1RM: 158 + i,
       }))
-      exercises = [{ id: 'ex-1', name: 'Bench Press', tags: [], sets }]
+      mockState.exercises = [{ id: 'ex-1', name: 'Bench Press', tags: [], sets }]
     })
 
     it('limits visible timeline entries to 50 initially', async () => {
@@ -1461,7 +1467,7 @@ describe('WorkoutTracker', () => {
         reps: 5,
         estimated1RM: 158 + i * 5,
       }))
-      exercises = [{ id: 'ex-1', name: 'Bench Press', tags: [], sets }]
+      mockState.exercises = [{ id: 'ex-1', name: 'Bench Press', tags: [], sets }]
     })
 
     it('limits visible sets to 10 initially in detail modal', async () => {
@@ -1523,7 +1529,7 @@ describe('WorkoutTracker', () => {
     })
 
     it('does not show "Show all" button when sets are within limit', async () => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES)) // 2 sets on Bench Press
+      mockState.exercises = createExercises() // 2 sets on Bench Press
       const wrapper = mountTracker()
       await wrapper.findAll('.wtExerciseRow')[0].trigger('click')
       await wrapper.vm.$nextTick()
@@ -1561,7 +1567,7 @@ describe('WorkoutTracker', () => {
     }
 
     beforeEach(() => {
-      exercises = JSON.parse(JSON.stringify(EXERCISES))
+      mockState.exercises = createExercises()
       vi.useFakeTimers()
     })
 
@@ -1682,7 +1688,7 @@ describe('WorkoutTracker', () => {
     it('does not arm a long-press while a search query is active (#383)', async () => {
       // Need ≥5 exercises for the search bar to render.
       vi.useRealTimers()
-      exercises = [
+      mockState.exercises = [
         { id: 'ex-1', name: 'Bench Press', tags: ['Chest'], sets: [] },
         { id: 'ex-2', name: 'Squat', tags: ['Legs'], sets: [] },
         { id: 'ex-3', name: 'Deadlift', tags: ['Back'], sets: [] },
@@ -1717,7 +1723,7 @@ describe('WorkoutTracker', () => {
      */
     it('disables drag handles while a search query is active (#383)', async () => {
       vi.useRealTimers()
-      exercises = [
+      mockState.exercises = [
         { id: 'ex-1', name: 'Bench Press', tags: ['Chest'], sets: [] },
         { id: 'ex-2', name: 'Squat', tags: ['Legs'], sets: [] },
         { id: 'ex-3', name: 'Deadlift', tags: ['Back'], sets: [] },


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-590](https://github.com/aschung212/Lift/issues/590)

Picked **LIFT-590** — fix shared mutable state anti-pattern in WorkoutTracker.test.ts, the largest test file (110 tests, 1734 lines).

**Root cause:** A module-level `let exercises: Exercise[] = []` was shared across all test cases via closure in the mock store. While `beforeEach` reset it, the pattern is fragile — any test mutating the array elements (9 instances of `exercises[0].property = ...`) could leak state to subsequent tests if cleanup is missed.

**Fix:**

## Changes
- `src/components/__tests__/WorkoutTracker.test.ts` — 103 insertions, 97 deletions (pure refactor, zero behavior change)

## Verification
- 110/110 WorkoutTracker tests pass
- 1683/1683 full suite tests pass
- Build succeeds
- ESLint clean
- Gemini post-commit review: no issues found

## Commits
- [`e4d0a32`](https://github.com/aschung212/Lift/commit/e4d0a32) test(#590): eliminate shared mutable state in WorkoutTracker tests

## Test Results
- Before: 1683 passing
- After: 1683 passing (0 delta)

---
_Automated by overnight pipeline — Tue May 19 00:09:02 PDT 2026_

## Preview
Test on your phone: https://lift-lacbh5xd1-aschung212-1101s-projects.vercel.app