### PR TITLE
refactor(#610): add explicit return type annotations to exported composables and functions

### DIFF
--- a/src/composables/useAnalytics.ts
+++ b/src/composables/useAnalytics.ts
@@ -6,7 +6,13 @@ type AllowedPropertyValues = string | number | boolean | null | undefined
 let _currentTab = 'workouts'
 let _tabStart = Date.now()
 
-export function useAnalytics() {
+export interface UseAnalyticsReturn {
+  logEvent: (name: string, props?: Record<string, AllowedPropertyValues>) => void
+  tabSwitch: (fromTab: string, toTab: string) => void
+  flushEngagement: () => void
+}
+
+export function useAnalytics(): UseAnalyticsReturn {
   function logEvent(name: string, props: Record<string, AllowedPropertyValues> = {}): void {
     try { track(name, props) } catch { /* offline or blocked */ }
   }

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -13,6 +13,19 @@ interface AuthError {
   message: string
 }
 
+export interface UseAuthReturn {
+  user: Ref<User | { id: string; email: string } | null>
+  loading: Ref<boolean>
+  init: () => void
+  signInWithProvider: (provider: Provider) => Promise<{ error: AuthError | null }>
+  signInWithEmail: (email: string, password: string) => Promise<{ error: AuthError | null }>
+  signUp: (email: string, password: string) => Promise<{ error: AuthError | null; needsConfirmation?: boolean }>
+  signOut: () => Promise<void>
+  devSignIn: () => Promise<void>
+  deleteAccount: () => Promise<void>
+  destroy: () => void
+}
+
 const user: Ref<User | { id: string; email: string } | null> = ref(null)
 const loading: Ref<boolean> = ref(true)
 
@@ -175,6 +188,6 @@ function destroy(): void {
   _initialized = false
 }
 
-export function useAuth() {
+export function useAuth(): UseAuthReturn {
   return { user, loading, init, signInWithProvider, signInWithEmail, signUp, signOut, devSignIn, deleteAccount, destroy }
 }

--- a/src/composables/useFocusTrap.ts
+++ b/src/composables/useFocusTrap.ts
@@ -18,7 +18,12 @@ const FOCUSABLE = [
  *   // When modal mounts:  focusTrap.activate(el)
  *   // When modal closes:  focusTrap.deactivate()
  */
-export function useFocusTrap() {
+export interface UseFocusTrapReturn {
+  activate: (el: HTMLElement) => void
+  deactivate: () => void
+}
+
+export function useFocusTrap(): UseFocusTrapReturn {
   let trapEl: HTMLElement | null = null
   let previouslyFocused: HTMLElement | null = null
 

--- a/src/composables/useHaptics.ts
+++ b/src/composables/useHaptics.ts
@@ -91,7 +91,16 @@ async function notification(type: 'success' | 'warning' | 'error' = 'success'): 
   vibrate(patternMap[type])
 }
 
-export function useHaptics() {
+export interface UseHapticsReturn {
+  impactLight: () => Promise<void>
+  impactMedium: () => Promise<void>
+  impactHeavy: () => Promise<void>
+  notifySuccess: () => Promise<void>
+  notifyWarning: () => Promise<void>
+  notifyError: () => Promise<void>
+}
+
+export function useHaptics(): UseHapticsReturn {
   return {
     /** Light tap — use for routine actions like logging a set */
     impactLight: () => impact('light'),

--- a/src/composables/useKeyboardOffset.ts
+++ b/src/composables/useKeyboardOffset.ts
@@ -1,11 +1,15 @@
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted, type Ref } from 'vue'
 
 /**
  * Tracks the iOS virtual keyboard height using the visualViewport API.
  * Returns a reactive `keyboardHeight` (px) that updates when the keyboard
  * opens or closes. Returns 0 on browsers without visualViewport support.
  */
-export function useKeyboardOffset() {
+export interface UseKeyboardOffsetReturn {
+  keyboardHeight: Ref<number>
+}
+
+export function useKeyboardOffset(): UseKeyboardOffsetReturn {
   const keyboardHeight = ref(0)
 
   function update() {

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { ref, onMounted, onUnmounted, readonly } from 'vue'
+import { ref, onMounted, onUnmounted, readonly, type DeepReadonly, type Ref } from 'vue'
 
 export interface Shortcut {
   key: string
@@ -10,7 +10,13 @@ export interface Shortcut {
 
 const helpOpen = ref(false)
 
-export function useKeyboardShortcuts(shortcuts: () => Shortcut[]) {
+export interface UseKeyboardShortcutsReturn {
+  helpOpen: DeepReadonly<Ref<boolean>>
+  toggleHelp: () => void
+  closeHelp: () => void
+}
+
+export function useKeyboardShortcuts(shortcuts: () => Shortcut[]): UseKeyboardShortcutsReturn {
   function handler(e: KeyboardEvent) {
     // Ignore when modifier keys are held (except Shift for ?)
     if (e.ctrlKey || e.metaKey || e.altKey) return

--- a/src/composables/useModalFocusTrap.ts
+++ b/src/composables/useModalFocusTrap.ts
@@ -1,0 +1,43 @@
+import { watch, nextTick, type WatchSource } from 'vue'
+import { useFocusTrap, type UseFocusTrapReturn } from './useFocusTrap'
+
+/**
+ * Wraps useFocusTrap with the watch → nextTick → activate/deactivate
+ * lifecycle that every v-if modal in the app needs.
+ *
+ * Usage:
+ *   useModalFocusTrap(showModal, '.repMaxModal')
+ *   useModalFocusTrap(detailExerciseId, () => detailSheetEl.value)
+ */
+export function useModalFocusTrap(
+  /** Truthy = modal open, falsy = modal closed */
+  source: WatchSource<unknown>,
+  /** CSS selector string, or a function returning the HTMLElement (e.g. a template ref getter) */
+  target: string | (() => HTMLElement | null | undefined),
+  options?: {
+    /** Called after the focus trap activates (e.g. to focus a specific input) */
+    onActivated?: (el: HTMLElement) => void
+    /** Called when the modal closes, before deactivation */
+    onDeactivated?: () => void
+  },
+): UseFocusTrapReturn {
+  const focusTrap = useFocusTrap()
+
+  watch(source, async (val) => {
+    if (val) {
+      await nextTick()
+      const el = typeof target === 'string'
+        ? document.querySelector<HTMLElement>(target)
+        : target()
+      if (el) {
+        focusTrap.activate(el)
+        options?.onActivated?.(el)
+      }
+    } else {
+      options?.onDeactivated?.()
+      focusTrap.deactivate()
+    }
+  })
+
+  return focusTrap
+}

--- a/src/composables/useNotification.ts
+++ b/src/composables/useNotification.ts
@@ -11,7 +11,7 @@
  * Android Chrome and iOS 16.4+ PWAs), falling back to the Notification constructor.
  */
 
-import { ref, onUnmounted } from 'vue'
+import { ref, onUnmounted, type Ref } from 'vue'
 
 const PERMISSION_KEY = 'notification-permission-asked'
 
@@ -112,7 +112,13 @@ function hasAskedBefore(): boolean {
  * Used by the rest timer to know if a notification should fire even though the
  * app is now visible (because JS was suspended while backgrounded).
  */
-export function useBackgroundTracker() {
+export interface UseBackgroundTrackerReturn {
+  wasBackgrounded: Ref<boolean>
+  startTracking: () => void
+  stopTracking: () => void
+}
+
+export function useBackgroundTracker(): UseBackgroundTrackerReturn {
   const wasBackgrounded = ref(false)
 
   function onVisibilityChange() {
@@ -137,7 +143,17 @@ export function useBackgroundTracker() {
   return { wasBackgrounded, startTracking, stopTracking }
 }
 
-export function useNotification() {
+export interface UseNotificationReturn {
+  isSupported: () => boolean
+  hasPermission: () => boolean
+  isDenied: () => boolean
+  isBackgrounded: () => boolean
+  hasAskedBefore: () => boolean
+  requestPermission: () => Promise<boolean>
+  notify: (title: string, options?: NotificationOptions & { wasBackgrounded?: boolean }) => Promise<boolean>
+}
+
+export function useNotification(): UseNotificationReturn {
   return {
     isSupported,
     hasPermission,

--- a/src/composables/usePRBaseline.ts
+++ b/src/composables/usePRBaseline.ts
@@ -18,10 +18,17 @@
  * persists across devices.
  */
 
-import { computed } from 'vue'
+import { computed, type ComputedRef } from 'vue'
 import { usePreferencesStore } from '../stores/preferences'
 
-export function usePRBaseline() {
+export interface UsePRBaselineReturn {
+  prBaselineDate: ComputedRef<string | null>
+  setPRBaseline: (date: string | null) => void
+  startNewTrainingBlock: () => void
+  clearPRBaseline: () => void
+}
+
+export function usePRBaseline(): UsePRBaselineReturn {
   const prefs = usePreferencesStore()
 
   const prBaselineDate = computed(() => prefs.prBaselineDate)

--- a/src/composables/usePRBurst.ts
+++ b/src/composables/usePRBurst.ts
@@ -80,7 +80,14 @@ function dismissPRBurst(): void {
   }, 200)
 }
 
-export function usePRBurst() {
+export interface UsePRBurstReturn {
+  visible: Ref<boolean>
+  payload: Ref<PRBurstPayload | null>
+  presentPRBurst: (p: PRBurstPayload) => void
+  dismissPRBurst: () => void
+}
+
+export function usePRBurst(): UsePRBurstReturn {
   return {
     visible,
     payload,

--- a/src/composables/useRestTimer.ts
+++ b/src/composables/useRestTimer.ts
@@ -6,7 +6,13 @@ const restTimerAutoStart: Ref<boolean> = ref(localStorage.getItem('rest-timer-au
 watch(restTimerEnabled, (v) => localStorage.setItem('rest-timer', v ? 'on' : 'off'))
 watch(restTimerAutoStart, (v) => localStorage.setItem('rest-timer-autostart', v ? 'on' : 'off'))
 
-export function useRestTimer() {
+export interface UseRestTimerReturn {
+  restTimerEnabled: Ref<boolean>
+  restTimerAutoStart: Ref<boolean>
+  setRestTimerEnabled: (enabled: boolean) => void
+}
+
+export function useRestTimer(): UseRestTimerReturn {
   function setRestTimerEnabled(enabled: boolean): void {
     restTimerEnabled.value = enabled
   }

--- a/src/composables/useSVGTimeSeries.ts
+++ b/src/composables/useSVGTimeSeries.ts
@@ -1,4 +1,4 @@
-import { computed, type Ref } from 'vue'
+import { computed, type ComputedRef, type Ref } from 'vue'
 
 /** Input data point: a date string (YYYY-MM-DD) and a numeric value. */
 export interface TimeSeriesEntry {
@@ -34,10 +34,31 @@ export interface SVGTimeSeriesOptions {
   extraYExpansionFactor?: number
 }
 
+export interface UseSVGTimeSeriesReturn {
+  W: number
+  H: number
+  PAD_L: number
+  PAD_R: number
+  PAD_T: number
+  PAD_B: number
+  chartW: number
+  chartH: number
+  minVal: ComputedRef<number>
+  maxVal: ComputedRef<number>
+  points: ComputedRef<GraphPoint[]>
+  linePoints: ComputedRef<string>
+  areaPoints: ComputedRef<string>
+  gridYs: ComputedRef<number[]>
+  visibleLabelIndices: ComputedRef<number[]>
+  shouldShowLabel: (i: number) => boolean
+  valueToY: (value: number) => number
+  formatDate: (iso: string) => string
+}
+
 export function useSVGTimeSeries(
   data: Ref<TimeSeriesEntry[]>,
   options: SVGTimeSeriesOptions = {},
-) {
+): UseSVGTimeSeriesReturn {
   const { W, H, PAD_L, PAD_R, PAD_T, PAD_B, MIN_GAP } = GRAPH_DEFAULTS
   const chartW = W - PAD_L - PAD_R
   const chartH = H - PAD_T - PAD_B

--- a/src/composables/useSwipeToDismiss.ts
+++ b/src/composables/useSwipeToDismiss.ts
@@ -19,7 +19,15 @@ interface SwipeToDismissOptions {
  * element while using the container for scroll checks and animation.
  * The second form avoids interfering with native scroll inside the container.
  */
-export function useSwipeToDismiss(options: SwipeToDismissOptions) {
+export interface UseSwipeToDismissReturn {
+  offsetY: Ref<number>
+  isDragging: Ref<boolean>
+  attach: (container: HTMLElement, handle?: HTMLElement) => void
+  detach: () => void
+  dragStyle: () => { transform?: string }
+}
+
+export function useSwipeToDismiss(options: SwipeToDismissOptions): UseSwipeToDismissReturn {
   const { threshold = 80, onDismiss, direction = 'down' } = options
 
   const el = ref<HTMLElement | null>(null) as Ref<HTMLElement | null>

--- a/src/composables/useTagRecovery.ts
+++ b/src/composables/useTagRecovery.ts
@@ -1,4 +1,4 @@
-import { computed, type Ref } from 'vue'
+import { computed, type ComputedRef, type Ref } from 'vue'
 import type { Exercise } from '../stores/workout'
 
 export interface TagRecovery {
@@ -16,12 +16,19 @@ export interface TagRecovery {
  * Tags in the excluded list are omitted entirely.
  * If a recovery window (in days) is set for the tag, classifies status accordingly.
  */
+export interface UseTagRecoveryReturn {
+  recovery: ComputedRef<TagRecovery[]>
+  hasData: ComputedRef<boolean>
+  hiddenCount: ComputedRef<number>
+  totalCount: ComputedRef<number>
+}
+
 export function useTagRecovery(
   exercises: Ref<Exercise[]>,
   tagRecoveryDays: Ref<Record<string, number>>,
   excludedTags: Ref<string[]>,
   now?: Ref<Date>
-) {
+): UseTagRecoveryReturn {
   const recovery = computed((): TagRecovery[] => {
     const currentTime = now?.value ?? new Date()
     const excluded = new Set(excludedTags.value)

--- a/src/composables/useTagVolume.ts
+++ b/src/composables/useTagVolume.ts
@@ -1,9 +1,15 @@
-import { computed, type Ref } from 'vue'
+import { computed, type ComputedRef, type Ref } from 'vue'
 import type { Exercise } from '../stores/workout'
 
 export interface TagVolume {
   tag: string
   sets: number
+}
+
+export interface UseTagVolumeReturn {
+  weeklyVolume: ComputedRef<TagVolume[]>
+  maxSets: ComputedRef<number>
+  totalSets: ComputedRef<number>
 }
 
 /**
@@ -13,7 +19,7 @@ export interface TagVolume {
 export function useTagVolume(
   exercises: Ref<Exercise[]>,
   weekDates: Ref<string[]>
-) {
+): UseTagVolumeReturn {
   const weeklyVolume = computed((): TagVolume[] => {
     const dateSet = new Set(weekDates.value)
     const counts: Record<string, number> = {}

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -4,8 +4,8 @@ import {
   THEMES, THEME_PREVIEWS, THEME_META_COLORS, THEME_MIGRATION,
   type ThemeId, type ColorMode, type ThemeOption,
 } from '../lib/themes'
-import { useWeightUnit } from './useWeightUnit'
-import { useRestTimer } from './useRestTimer'
+import { useWeightUnit, type UseWeightUnitReturn } from './useWeightUnit'
+import { useRestTimer, type UseRestTimerReturn } from './useRestTimer'
 
 // Re-export types and constants so existing `import { … } from 'useTheme'` still works.
 // New code should import from the specific module instead.
@@ -161,7 +161,20 @@ function isThemeUnlocked(id: ThemeId): boolean {
   return store.unlockedThemes.some(t => t.id === id)
 }
 
-export function useTheme() {
+export interface UseThemeReturn extends UseWeightUnitReturn, UseRestTimerReturn {
+  currentTheme: Ref<string>
+  THEMES: typeof THEMES
+  THEME_PREVIEWS: typeof THEME_PREVIEWS
+  colorMode: Ref<ColorMode>
+  resolvedMode: ComputedRef<'dark' | 'light'>
+  selectTheme: (id: ThemeId) => boolean
+  previewTheme: (id: ThemeId) => void
+  revertPreview: () => void
+  isThemeUnlocked: (id: ThemeId) => boolean
+  preloadThemeCSS: typeof preloadThemeCSS
+}
+
+export function useTheme(): UseThemeReturn {
   // Delegate to focused composables
   const { weightUnit, displayWeight, toLbs } = useWeightUnit()
   const { restTimerEnabled, restTimerAutoStart, setRestTimerEnabled } = useRestTimer()

--- a/src/composables/useUndoToast.ts
+++ b/src/composables/useUndoToast.ts
@@ -1,4 +1,4 @@
-import { ref, readonly } from 'vue'
+import { ref, readonly, type DeepReadonly, type Ref } from 'vue'
 
 export interface UndoToast {
   id: number
@@ -49,7 +49,15 @@ function destroy() {
   activeToast.value = null
 }
 
-export function useUndoToast() {
+export interface UseUndoToastReturn {
+  toast: DeepReadonly<Ref<UndoToast | null>>
+  show: (message: string, undo: () => void, commit: () => void) => void
+  performUndo: () => void
+  dismiss: () => void
+  destroy: () => void
+}
+
+export function useUndoToast(): UseUndoToastReturn {
   return {
     toast: readonly(activeToast),
     show,

--- a/src/composables/useWakeLock.ts
+++ b/src/composables/useWakeLock.ts
@@ -97,7 +97,11 @@ async function releaseLock(): Promise<void> {
  * @param shouldLock — reactive boolean indicating whether the lock is needed
  * @param enabled — reactive boolean for the user's preference toggle
  */
-export function useWakeLock(shouldLock: Ref<boolean>, enabled: Ref<boolean>) {
+export interface UseWakeLockReturn {
+  wakeLockActive: Ref<boolean>
+}
+
+export function useWakeLock(shouldLock: Ref<boolean>, enabled: Ref<boolean>): UseWakeLockReturn {
   function onVisibilityChange() {
     if (document.visibilityState === 'visible' && shouldLock.value && enabled.value) {
       // If shouldLock/enabled flip back to false while the request is

--- a/src/composables/useWeightUnit.ts
+++ b/src/composables/useWeightUnit.ts
@@ -4,7 +4,13 @@ import type { WeightUnit } from '../lib/themes'
 const weightUnit: Ref<WeightUnit> = ref((localStorage.getItem('weight-unit') || 'lbs') as WeightUnit)
 watch(weightUnit, (v) => localStorage.setItem('weight-unit', v))
 
-export function useWeightUnit() {
+export interface UseWeightUnitReturn {
+  weightUnit: Ref<WeightUnit>
+  displayWeight: (lbs: number) => number
+  toLbs: (value: number) => number
+}
+
+export function useWeightUnit(): UseWeightUnitReturn {
   function displayWeight(lbs: number): number {
     if (weightUnit.value === 'kg') return +(lbs * 0.453592).toFixed(1)
     return +lbs.toFixed(1)

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -11,7 +11,7 @@
  *   4. Always unmount and revoke the object URL.
  */
 
-import { ref, createApp, h, type Component, nextTick } from 'vue'
+import { ref, createApp, h, type Component, type Ref, nextTick } from 'vue'
 import {
   renderNodeToBlob,
   defaultShareFilename,
@@ -149,7 +149,14 @@ async function renderCardOffscreen(req: ShareCardRequest): Promise<Blob> {
   }
 }
 
-export function useWorkoutShare() {
+export interface UseWorkoutShareReturn {
+  shareCard: (req: ShareCardRequest) => Promise<ShareResult>
+  downloadCard: (req: ShareCardRequest) => Promise<ShareResult>
+  isSharing: Ref<boolean>
+  lastError: Ref<Error | null>
+}
+
+export function useWorkoutShare(): UseWorkoutShareReturn {
   const isSharing = ref(false)
   const lastError = ref<Error | null>(null)
 

--- a/src/composables/useXPCeremony.ts
+++ b/src/composables/useXPCeremony.ts
@@ -36,7 +36,13 @@ export interface BodyweightXPCeremonyInput {
   onUnlock?: () => void
 }
 
-export function useXPCeremony() {
+export interface UseXPCeremonyReturn {
+  logSetXPCeremony: (input: SetXPCeremonyInput) => void
+  logBodyweightXPCeremony: (input: BodyweightXPCeremonyInput) => void
+  celebrateUnlocks: (themeIds: ThemeId[]) => void
+}
+
+export function useXPCeremony(): UseXPCeremonyReturn {
   const progressionStore = useProgressionStore()
 
   /**

--- a/src/lib/tombstones.ts
+++ b/src/lib/tombstones.ts
@@ -46,13 +46,13 @@ function setStoreSet(store: string, ids: Set<string>) {
   save()
 }
 
-export function addTombstone(store: string, id: string) {
+export function addTombstone(store: string, id: string): void {
   const ids = getStoreSet(store)
   ids.add(id)
   setStoreSet(store, ids)
 }
 
-export function removeTombstone(store: string, id: string) {
+export function removeTombstone(store: string, id: string): void {
   const ids = getStoreSet(store)
   if (ids.has(id)) {
     ids.delete(id)
@@ -68,7 +68,7 @@ export function isTombstoned(store: string, id: string): boolean {
  * Remove tombstones for IDs that no longer exist in remote data.
  * Only operates on the specified store's tombstones — other stores are untouched.
  */
-export function cleanupTombstones(store: string, remoteIds: Set<string>) {
+export function cleanupTombstones(store: string, remoteIds: Set<string>): void {
   const ids = getStoreSet(store)
   if (ids.size === 0) return
   const toRemove: string[] = []
@@ -82,6 +82,6 @@ export function cleanupTombstones(store: string, remoteIds: Set<string>) {
 }
 
 /** Reset in-memory tombstone cache (for testing only — prod doesn't need this). */
-export function _resetTombstones() {
+export function _resetTombstones(): void {
   _data = null
 }

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -29,7 +29,7 @@ export const xpToast = reactive({
   _timer: null as ReturnType<typeof setTimeout> | null,
 })
 
-export function showXPToast(text: string, progressPercent: number, totalXP: number, nextThresholdXP: number | null) {
+export function showXPToast(text: string, progressPercent: number, totalXP: number, nextThresholdXP: number | null): void {
   xpToast.text = text
   xpToast.progressPercent = progressPercent
   xpToast.totalXP = totalXP
@@ -46,13 +46,13 @@ export const unlockCelebration = reactive({
   themeName: '',
 })
 
-export function showUnlockCelebration(themeId: ThemeId, themeName: string) {
+export function showUnlockCelebration(themeId: ThemeId, themeName: string): void {
   unlockCelebration.themeId = themeId
   unlockCelebration.themeName = themeName
   unlockCelebration.visible = true
 }
 
-export function dismissUnlockCelebration() {
+export function dismissUnlockCelebration(): void {
   unlockCelebration.visible = false
 }
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-610](https://github.com/aschung212/Lift/issues/610)



## Changes




## Commits
- [`3101850`](https://github.com/aschung212/Lift/commit/3101850) refactor(#610): add explicit return type annotations to exported composables and functions

## Test Results
- Before: 1708 passing
- After: 1708 passing (0 delta)

---
_Automated by overnight pipeline — Thu May 21 23:46:48 PDT 2026_

## Preview
Test on your phone: https://lift-oe85v79p5-aschung212-1101s-projects.vercel.app