### PR TITLE
refactor(#612): add runtime validation to preferences migration function

### DIFF
--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { usePreferencesStore } from '../preferences'
+import { usePreferencesStore, _migrateWeightGoal } from '../preferences'
 import { getLocalStorageMock } from '../../__tests__/helpers'
 
 vi.mock('../../lib/durableStorage', () => ({
@@ -327,6 +327,125 @@ describe('usePreferencesStore', () => {
 
       expect(freshStore.experience.prCelebrations).toBe(true)
       expect(freshStore.experience.haptics).toBe(true)
+    })
+  })
+
+  describe('_migrateWeightGoal runtime validation', () => {
+    it('migrates valid v1 string direction', () => {
+      expect(_migrateWeightGoal('gain')).toEqual({
+        direction: 'gain',
+        loseTarget: null,
+        gainTarget: null,
+        maintainMin: null,
+        maintainMax: null,
+      })
+    })
+
+    it('returns default for unrecognized v1 string', () => {
+      const result = _migrateWeightGoal('bulking')
+      expect(result.direction).toBe('lose') // default
+    })
+
+    it('returns default for null input', () => {
+      const result = _migrateWeightGoal(null)
+      expect(result.direction).toBe('lose')
+      expect(result.loseTarget).toBeNull()
+    })
+
+    it('returns default for undefined input', () => {
+      const result = _migrateWeightGoal(undefined)
+      expect(result.direction).toBe('lose')
+    })
+
+    it('returns default for numeric input', () => {
+      const result = _migrateWeightGoal(42)
+      expect(result.direction).toBe('lose')
+    })
+
+    it('returns default for boolean input', () => {
+      const result = _migrateWeightGoal(true)
+      expect(result.direction).toBe('lose')
+    })
+
+    it('returns default for array input', () => {
+      const result = _migrateWeightGoal([1, 2, 3])
+      expect(result.direction).toBe('lose')
+    })
+
+    it('migrates valid v3 object with all fields', () => {
+      const result = _migrateWeightGoal({
+        direction: 'maintain',
+        loseTarget: 150,
+        gainTarget: 200,
+        maintainMin: 160,
+        maintainMax: 180,
+      })
+      expect(result).toEqual({
+        direction: 'maintain',
+        loseTarget: 150,
+        gainTarget: 200,
+        maintainMin: 160,
+        maintainMax: 180,
+      })
+    })
+
+    it('fills defaults for missing fields in v3 object', () => {
+      const result = _migrateWeightGoal({ direction: 'gain' })
+      expect(result).toEqual({
+        direction: 'gain',
+        loseTarget: null,
+        gainTarget: null,
+        maintainMin: null,
+        maintainMax: null,
+      })
+    })
+
+    it('uses default direction when object has invalid direction', () => {
+      const result = _migrateWeightGoal({ direction: 'shred', loseTarget: 150 })
+      expect(result.direction).toBe('lose')
+      expect(result.loseTarget).toBe(150)
+    })
+
+    it('ignores non-number target values', () => {
+      const result = _migrateWeightGoal({
+        direction: 'lose',
+        loseTarget: 'heavy',
+        gainTarget: true,
+        maintainMin: {},
+      })
+      expect(result.loseTarget).toBeNull()
+      expect(result.gainTarget).toBeNull()
+      expect(result.maintainMin).toBeNull()
+    })
+
+    it('migrates v2 object with targetWeight to loseTarget', () => {
+      const result = _migrateWeightGoal({
+        direction: 'lose',
+        targetWeight: 165,
+      })
+      expect(result.loseTarget).toBe(165)
+    })
+
+    it('migrates v2 object with targetWeight to gainTarget when direction is gain', () => {
+      const result = _migrateWeightGoal({
+        direction: 'gain',
+        targetWeight: 200,
+      })
+      expect(result.gainTarget).toBe(200)
+    })
+
+    it('ignores non-number targetWeight in v2 migration', () => {
+      const result = _migrateWeightGoal({
+        direction: 'lose',
+        targetWeight: 'heavy',
+      })
+      expect(result.loseTarget).toBeNull()
+    })
+
+    it('handles empty object gracefully', () => {
+      const result = _migrateWeightGoal({})
+      expect(result.direction).toBe('lose')
+      expect(result.loseTarget).toBeNull()
     })
   })
 

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -65,19 +65,52 @@ const DEFAULT_FILTERS: FilterSettings = {
   warmupThreshold: 0.75,
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function _migrateWeightGoal(raw: any): WeightGoalConfig {
-  // v1: string ('lose' | 'gain' | 'maintain')
+const VALID_DIRECTIONS: ReadonlySet<string> = new Set(['lose', 'gain', 'maintain'])
+
+function _isValidDirection(value: unknown): value is WeightGoalDirection {
+  return typeof value === 'string' && VALID_DIRECTIONS.has(value)
+}
+
+/**
+ * Migrate weight-goal data from any previous schema version to the current shape.
+ * Exported for testing only — not part of the public API.
+ */
+export function _migrateWeightGoal(raw: unknown): WeightGoalConfig {
+  // v1: bare string direction ('lose' | 'gain' | 'maintain')
   if (typeof raw === 'string') {
-    return { ...DEFAULT_WEIGHT_GOAL, direction: raw as WeightGoalDirection }
+    if (_isValidDirection(raw)) {
+      return { ...DEFAULT_WEIGHT_GOAL, direction: raw }
+    }
+    logError(new Error(`_migrateWeightGoal: unrecognized direction string "${raw}"`), { source: 'preferences.migrate' })
+    return { ...DEFAULT_WEIGHT_GOAL }
   }
-  const goal = { ...DEFAULT_WEIGHT_GOAL, ...raw }
+
+  // Must be a non-null object for v2/v3 shapes
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    logError(new Error(`_migrateWeightGoal: unexpected type ${raw === null ? 'null' : typeof raw}`), { source: 'preferences.migrate' })
+    return { ...DEFAULT_WEIGHT_GOAL }
+  }
+
+  const obj = raw as Record<string, unknown>
+
+  // Validate direction if present
+  const direction: WeightGoalDirection =
+    _isValidDirection(obj.direction) ? obj.direction : DEFAULT_WEIGHT_GOAL.direction
+
+  const goal: WeightGoalConfig = {
+    direction,
+    loseTarget: typeof obj.loseTarget === 'number' ? obj.loseTarget : DEFAULT_WEIGHT_GOAL.loseTarget,
+    gainTarget: typeof obj.gainTarget === 'number' ? obj.gainTarget : DEFAULT_WEIGHT_GOAL.gainTarget,
+    maintainMin: typeof obj.maintainMin === 'number' ? obj.maintainMin : DEFAULT_WEIGHT_GOAL.maintainMin,
+    maintainMax: typeof obj.maintainMax === 'number' ? obj.maintainMax : DEFAULT_WEIGHT_GOAL.maintainMax,
+  }
+
   // v2: had single targetWeight field — migrate to direction-specific
-  if ('targetWeight' in raw && raw.targetWeight != null) {
-    if (goal.direction === 'gain') goal.gainTarget = raw.targetWeight
-    else goal.loseTarget = raw.targetWeight
-    delete (goal as Record<string, unknown>).targetWeight
+  if ('targetWeight' in obj && typeof obj.targetWeight === 'number') {
+    if (goal.direction === 'gain') goal.gainTarget = obj.targetWeight
+    else goal.loseTarget = obj.targetWeight
   }
+
   return goal
 }
 
@@ -182,7 +215,7 @@ export const usePreferencesStore = defineStore('preferences', {
           if (prefs?.features) {
             this.features = { ...DEFAULTS, ...prefs.features as Record<string, boolean> }
             if (prefs.weightGoal) {
-              this.weightGoal = _migrateWeightGoal(prefs.weightGoal as { target?: number; unit?: string })
+              this.weightGoal = _migrateWeightGoal(prefs.weightGoal)
             }
             if (prefs.experience) {
               this.experience = { ...DEFAULT_EXPERIENCE, ...(prefs.experience as Partial<ExperienceFlags>) }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-612](https://github.com/aschung212/Lift/issues/612)

- Implement LIFT-612: Replace `any` with `unknown` in `_migrateWeightGoal`, add exhaustive type guards for all schema versions, return safe defaults for invalid input
- Add comprehensive unit tests for the migration function

## Changes
- `src/stores/preferences.ts`: Replaced `raw: any` with `raw: unknown`, added `_isValidDirection` type guard, exported `_migrateWeightGoal` for testing, added field-level validation for all object properties, removed the eslint-disable comment, removed unnecessary type cast at the Supabase call site
- `src/stores/__tests__/preferences.test.ts`: Added 15 new tests in a `_migrateWeightGoal runtime validation` describe block covering v1 strings (valid/invalid), v2 targetWeight migration, v3 full objects, and malformed inputs (null, undefined, numbers, booleans, arrays, empty objects, non-number fields, invalid direction strings)

## Verification
- 1723 tests pass (83 files) — 15 new tests added
- Build succeeds
- Lint clean (0 errors)
- Gemini post-commit review: no issues found

ISSUE_DONE:LIFT-612:Replaced `any` with `unknown` in _migrateWeightGoal, added exhaustive type narrowing and field-level validation for all migration versions, 15 new unit tests
  📊 Output tokens: 7222 | Nightly total: 11342/500000 | Run 2/12
✅ Run 2 finished at Fri May 22 23:10:31 PDT 2026 — 1 new commit(s)
remote: This repository moved. Please use the new location:        
remote:   https://github.com/aschung212/Lift.git        
remote: 
remote: Create a pull request for 'enhance/LIFT-612-2026-05-22' on GitHub by visiting:        
remote:      https://github.com/aschung212/Lift/pull/new/enhance/LIFT-612-2026-05-22        
remote: 
To https://github.com/aschung212/lift.git
 * [new branch]      enhance/LIFT-612-2026-05-22 -> enhance/LIFT-612-2026-05-22
branch 'enhance/LIFT-612-2026-05-22' set up to track 'origin/enhance/LIFT-612-2026-05-22'.
✅ CI passed (build + tests)

## Commits
- [`edccae2`](https://github.com/aschung212/Lift/commit/edccae2) refactor(#612): add runtime validation to preferences migration function

## Test Results
- Before: 1708 passing
- After: 1723 passing (15 delta)

---
_Automated by overnight pipeline — Fri May 22 23:11:10 PDT 2026_

## Preview
Test on your phone: https://lift-mmzerynfs-aschung212-1101s-projects.vercel.app