### PR TITLE
refactor(#520): extract useModal composable from repeated focus-trap boilerplate

### DIFF
--- a/src/components/BodyweightTracker.vue
+++ b/src/components/BodyweightTracker.vue
@@ -236,7 +236,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { ref, computed } from 'vue'
 import { useBodyweightStore } from '../stores/bodyweight'
 import type { BodyweightEntry } from '../stores/bodyweight'
 import { useAnalytics } from '../composables/useAnalytics'

--- a/src/components/BodyweightTracker.vue
+++ b/src/components/BodyweightTracker.vue
@@ -236,14 +236,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useBodyweightStore } from '../stores/bodyweight'
 import type { BodyweightEntry } from '../stores/bodyweight'
 import { useAnalytics } from '../composables/useAnalytics'
 import { useTheme } from '../composables/useTheme'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { useUndoToast } from '../composables/useUndoToast'
-import { useFocusTrap } from '../composables/useFocusTrap'
+import { useModal } from '../composables/useModal'
 import { usePreferencesStore } from '../stores/preferences'
 import { useXPCeremony } from '../composables/useXPCeremony'
 
@@ -256,12 +256,14 @@ const { show: showUndo } = useUndoToast()
 const { logBodyweightXPCeremony } = useXPCeremony()
 
 // ── Modal state ──────────────────────────────────────────────────
-const bwModalFocus = useFocusTrap()
-const showModal = ref(false)
+const weightInputEl = ref<HTMLInputElement | null>(null)
+const { isOpen: showModal, open: openModalTrap, close: closeModalTrap } = useModal({
+  selector: '[aria-labelledby="bw-modal-title"]',
+  onOpen: () => weightInputEl.value?.focus(),
+})
 const editing = ref<string | null>(null) // entry id when editing
 const weight = ref<number | null>(null)
 const date = ref(todayISO())
-const weightInputEl = ref<HTMLInputElement | null>(null)
 
 const dateDisplay = computed(() =>
   new Date(date.value + 'T12:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
@@ -299,25 +301,15 @@ function openModal(entry: BodyweightEntry | null = null) {
     weight.value = null
     date.value = todayISO()
   }
-  showModal.value = true
+  openModalTrap()
 }
 
 function closeModal() {
-  showModal.value = false
+  closeModalTrap()
   editing.value = null
   weight.value = null
   date.value = todayISO()
-  bwModalFocus.deactivate()
 }
-
-watch(showModal, async (open) => {
-  if (open) {
-    await nextTick()
-    const el = document.querySelector<HTMLElement>('[aria-labelledby="bw-modal-title"]')
-    if (el) bwModalFocus.activate(el)
-    weightInputEl.value?.focus()
-  }
-})
 
 const canSave = computed(() => weight.value !== null && weight.value > 0)
 

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -224,7 +224,7 @@
 
   <!-- Exercise Picker Modal -->
   <Teleport to="body">
-    <div v-if="exercisePickerDate" class="repMaxOverlay" @click.self="exercisePickerDate = null" @keydown.escape="exercisePickerDate = null">
+    <div v-if="pickerOpen" class="repMaxOverlay" @click.self="closeExercisePicker" @keydown.escape="closeExercisePicker">
       <div class="repMaxModal" role="dialog" aria-modal="true" aria-labelledby="exercise-picker-title">
         <h2 id="exercise-picker-title">Choose Exercise</h2>
         <div class="wtExPickerList">
@@ -239,7 +239,7 @@
           </button>
         </div>
         <div class="repMaxActions">
-          <button class="repMaxBtn repMaxBtnClose" @click="exercisePickerDate = null">Cancel</button>
+          <button class="repMaxBtn repMaxBtnClose" @click="closeExercisePicker">Cancel</button>
         </div>
       </div>
     </div>
@@ -247,7 +247,7 @@
 
   <!-- Log Set Modal -->
   <Teleport to="body">
-    <div v-if="logModal.open" class="repMaxOverlay" @click.self="closeLogModal" @keydown.escape="closeLogModal">
+    <div v-if="logModalOpen" class="repMaxOverlay" @click.self="closeLogModal" @keydown.escape="closeLogModal">
       <div class="repMaxModal" role="dialog" aria-modal="true" aria-labelledby="cal-modal-title">
         <h2 id="cal-modal-title">{{ store.exercises.find(e => e.id === logModal.exerciseId)?.name || 'Log a Set' }}</h2>
         <p class="wtModalSubtitle">{{ formatSelectedDay(logModal.date) }}</p>
@@ -298,12 +298,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useWorkoutStore } from '../stores/workout'
 import { useAnalytics } from '../composables/useAnalytics'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { usePRBaseline } from '../composables/usePRBaseline'
