### PR TITLE
fix(#609): handle empty remote arrays and provide defaults for legacy streak entries

### DIFF
--- a/src/lib/__tests__/jsonColumns.test.ts
+++ b/src/lib/__tests__/jsonColumns.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ThemeUnlock, StreakWeekEntry, SetXPEntry } from '../../stores/progression'
+import {
+  themeUnlocksToJson,
+  streakHistoryToJson,
+  xpPerSetToJson,
+  bodyweightDatesToJson,
+  parseStreakHistory,
+  parseUnlockedThemes,
+  parseXpPerSet,
+  parseBodyweightDates,
+} from '../jsonColumns'
+import type { Json } from '../database.types'
+
+vi.mock('../logger', () => ({
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}))
+
+describe('jsonColumns', () => {
+  // ── Round-trip: write → read ────────────────────────────────────
+
+  describe('ThemeUnlock round-trip', () => {
+    it('round-trips ThemeUnlock[] through toJson/parse', () => {
+      const themes: ThemeUnlock[] = [
+        { id: 'pearl', unlockedAt: '2026-01-01T00:00:00Z' },
+        { id: 'fire', unlockedAt: '2026-02-15T10:30:00Z', totalXPAtUnlock: 5000, totalSetsAtUnlock: 100 },
+      ]
+      const json = themeUnlocksToJson(themes)
+      const parsed = parseUnlockedThemes(json)
+      expect(parsed).toEqual(themes)
+    })
+
+    it('round-trips themes without optional fields', () => {
+      const themes: ThemeUnlock[] = [
+        { id: 'midnight', unlockedAt: '2026-03-01T00:00:00Z' },
+      ]
+      const json = themeUnlocksToJson(themes)
+      const parsed = parseUnlockedThemes(json)
+      expect(parsed).toEqual(themes)
+    })
+  })
+
+  describe('StreakWeekEntry round-trip', () => {
+    it('round-trips StreakWeekEntry[] through toJson/parse', () => {
+      const history: StreakWeekEntry[] = [
+        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+        { weekStart: '2026-01-13', streakCount: 2, weeklyTarget: 4, combinedMultiplier: 1.15 },
+      ]
+      const json = streakHistoryToJson(history)
+      const parsed = parseStreakHistory(json, [])
+      expect(parsed).toEqual(history)
+    })
+  })
+
+  describe('xpPerSet round-trip', () => {
+    it('round-trips mixed SetXPEntry and legacy number entries', () => {
+      const xpPerSet: Record<string, SetXPEntry | number> = {
+        'set-1': { xp: 50, theme: 'fire', epoch: 1, zone: 'strength', isPR: true, isRepPR: false },
+        'set-2': 25,  // legacy number format
+        'set-3': { xp: 100, theme: 'pearl', epoch: 1, zone: 'hypertrophy', isPR: false, isRepPR: true },
+      }
+      const json = xpPerSetToJson(xpPerSet)
+      const parsed = parseXpPerSet(json, {})
+      expect(parsed).toEqual(xpPerSet)
+    })
+
+    it('round-trips empty xpPerSet', () => {
+      const json = xpPerSetToJson({})
+      const parsed = parseXpPerSet(json, {})
+      expect(parsed).toEqual({})
+    })
+  })
+
+  describe('bodyweightXPDates round-trip', () => {
+    it('round-trips string[]', () => {
+      const dates = ['2026-01-01', '2026-01-15', '2026-02-01']
+      const json = bodyweightDatesToJson(dates)
+      const parsed = parseBodyweightDates(json, [])
+      expect(parsed).toEqual(dates)
+    })
+  })
+
+  // ── Parse: invalid/corrupt data ─────────────────────────────────
+
+  describe('parseStreakHistory validation', () => {
+    it('returns fallback for null', () => {
+      const fallback: StreakWeekEntry[] = [
+        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+      ]
+      expect(parseStreakHistory(null, fallback)).toBe(fallback)
+    })
+
+    it('returns fallback for non-array', () => {
+      expect(parseStreakHistory('not-an-array' as Json, [])).toEqual([])
+    })
+
+    it('returns fallback for entries with missing fields', () => {
+      const fallback: StreakWeekEntry[] = []
+      const corrupt: Json = [{ weekStart: '2026-01-06' }]  // missing streakCount, weeklyTarget, combinedMultiplier
+      expect(parseStreakHistory(corrupt, fallback)).toBe(fallback)
+    })
+
+    it('returns fallback for entries with wrong types', () => {
+      const corrupt: Json = [
+        { weekStart: 123, streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+      ]
+      expect(parseStreakHistory(corrupt, [])).toEqual([])
+    })
+
+    it('parses valid empty array', () => {
+      expect(parseStreakHistory([], [])).toEqual([])
+    })
+  })
+
+  describe('parseUnlockedThemes validation', () => {
+    it('returns null for non-array', () => {
+      expect(parseUnlockedThemes('not-array')).toBeNull()
+    })
+
+    it('returns null for empty array', () => {
+      expect(parseUnlockedThemes([])).toBeNull()
+    })
+
+    it('handles legacy string[] format', () => {
+      const result = parseUnlockedThemes(['pearl', 'fire'])
+      expect(result).toHaveLength(2)
+      expect(result![0].id).toBe('pearl')
+      expect(result![1].id).toBe('fire')
+      expect(result![0].unlockedAt).toBeDefined()
+    })
+
+    it('returns null for entries with missing id', () => {
+      const corrupt: Json = [{ unlockedAt: '2026-01-01T00:00:00Z' }]
+      expect(parseUnlockedThemes(corrupt)).toBeNull()
+    })
+
+    it('returns null for entries with missing unlockedAt', () => {
+      const corrupt: Json = [{ id: 'pearl' }]
+      expect(parseUnlockedThemes(corrupt)).toBeNull()
+    })
+  })
+
+  describe('parseXpPerSet validation', () => {
+    it('returns fallback for non-object', () => {
+      expect(parseXpPerSet('not-object' as Json, {})).toEqual({})
+    })
+
+    it('returns fallback for null', () => {
+      expect(parseXpPerSet(null, { 'set-1': 10 })).toEqual({ 'set-1': 10 })
+    })
+
+    it('returns fallback for array', () => {
+      expect(parseXpPerSet([] as Json, {})).toEqual({})
+    })
+
+    it('skips entries with invalid SetXPEntry shape', () => {
+      const corrupt: Json = {
+        'set-1': { xp: 50, theme: 'fire' },  // missing epoch, zone, isPR, isRepPR
+        'set-2': 25,  // valid legacy
+      }
+      const result = parseXpPerSet(corrupt, {})
+      expect(result).toEqual({ 'set-2': 25 })
+    })
+
+    it('skips entries that are neither number nor valid object', () => {
+      const corrupt: Json = {
+        'set-1': 'not-a-number-or-object',
+        'set-2': 25,
+      }
+      const result = parseXpPerSet(corrupt, {})
+      expect(result).toEqual({ 'set-2': 25 })
+    })
+  })
+
+  describe('parseBodyweightDates validation', () => {
+    it('returns fallback for non-array', () => {
+      expect(parseBodyweightDates('not-array' as Json, ['fallback'])).toEqual(['fallback'])
+    })
+
+    it('returns fallback if any entry is not a string', () => {
+      const corrupt: Json = ['2026-01-01', 42, '2026-01-03']
+      expect(parseBodyweightDates(corrupt, [])).toEqual([])
+    })
+
+    it('parses valid empty array', () => {
+      expect(parseBodyweightDates([], [])).toEqual([])
+    })
+  })
+
+  // ── Write helpers produce Json-compatible output ────────────────
+
+  describe('toJson helpers type safety', () => {
+    it('themeUnlocksToJson produces array of plain objects', () => {
+      const result = themeUnlocksToJson([
+        { id: 'pearl', unlockedAt: '2026-01-01T00:00:00Z' },
+      ])
+      expect(Array.isArray(result)).toBe(true)
+      const arr = result as Json[]
+      expect(arr[0]).toEqual({ id: 'pearl', unlockedAt: '2026-01-01T00:00:00Z' })
+    })
+
+    it('themeUnlocksToJson excludes undefined optional fields', () => {
+      const result = themeUnlocksToJson([
+        { id: 'fire', unlockedAt: '2026-01-01T00:00:00Z' },
+      ])
+      const arr = result as Json[]
+      const obj = arr[0] as Record<string, Json | undefined>
+      expect('totalXPAtUnlock' in obj).toBe(false)
+      expect('totalSetsAtUnlock' in obj).toBe(false)
+    })
+
+    it('bodyweightDatesToJson creates a copy', () => {
+      const dates = ['2026-01-01']
+      const result = bodyweightDatesToJson(dates)
+      expect(result).toEqual(dates)
+      expect(result).not.toBe(dates)
+    })
+  })
+})

--- a/src/lib/__tests__/jsonColumns.test.ts
+++ b/src/lib/__tests__/jsonColumns.test.ts
@@ -95,18 +95,20 @@ describe('jsonColumns', () => {
       expect(parseStreakHistory('not-an-array' as Json, [])).toEqual([])
     })
 
-    it('skips entries with missing fields, returns fallback when all invalid', () => {
-      const fallback: StreakWeekEntry[] = [
-        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
-      ]
-      const corrupt: Json = [{ weekStart: '2026-01-06' }]  // missing streakCount, weeklyTarget, combinedMultiplier
-      expect(parseStreakHistory(corrupt, fallback)).toBe(fallback)
+    it('provides defaults for entries missing numeric fields', () => {
+      const result = parseStreakHistory(
+        [{ weekStart: '2026-01-06' }] as Json,
+        [],
+      )
+      expect(result).toEqual([
+        { weekStart: '2026-01-06', streakCount: 0, weeklyTarget: 3, combinedMultiplier: 1.0 },
+      ])
     })
 
     it('skips invalid entries but keeps valid ones', () => {
       const mixed: Json = [
         { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
-        { weekStart: 123, streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },  // invalid
+        { weekStart: 123, streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },  // invalid weekStart type
         { weekStart: '2026-01-20', streakCount: 3, weeklyTarget: 3, combinedMultiplier: 1.1 },
       ]
       const result = parseStreakHistory(mixed, [])
@@ -116,11 +118,18 @@ describe('jsonColumns', () => {
       ])
     })
 
-    it('returns fallback when all entries have wrong types', () => {
+    it('returns fallback when all entries have invalid weekStart', () => {
       const corrupt: Json = [
         { weekStart: 123, streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
       ]
       expect(parseStreakHistory(corrupt, [])).toEqual([])
+    })
+
+    it('returns empty array for empty remote array (not fallback)', () => {
+      const fallback: StreakWeekEntry[] = [
+        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+      ]
+      expect(parseStreakHistory([], fallback)).toEqual([])
     })
 
     it('parses valid empty array', () => {
@@ -219,8 +228,8 @@ describe('jsonColumns', () => {
       expect(parseBodyweightDates(corrupt, ['fallback'])).toEqual(['fallback'])
     })
 
-    it('parses valid empty array', () => {
-      expect(parseBodyweightDates([], [])).toEqual([])
+    it('returns empty array for empty remote array (not fallback)', () => {
+      expect(parseBodyweightDates([], ['2026-01-01'])).toEqual([])
     })
   })
 

--- a/src/lib/__tests__/jsonColumns.test.ts
+++ b/src/lib/__tests__/jsonColumns.test.ts
@@ -95,13 +95,28 @@ describe('jsonColumns', () => {
       expect(parseStreakHistory('not-an-array' as Json, [])).toEqual([])
     })
 
-    it('returns fallback for entries with missing fields', () => {
-      const fallback: StreakWeekEntry[] = []
+    it('skips entries with missing fields, returns fallback when all invalid', () => {
+      const fallback: StreakWeekEntry[] = [
+        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+      ]
       const corrupt: Json = [{ weekStart: '2026-01-06' }]  // missing streakCount, weeklyTarget, combinedMultiplier
       expect(parseStreakHistory(corrupt, fallback)).toBe(fallback)
     })
 
-    it('returns fallback for entries with wrong types', () => {
+    it('skips invalid entries but keeps valid ones', () => {
+      const mixed: Json = [
+        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+        { weekStart: 123, streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },  // invalid
+        { weekStart: '2026-01-20', streakCount: 3, weeklyTarget: 3, combinedMultiplier: 1.1 },
+      ]
+      const result = parseStreakHistory(mixed, [])
+      expect(result).toEqual([
+        { weekStart: '2026-01-06', streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
+        { weekStart: '2026-01-20', streakCount: 3, weeklyTarget: 3, combinedMultiplier: 1.1 },
+      ])
+    })
+
+    it('returns fallback when all entries have wrong types', () => {
       const corrupt: Json = [
         { weekStart: 123, streakCount: 1, weeklyTarget: 3, combinedMultiplier: 1.0 },
       ]
@@ -130,13 +145,17 @@ describe('jsonColumns', () => {
       expect(result![0].unlockedAt).toBeDefined()
     })
 
-    it('returns null for entries with missing id', () => {
-      const corrupt: Json = [{ unlockedAt: '2026-01-01T00:00:00Z' }]
-      expect(parseUnlockedThemes(corrupt)).toBeNull()
+    it('skips entries with missing id but keeps valid ones', () => {
+      const mixed: Json = [
+        { id: 'pearl', unlockedAt: '2026-01-01T00:00:00Z' },
+        { unlockedAt: '2026-02-01T00:00:00Z' },  // missing id
+      ]
+      const result = parseUnlockedThemes(mixed)
+      expect(result).toEqual([{ id: 'pearl', unlockedAt: '2026-01-01T00:00:00Z' }])
     })
 
-    it('returns null for entries with missing unlockedAt', () => {
-      const corrupt: Json = [{ id: 'pearl' }]
+    it('returns null when all entries are invalid', () => {
+      const corrupt: Json = [{ unlockedAt: '2026-01-01T00:00:00Z' }]
       expect(parseUnlockedThemes(corrupt)).toBeNull()
     })
   })
@@ -154,10 +173,22 @@ describe('jsonColumns', () => {
       expect(parseXpPerSet([] as Json, {})).toEqual({})
     })
 
-    it('skips entries with invalid SetXPEntry shape', () => {
-      const corrupt: Json = {
+    it('provides defaults for legacy SetXPEntry missing newer fields', () => {
+      const legacy: Json = {
         'set-1': { xp: 50, theme: 'fire' },  // missing epoch, zone, isPR, isRepPR
-        'set-2': 25,  // valid legacy
+        'set-2': 25,  // valid legacy number
+      }
+      const result = parseXpPerSet(legacy, {})
+      expect(result).toEqual({
+        'set-1': { xp: 50, theme: 'fire', epoch: 1, zone: '', isPR: false, isRepPR: false },
+        'set-2': 25,
+      })
+    })
+
+    it('skips object entries missing xp field', () => {
+      const corrupt: Json = {
+        'set-1': { theme: 'fire', epoch: 1 },  // missing xp
+        'set-2': 25,
       }
       const result = parseXpPerSet(corrupt, {})
       expect(result).toEqual({ 'set-2': 25 })
@@ -178,9 +209,14 @@ describe('jsonColumns', () => {
       expect(parseBodyweightDates('not-array' as Json, ['fallback'])).toEqual(['fallback'])
     })
 
-    it('returns fallback if any entry is not a string', () => {
+    it('skips non-string entries and keeps valid ones', () => {
       const corrupt: Json = ['2026-01-01', 42, '2026-01-03']
-      expect(parseBodyweightDates(corrupt, [])).toEqual([])
+      expect(parseBodyweightDates(corrupt, [])).toEqual(['2026-01-01', '2026-01-03'])
+    })
+
+    it('returns fallback when all entries are invalid', () => {
+      const corrupt: Json = [42, true, null]
+      expect(parseBodyweightDates(corrupt, ['fallback'])).toEqual(['fallback'])
     })
 
     it('parses valid empty array', () => {

--- a/src/lib/jsonColumns.ts
+++ b/src/lib/jsonColumns.ts
@@ -63,6 +63,8 @@ export function bodyweightDatesToJson(dates: string[]): Json {
 /** Parse a Json value as StreakWeekEntry[], skipping invalid entries. */
 export function parseStreakHistory(value: Json | undefined, fallback: StreakWeekEntry[]): StreakWeekEntry[] {
   if (!Array.isArray(value)) return fallback
+  // Empty array is a valid remote state (cleared history) — return it, don't use fallback
+  if (value.length === 0) return []
   const result: StreakWeekEntry[] = []
   for (const item of value) {
     if (!isPlainObject(item)) {
@@ -70,20 +72,15 @@ export function parseStreakHistory(value: Json | undefined, fallback: StreakWeek
       continue
     }
     const obj = item as { [key: string]: Json | undefined }
-    if (
-      typeof obj.weekStart !== 'string' ||
-      typeof obj.streakCount !== 'number' ||
-      typeof obj.weeklyTarget !== 'number' ||
-      typeof obj.combinedMultiplier !== 'number'
-    ) {
-      logWarn('Invalid streak history entry, skipping', { item })
+    if (typeof obj.weekStart !== 'string') {
+      logWarn('Invalid streak history entry (missing weekStart), skipping', { item })
       continue
     }
     result.push({
       weekStart: obj.weekStart,
-      streakCount: obj.streakCount,
-      weeklyTarget: obj.weeklyTarget,
-      combinedMultiplier: obj.combinedMultiplier,
+      streakCount: typeof obj.streakCount === 'number' ? obj.streakCount : 0,
+      weeklyTarget: typeof obj.weeklyTarget === 'number' ? obj.weeklyTarget : 3,
+      combinedMultiplier: typeof obj.combinedMultiplier === 'number' ? obj.combinedMultiplier : 1.0,
     })
   }
   return result.length > 0 ? result : fallback
@@ -163,6 +160,8 @@ export function parseXpPerSet(
 /** Parse a Json value as string[] (bodyweight XP dates), skipping invalid entries. */
 export function parseBodyweightDates(value: Json | undefined, fallback: string[]): string[] {
   if (!Array.isArray(value)) return fallback
+  // Empty array is a valid remote state — return it, don't use fallback
+  if (value.length === 0) return []
   const result: string[] = []
   for (const item of value) {
     if (typeof item !== 'string') {

--- a/src/lib/jsonColumns.ts
+++ b/src/lib/jsonColumns.ts
@@ -1,0 +1,178 @@
+/**
+ * Typed JSON column helpers for Supabase.
+ *
+ * Replaces the double-cast pattern (`as unknown as Json`) with functions
+ * that validate shape on read and produce `Json` on write without unsafe casts.
+ * If a column value doesn't match the expected shape, the fallback is returned
+ * instead of silently accepting corrupt data.
+ */
+import type { Json } from './database.types'
+import type { ThemeId } from './themes'
+import type { StreakWeekEntry, SetXPEntry, ThemeUnlock } from '../stores/progression'
+import { logWarn } from './logger'
+
+// ── Write helpers (domain → Json) ─────────────────────────────────
+
+/** Convert ThemeUnlock[] to a Json-compatible value. */
+export function themeUnlocksToJson(themes: ThemeUnlock[]): Json {
+  return themes.map(t => ({
+    id: t.id,
+    unlockedAt: t.unlockedAt,
+    ...(t.totalXPAtUnlock !== undefined ? { totalXPAtUnlock: t.totalXPAtUnlock } : {}),
+    ...(t.totalSetsAtUnlock !== undefined ? { totalSetsAtUnlock: t.totalSetsAtUnlock } : {}),
+  }))
+}
+
+/** Convert StreakWeekEntry[] to a Json-compatible value. */
+export function streakHistoryToJson(history: StreakWeekEntry[]): Json {
+  return history.map(e => ({
+    weekStart: e.weekStart,
+    streakCount: e.streakCount,
+    weeklyTarget: e.weeklyTarget,
+    combinedMultiplier: e.combinedMultiplier,
+  }))
+}
+
+/** Convert xpPerSet record to a Json-compatible value. */
+export function xpPerSetToJson(xpPerSet: Record<string, SetXPEntry | number>): Json {
+  const result: { [key: string]: Json | undefined } = {}
+  for (const [key, entry] of Object.entries(xpPerSet)) {
+    if (typeof entry === 'number') {
+      result[key] = entry
+    } else {
+      result[key] = {
+        xp: entry.xp,
+        theme: entry.theme,
+        epoch: entry.epoch,
+        zone: entry.zone,
+        isPR: entry.isPR,
+        isRepPR: entry.isRepPR,
+      }
+    }
+  }
+  return result
+}
+
+/** Convert bodyweightXPDates to a Json-compatible value. */
+export function bodyweightDatesToJson(dates: string[]): Json {
+  return [...dates]
+}
+
+// ── Read helpers (Json → domain) ──────────────────────────────────
+
+/** Parse a Json value as StreakWeekEntry[], returning fallback on invalid shape. */
+export function parseStreakHistory(value: Json | undefined, fallback: StreakWeekEntry[]): StreakWeekEntry[] {
+  if (!Array.isArray(value)) return fallback
+  const result: StreakWeekEntry[] = []
+  for (const item of value) {
+    if (!isPlainObject(item)) return fallback
+    const obj = item as { [key: string]: Json | undefined }
+    if (
+      typeof obj.weekStart !== 'string' ||
+      typeof obj.streakCount !== 'number' ||
+      typeof obj.weeklyTarget !== 'number' ||
+      typeof obj.combinedMultiplier !== 'number'
+    ) {
+      logWarn('Invalid streak history entry, using fallback', { item })
+      return fallback
+    }
+    result.push({
+      weekStart: obj.weekStart,
+      streakCount: obj.streakCount,
+      weeklyTarget: obj.weeklyTarget,
+      combinedMultiplier: obj.combinedMultiplier,
+    })
+  }
+  return result
+}
+
+/** Parse a Json value as ThemeUnlock[] (handles legacy string[] format). */
+export function parseUnlockedThemes(value: Json | undefined): ThemeUnlock[] | null {
+  if (!Array.isArray(value)) return null
+  if (value.length === 0) return null
+
+  // Check if already new format (objects with id field)
+  if (isPlainObject(value[0]) && 'id' in (value[0] as Record<string, unknown>)) {
+    const result: ThemeUnlock[] = []
+    for (const item of value) {
+      if (!isPlainObject(item)) return null
+      const obj = item as { [key: string]: Json | undefined }
+      if (typeof obj.id !== 'string' || typeof obj.unlockedAt !== 'string') return null
+      result.push({
+        id: obj.id as ThemeId,
+        unlockedAt: obj.unlockedAt,
+        ...(typeof obj.totalXPAtUnlock === 'number' ? { totalXPAtUnlock: obj.totalXPAtUnlock } : {}),
+        ...(typeof obj.totalSetsAtUnlock === 'number' ? { totalSetsAtUnlock: obj.totalSetsAtUnlock } : {}),
+      })
+    }
+    return result
+  }
+
+  // Legacy string[] format
+  if (typeof value[0] === 'string') {
+    return (value as string[]).map(id => ({
+      id: id as ThemeId,
+      unlockedAt: new Date().toISOString(),
+    }))
+  }
+
+  return null
+}
+
+/** Parse a Json value as Record<string, SetXPEntry | number>. */
+export function parseXpPerSet(
+  value: Json | undefined,
+  fallback: Record<string, SetXPEntry | number>,
+): Record<string, SetXPEntry | number> {
+  if (!isPlainObject(value)) return fallback
+  const obj = value as { [key: string]: Json | undefined }
+  const result: Record<string, SetXPEntry | number> = {}
+  for (const [key, entry] of Object.entries(obj)) {
+    if (entry === undefined) continue
+    if (typeof entry === 'number') {
+      result[key] = entry
+    } else if (isPlainObject(entry)) {
+      const e = entry as { [key: string]: Json | undefined }
+      if (
+        typeof e.xp === 'number' &&
+        typeof e.theme === 'string' &&
+        typeof e.epoch === 'number' &&
+        typeof e.zone === 'string' &&
+        typeof e.isPR === 'boolean' &&
+        typeof e.isRepPR === 'boolean'
+      ) {
+        result[key] = {
+          xp: e.xp,
+          theme: e.theme,
+          epoch: e.epoch,
+          zone: e.zone,
+          isPR: e.isPR,
+          isRepPR: e.isRepPR,
+        }
+      } else {
+        logWarn('Invalid xpPerSet entry, skipping', { key, entry })
+      }
+    }
+  }
+  return result
+}
+
+/** Parse a Json value as string[] (bodyweight XP dates). */
+export function parseBodyweightDates(value: Json | undefined, fallback: string[]): string[] {
+  if (!Array.isArray(value)) return fallback
+  const result: string[] = []
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      logWarn('Invalid bodyweight date entry, using fallback', { item })
+      return fallback
+    }
+    result.push(item)
+  }
+  return result
+}
+
+// ── Internal ──────────────────────────────────────────────────────
+
+function isPlainObject(v: unknown): v is { [key: string]: Json | undefined } {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}

--- a/src/lib/jsonColumns.ts
+++ b/src/lib/jsonColumns.ts
@@ -60,12 +60,15 @@ export function bodyweightDatesToJson(dates: string[]): Json {
 
 // ── Read helpers (Json → domain) ──────────────────────────────────
 
-/** Parse a Json value as StreakWeekEntry[], returning fallback on invalid shape. */
+/** Parse a Json value as StreakWeekEntry[], skipping invalid entries. */
 export function parseStreakHistory(value: Json | undefined, fallback: StreakWeekEntry[]): StreakWeekEntry[] {
   if (!Array.isArray(value)) return fallback
   const result: StreakWeekEntry[] = []
   for (const item of value) {
-    if (!isPlainObject(item)) return fallback
+    if (!isPlainObject(item)) {
+      logWarn('Invalid streak history entry, skipping', { item })
+      continue
+    }
     const obj = item as { [key: string]: Json | undefined }
     if (
       typeof obj.weekStart !== 'string' ||
@@ -73,8 +76,8 @@ export function parseStreakHistory(value: Json | undefined, fallback: StreakWeek
       typeof obj.weeklyTarget !== 'number' ||
       typeof obj.combinedMultiplier !== 'number'
     ) {
-      logWarn('Invalid streak history entry, using fallback', { item })
-      return fallback
+      logWarn('Invalid streak history entry, skipping', { item })
+      continue
     }
     result.push({
       weekStart: obj.weekStart,
@@ -83,7 +86,7 @@ export function parseStreakHistory(value: Json | undefined, fallback: StreakWeek
       combinedMultiplier: obj.combinedMultiplier,
     })
   }
-  return result
+  return result.length > 0 ? result : fallback
 }
 
 /** Parse a Json value as ThemeUnlock[] (handles legacy string[] format). */
@@ -95,9 +98,15 @@ export function parseUnlockedThemes(value: Json | undefined): ThemeUnlock[] | nu
   if (isPlainObject(value[0]) && 'id' in (value[0] as Record<string, unknown>)) {
     const result: ThemeUnlock[] = []
     for (const item of value) {
-      if (!isPlainObject(item)) return null
+      if (!isPlainObject(item)) {
+        logWarn('Invalid theme unlock entry, skipping', { item })
+        continue
+      }
       const obj = item as { [key: string]: Json | undefined }
-      if (typeof obj.id !== 'string' || typeof obj.unlockedAt !== 'string') return null
+      if (typeof obj.id !== 'string' || typeof obj.unlockedAt !== 'string') {
+        logWarn('Invalid theme unlock entry, skipping', { item })
+        continue
+      }
       result.push({
         id: obj.id as ThemeId,
         unlockedAt: obj.unlockedAt,
@@ -105,7 +114,7 @@ export function parseUnlockedThemes(value: Json | undefined): ThemeUnlock[] | nu
         ...(typeof obj.totalSetsAtUnlock === 'number' ? { totalSetsAtUnlock: obj.totalSetsAtUnlock } : {}),
       })
     }
-    return result
+    return result.length > 0 ? result : null
   }
 
   // Legacy string[] format
@@ -133,42 +142,36 @@ export function parseXpPerSet(
       result[key] = entry
     } else if (isPlainObject(entry)) {
       const e = entry as { [key: string]: Json | undefined }
-      if (
-        typeof e.xp === 'number' &&
-        typeof e.theme === 'string' &&
-        typeof e.epoch === 'number' &&
-        typeof e.zone === 'string' &&
-        typeof e.isPR === 'boolean' &&
-        typeof e.isRepPR === 'boolean'
-      ) {
-        result[key] = {
-          xp: e.xp,
-          theme: e.theme,
-          epoch: e.epoch,
-          zone: e.zone,
-          isPR: e.isPR,
-          isRepPR: e.isRepPR,
-        }
-      } else {
-        logWarn('Invalid xpPerSet entry, skipping', { key, entry })
+      // xp is the only required field; other fields may be absent in legacy data
+      if (typeof e.xp !== 'number') {
+        logWarn('Invalid xpPerSet entry (missing xp), skipping', { key, entry })
+        continue
+      }
+      result[key] = {
+        xp: e.xp,
+        theme: typeof e.theme === 'string' ? e.theme : '',
+        epoch: typeof e.epoch === 'number' ? e.epoch : 1,
+        zone: typeof e.zone === 'string' ? e.zone : '',
+        isPR: typeof e.isPR === 'boolean' ? e.isPR : false,
+        isRepPR: typeof e.isRepPR === 'boolean' ? e.isRepPR : false,
       }
     }
   }
   return result
 }
 
-/** Parse a Json value as string[] (bodyweight XP dates). */
+/** Parse a Json value as string[] (bodyweight XP dates), skipping invalid entries. */
 export function parseBodyweightDates(value: Json | undefined, fallback: string[]): string[] {
   if (!Array.isArray(value)) return fallback
   const result: string[] = []
   for (const item of value) {
     if (typeof item !== 'string') {
-      logWarn('Invalid bodyweight date entry, using fallback', { item })
-      return fallback
+      logWarn('Invalid bodyweight date entry, skipping', { item })
+      continue
     }
     result.push(item)
   }
-  return result
+  return result.length > 0 ? result : fallback
 }
 
 // ── Internal ──────────────────────────────────────────────────────

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -9,7 +9,16 @@ import type { StreakHistoryEntry } from '../lib/xp'
 import { XP_CONFIG } from '../lib/xp'
 import { logError, logWarn } from '../lib/logger'
 import { broadcastStoreUpdate } from '../lib/crossTabSync'
-import type { Json } from '../lib/database.types'
+import {
+  themeUnlocksToJson,
+  streakHistoryToJson,
+  xpPerSetToJson,
+  bodyweightDatesToJson,
+  parseStreakHistory,
+  parseUnlockedThemes,
+  parseXpPerSet,
+  parseBodyweightDates,
+} from '../lib/jsonColumns'
 
 const STORAGE_KEY = 'user-progression'
 
@@ -290,16 +299,16 @@ export const useProgressionStore = defineStore('progression', {
       this.starterTheme = (data.starter_theme as ThemeId | null) ?? this.starterTheme
       this.starterConfirmed = (data.starter_confirmed as boolean) ?? this.starterConfirmed
       this.epoch = (data.epoch as number) ?? this.epoch
-      this.streakHistory = (data.streak_history as unknown as StreakWeekEntry[]) ?? this.streakHistory
+      this.streakHistory = parseStreakHistory(data.streak_history, this.streakHistory)
 
       // Merge collection fields — union strategy, no data loss
-      const remoteThemes = migrateUnlockedThemes((data.unlocked_themes as unknown) ?? [])
+      const remoteThemes = parseUnlockedThemes(data.unlocked_themes) ?? migrateUnlockedThemes([])
       this.unlockedThemes = mergeUnlockedThemes(this.unlockedThemes, remoteThemes)
 
-      const remoteXpPerSet = (data.xp_per_set as Record<string, SetXPEntry | number>) ?? {}
+      const remoteXpPerSet = parseXpPerSet(data.xp_per_set, {})
       this.xpPerSet = mergeXpPerSet(this.xpPerSet, remoteXpPerSet)
 
-      const remoteBodyweightDates = (data.bodyweight_xp_dates as string[]) ?? []
+      const remoteBodyweightDates = parseBodyweightDates(data.bodyweight_xp_dates, [])
       this.bodyweightXPDates = mergeBodyweightDates(this.bodyweightXPDates, remoteBodyweightDates)
 
       // Recalculate totalXP from merged data — eliminates drift from stale overwrites
@@ -327,13 +336,13 @@ export const useProgressionStore = defineStore('progression', {
         pending_target_change: this.pendingTargetChange,
         show_progression: this.showProgression,
         progression_enabled: this.progressionEnabled,
-        unlocked_themes: this.unlockedThemes as unknown as Json,
+        unlocked_themes: themeUnlocksToJson(this.unlockedThemes),
         starter_theme: this.starterTheme,
         starter_confirmed: this.starterConfirmed,
         epoch: this.epoch,
-        streak_history: this.streakHistory as unknown as Json,
-        xp_per_set: this.xpPerSet as unknown as Json,
-        bodyweight_xp_dates: this.bodyweightXPDates as unknown as Json,
+        streak_history: streakHistoryToJson(this.streakHistory),
+        xp_per_set: xpPerSetToJson(this.xpPerSet),
+        bodyweight_xp_dates: bodyweightDatesToJson(this.bodyweightXPDates),
       }
       syncQueue.enqueue('progression-sync', () =>
         supabase!.from('user_progression').upsert(payload)


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-609](https://github.com/aschung212/Lift/issues/609)



## Changes




## Commits
- [`d0dfcff`](https://github.com/aschung212/Lift/commit/d0dfcff) fix(#609): handle empty remote arrays and provide defaults for legacy streak entries
- [`3de2c33`](https://github.com/aschung212/Lift/commit/3de2c33) fix(#609): skip invalid entries instead of discarding entire collections
- [`88bffc1`](https://github.com/aschung212/Lift/commit/88bffc1) refactor(#609): replace double-cast (as unknown as Json) with typed JSON column helpers

## Test Results
- Before: 1708 passing
- After: 1739 passing (31 delta)

---
_Automated by overnight pipeline — Fri May 22 23:35:10 PDT 2026_