### PR TITLE
refactor(#611): type BeforeInstallPromptEvent and remove `any` from useInstallPrompt

### DIFF
--- a/src/composables/__tests__/useInstallPrompt.test.ts
+++ b/src/composables/__tests__/useInstallPrompt.test.ts
@@ -87,8 +87,7 @@ describe('useInstallPrompt', () => {
         configurable: true,
       })
       expect(isStandalone()).toBe(true)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      delete (navigator as any).standalone
+      delete (navigator as unknown as { standalone?: boolean }).standalone
     })
   })
 

--- a/src/composables/useInstallPrompt.ts
+++ b/src/composables/useInstallPrompt.ts
@@ -1,6 +1,17 @@
 import { ref, watch, type Ref, type WatchSource } from 'vue'
 import { isNative, isIOS } from '../lib/platform'
 
+/**
+ * The `beforeinstallprompt` event fired by Chromium browsers.
+ * Not included in TypeScript's lib.dom.d.ts because it is non-standard.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent
+ */
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[]
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+  prompt(): Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
 const DISMISS_KEY = 'install-prompt-dismissed'
 const MIN_WORKOUT_DAYS = 3
 
@@ -44,8 +55,7 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
   const showBanner = ref(false)
   const isIOSPrompt = ref(false)
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let deferredPrompt: any = null
+  let deferredPrompt: BeforeInstallPromptEvent | null = null
   // True when we intercepted beforeinstallprompt but haven't shown the banner yet
   // (waiting for workout data to hydrate past the threshold).
   let hasPendingPrompt = false
@@ -83,8 +93,7 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function onBeforeInstallPrompt(e: any) {
+  function onBeforeInstallPrompt(e: BeforeInstallPromptEvent) {
     // Prevent the browser's mini-infobar
     e.preventDefault()
     deferredPrompt = e
@@ -105,12 +114,14 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     localStorage.setItem(DISMISS_KEY, 'true')
   }
 
-  // Register listeners — cleaned up via destroy() if the consumer unmounts
-  window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+  // Register listeners — cleaned up via destroy() if the consumer unmounts.
+  // 'beforeinstallprompt' is not in WindowEventMap, so we cast the handler.
+  const promptHandler = onBeforeInstallPrompt as EventListener
+  window.addEventListener('beforeinstallprompt', promptHandler)
   window.addEventListener('appinstalled', onAppInstalled)
 
   function destroy() {
-    window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.removeEventListener('beforeinstallprompt', promptHandler)
     window.removeEventListener('appinstalled', onAppInstalled)
   }
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-611](https://github.com/aschung212/Lift/issues/611)

- Implement LIFT-611: Replace `any` with proper `BeforeInstallPromptEvent` interface in `useInstallPrompt.ts`
- Add typed interface, remove eslint-disable comments, clean up test file

## Changes
- **`src/composables/useInstallPrompt.ts`**: Added exported `BeforeInstallPromptEvent` interface extending `Event` with `platforms`, `userChoice`, and `prompt()`. Changed `deferredPrompt` from `any` to `BeforeInstallPromptEvent | null`. Typed `onBeforeInstallPrompt` parameter. Removed two `eslint-disable-next-line` comments. Cast handler as `EventListener` at the `addEventListener` call site (necessary because `beforeinstallprompt` is not in `WindowEventMap`).
- **`src/composables/__tests__/useInstallPrompt.test.ts`**: Replaced `as any` cast with `as unknown as { standalone?: boolean }` for the `delete navigator.standalone` cleanup.

## Verification
- 83/83 test files pass, 1708/1708 tests pass
- ESLint: 0 errors (15 pre-existing warnings, none in changed files)
- Post-commit Gemini 3.1 Pro review: no issues found

ISSUE_DONE:LIFT-611:Typed BeforeInstallPromptEvent interface, replaced all `any` usage in useInstallPrompt composable and tests. PR branch pushed: enhance/run3-2026-05-22.
  📊 Output tokens: 5680 | Nightly total: 17022/500000 | Run 3/12
✅ Run 3 finished at Fri May 22 23:16:45 PDT 2026 — 1 new commit(s)
remote: This repository moved. Please use the new location:        
remote:   https://github.com/aschung212/Lift.git        
remote: 
remote: Create a pull request for 'enhance/LIFT-611-2026-05-22' on GitHub by visiting:        
remote:      https://github.com/aschung212/Lift/pull/new/enhance/LIFT-611-2026-05-22        
remote: 
To https://github.com/aschung212/lift.git
 * [new branch]      enhance/LIFT-611-2026-05-22 -> enhance/LIFT-611-2026-05-22
branch 'enhance/LIFT-611-2026-05-22' set up to track 'origin/enhance/LIFT-611-2026-05-22'.
✅ CI passed (build + tests)

## Commits
- [`78d756a`](https://github.com/aschung212/Lift/commit/78d756a) refactor(#611): type BeforeInstallPromptEvent and remove `any` from useInstallPrompt

## Test Results
- Before: 1708 passing
- After: 1708 passing (0 delta)

---
_Automated by overnight pipeline — Fri May 22 23:17:22 PDT 2026_

## Preview
Test on your phone: https://lift-78oc7ebhi-aschung212-1101s-projects.vercel.app