-import { useFocusTrap } from '../composables/useFocusTrap'
+import { useModal } from '../composables/useModal'
 import { useTagVolume } from '../composables/useTagVolume'
 import { useTagRecovery } from '../composables/useTagRecovery'
 import MuscleGroupChart from './MuscleGroupChart.vue'
@@ -642,44 +642,38 @@ function formatSelectedDay(dateStr: string) {
 }
 
 // ── Log modal ─────────────────────────────────────────────────────
-const calModalFocus = useFocusTrap()
-const pickerFocus = useFocusTrap()
-const logModal = ref<{ open: boolean; date: string; exerciseId: string; weight: number | null; reps: number | null }>({ open: false, date: '', exerciseId: '', weight: null, reps: null })
+const { isOpen: pickerOpen, open: openPicker, close: closePicker } = useModal({
+  selector: '[aria-labelledby="exercise-picker-title"]',
+})
+const { isOpen: logModalOpen, open: openLogTrap, close: closeLogTrap } = useModal({
+  selector: '[aria-labelledby="cal-modal-title"]',
+})
+const logModal = ref<{ date: string; exerciseId: string; weight: number | null; reps: number | null }>({ date: '', exerciseId: '', weight: null, reps: null })
 
 const exercisePickerDate = ref<string | null>(null)
 
 function openLogModal(dateStr: string) {
   exercisePickerDate.value = dateStr
+  openPicker()
 }
-
-watch(exercisePickerDate, async (val) => {
-  if (val) {
-    await nextTick()
-    const el = document.querySelector<HTMLElement>('[aria-labelledby="exercise-picker-title"]')
-    if (el) pickerFocus.activate(el)
-  } else {
-    pickerFocus.deactivate()
-  }
-})
 
 function pickExercise(exerciseId: string) {
   const dateStr = exercisePickerDate.value!
   exercisePickerDate.value = null
-  logModal.value = { open: true, date: dateStr, exerciseId, weight: null, reps: null }
+  closePicker()
+  logModal.value = { date: dateStr, exerciseId, weight: null, reps: null }
+  openLogTrap()
 }
 
 function closeLogModal() {
-  logModal.value = { open: false, date: '', exerciseId: '', weight: null, reps: null }
-  calModalFocus.deactivate()
+  closeLogTrap()
+  logModal.value = { date: '', exerciseId: '', weight: null, reps: null }
 }
 
-watch(() => logModal.value.open, async (open) => {
-  if (open) {
-    await nextTick()
-    const el = document.querySelector<HTMLElement>('[aria-labelledby="cal-modal-title"]')
-    if (el) calModalFocus.activate(el)
-  }
-})
+function closeExercisePicker() {
+  exercisePickerDate.value = null
+  closePicker()
+}
 
 const logModalEstimate = computed(() => {
   const { weight, reps } = logModal.value

--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    ref="overlayEl"
     class="wcOverlay"
     role="dialog"
     aria-modal="true"
@@ -86,7 +85,7 @@ function openPicker() {
   pickerOpen.value = true
 }
 
-const { open: activateTrap, close: deactivateTrap, trapRef: overlayEl } = useModal()
+const { open: activateTrap, close: deactivateTrap } = useModal({ selector: '.wcOverlay' })
 
 const summary = computed(() => props.summary)
 

--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -72,8 +72,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, nextTick, defineAsyncComponent } from 'vue'
-import { useFocusTrap } from '../composables/useFocusTrap'
+import { computed, onMounted, onUnmounted, ref, defineAsyncComponent } from 'vue'
+import { useModal } from '../composables/useModal'
 import type { SessionSummary } from '../lib/sessionSummary'
 
 const SharePickerSheet = defineAsyncComponent(() => import('./share/SharePickerSheet.vue'))
@@ -86,8 +86,7 @@ function openPicker() {
   pickerOpen.value = true
 }
 
-const focusTrap = useFocusTrap()
-const overlayEl = ref<HTMLElement | null>(null)
+const { open: activateTrap, close: deactivateTrap, trapRef: overlayEl } = useModal()
 
 const summary = computed(() => props.summary)
 
@@ -106,13 +105,12 @@ function onKey(e: KeyboardEvent) {
 onMounted(async () => {
   document.documentElement.classList.add('modal-open')
   window.addEventListener('keydown', onKey)
-  await nextTick()
-  if (overlayEl.value) focusTrap.activate(overlayEl.value)
+  activateTrap()
 })
 onUnmounted(() => {
   document.documentElement.classList.remove('modal-open')
   window.removeEventListener('keydown', onKey)
-  focusTrap.deactivate()
+  deactivateTrap()
 })
 </script>
 

--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    ref="overlayEl"
     class="spOverlay"
     role="dialog"
     aria-modal="true"
@@ -82,7 +81,7 @@ import { useModal } from '../../composables/useModal'
 const props = defineProps<{ summary: SessionSummary }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
-const { open: activateTrap, close: deactivateTrap, trapRef: overlayEl } = useModal()
+const { open: activateTrap, close: deactivateTrap } = useModal({ selector: '.spOverlay' })
 const { currentTheme, resolvedMode } = useTheme()
 const { shareCard, downloadCard, isSharing } = useWorkoutShare()
 

--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -71,19 +71,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, nextTick, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { SessionSummary } from '../../lib/sessionSummary'
 import type { CardFormat } from '../../lib/shareImage'
 import { eligibleSquareCards, eligibleStoryCards } from './cardRegistry'
 import { useWorkoutShare } from '../../composables/useWorkoutShare'
 import { useTheme } from '../../composables/useTheme'
-import { useFocusTrap } from '../../composables/useFocusTrap'
+import { useModal } from '../../composables/useModal'
 
 const props = defineProps<{ summary: SessionSummary }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
 
-const overlayEl = ref<HTMLElement | null>(null)
-const focusTrap = useFocusTrap()
+const { open: activateTrap, close: deactivateTrap, trapRef: overlayEl } = useModal()
 const { currentTheme, resolvedMode } = useTheme()
 const { shareCard, downloadCard, isSharing } = useWorkoutShare()
 
@@ -147,12 +146,11 @@ async function onSave() {
 // `modal-open` is also owned by the parent. The picker doesn't toggle
 // it — doing so would re-enable background scroll the moment the picker
 // closes even though the parent is still up.
-onMounted(async () => {
-  await nextTick()
-  if (overlayEl.value) focusTrap.activate(overlayEl.value)
+onMounted(() => {
+  activateTrap()
 })
 onUnmounted(() => {
-  focusTrap.deactivate()
+  deactivateTrap()
 })
 </script>
 

--- a/src/composables/__tests__/useModal.test.ts
+++ b/src/composables/__tests__/useModal.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { nextTick } from 'vue'
+import { useModal } from '../useModal'
+
+// Mock onUnmounted since we're not in a Vue component context
+vi.mock('vue', async () => {
+  const actual = await vi.importActual('vue')
+  return { ...actual as object, onUnmounted: vi.fn() }
+})
+
+function createModal(id: string): HTMLElement {
+  const el = document.createElement('div')
+  el.setAttribute('aria-labelledby', id)
+  el.innerHTML = '<button>OK</button><button>Cancel</button>'
+  document.body.appendChild(el)
+  return el
+}
+
+describe('useModal', () => {
+  let modalEl: HTMLElement | null = null
+
+  afterEach(() => {
+    modalEl?.remove()
+    modalEl = null
+  })
+
+  it('starts closed', () => {
+    const { isOpen } = useModal()
+    expect(isOpen.value).toBe(false)
+  })
+
+  it('opens and closes via open()/close()', () => {
+    const { isOpen, open, close } = useModal()
+    open()
+    expect(isOpen.value).toBe(true)
+    close()
+    expect(isOpen.value).toBe(false)
+  })
+
+  it('activates focus trap on open via selector', async () => {
+    modalEl = createModal('test-title')
+    const { open, close } = useModal({
+      selector: '[aria-labelledby="test-title"]',
+    })
+
+    open()
+    await nextTick()
+    // Wait for the internal watch → nextTick
+    await nextTick()
+
+    // Focus trap should have moved focus into the modal
+    expect(document.activeElement).toBe(modalEl.querySelector('button'))
+
+    close()
+    await nextTick()
+  })
+
+  it('activates focus trap on open via trapRef', async () => {
+    modalEl = document.createElement('div')
+    modalEl.innerHTML = '<input id="first" /><button>OK</button>'
+    document.body.appendChild(modalEl)
+
+    const { open, close, trapRef } = useModal()
+    trapRef.value = modalEl
+
+    open()
+    await nextTick()
+    await nextTick()
+
+    expect(document.activeElement).toBe(modalEl.querySelector('#first'))
+
+    close()
+    await nextTick()
+  })
+
+  it('calls onOpen callback after activation', async () => {
+    modalEl = createModal('cb-test')
+    const onOpen = vi.fn()
+    const { open, close } = useModal({
+      selector: '[aria-labelledby="cb-test"]',
+      onOpen,
+    })
+
+    open()
+    await nextTick()
+    await nextTick()
+
+    expect(onOpen).toHaveBeenCalledOnce()
+
+    close()
+    await nextTick()
+  })
+
+  it('calls onClose callback on close', async () => {
+    modalEl = createModal('close-test')
+    const onClose = vi.fn()
+    const { open, close } = useModal({
+      selector: '[aria-labelledby="close-test"]',
+      onClose,
+    })
+
+    open()
+    await nextTick()
+    await nextTick()
+
+    close()
+    await nextTick()
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('restores focus to previously focused element on close', async () => {
+    const trigger = document.createElement('button')
+    trigger.textContent = 'Trigger'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    modalEl = createModal('restore-test')
+    const { open, close } = useModal({
+      selector: '[aria-labelledby="restore-test"]',
+    })
+
+    open()
+    await nextTick()
+    await nextTick()
+    expect(document.activeElement).not.toBe(trigger)
+
+    close()
+    await nextTick()
+    expect(document.activeElement).toBe(trigger)
+
+    trigger.remove()
+  })
+
+  it('does not activate trap when no element matches selector', async () => {
+    const onOpen = vi.fn()
+    const { open, close } = useModal({
+      selector: '[aria-labelledby="nonexistent"]',
+      onOpen,
+    })
+
+    open()
+    await nextTick()
+    await nextTick()
+
+    // onOpen still called — component may need to do other setup
+    expect(onOpen).toHaveBeenCalledOnce()
+
+    close()
+    await nextTick()
+  })
+})

--- a/src/composables/useModal.ts
+++ b/src/composables/useModal.ts
@@ -1,0 +1,57 @@
+import { ref, watch, nextTick, type Ref } from 'vue'
+import { useFocusTrap } from './useFocusTrap'
+
+export interface UseModalOptions {
+  /**
+   * CSS selector to find the modal element for focus trapping.
+   * If not provided, `trapRef` template ref is used instead.
+   */
+  selector?: string
+
+  /**
+   * Called after the modal opens and focus trap activates.
+   */
+  onOpen?: () => void
+
+  /**
+   * Called after the modal closes and focus trap deactivates.
+   */
+  onClose?: () => void
+}
+
+/**
+ * Encapsulates the repeated modal open/focus-trap/close boilerplate.
+ *
+ * Handles: watch → nextTick → querySelector/ref → activate focus trap,
+ * and deactivate on close. Components just call open()/close() and
+ * register lifecycle callbacks via options.
+ */
+export function useModal(options: UseModalOptions = {}) {
+  const isOpen = ref(false)
+  const trapRef = ref<HTMLElement | null>(null) as Ref<HTMLElement | null>
+  const focusTrap = useFocusTrap()
+
+  function open() {
+    isOpen.value = true
+  }
+
+  function close() {
+    isOpen.value = false
+  }
+
+  watch(isOpen, async (open) => {
+    if (open) {
+      await nextTick()
+      const el = options.selector
+        ? document.querySelector<HTMLElement>(options.selector)
+        : trapRef.value
+      if (el) focusTrap.activate(el)
+      options.onOpen?.()
+    } else {
+      focusTrap.deactivate()
+      options.onClose?.()
+    }
+  })
+
+  return { isOpen, open, close, trapRef }
+}


### PR DESCRIPTION
## Summary
Extracts the duplicated modal open/focus-trap/close boilerplate into a `useModal` composable. The watch → nextTick → querySelector → activate/deactivate cycle was repeated (~30-40 lines) across BodyweightTracker, CalendarView, WorkoutCompleteView, and SharePickerSheet. Includes 8 unit tests.

## Provenance
Salvaged from the 2026-05-19 overnight builder run. The builder produced this work but stranded it on a non-standard branch because of a PR-pipeline bug (pre-pick parsing broken by a Bun stderr warning → no issue steering → builder created its own branch off the pipeline's `enhance/runN` branch). The pipeline has been fixed; this PR recovers the otherwise-lost work.

Closes #520

## Test plan
- [ ] 8 useModal unit tests pass
- [ ] Manual: open/close each migrated modal, verify focus trap + restoration