### PR TITLE
perf(#633): add CSS content-visibility: auto to timeline groups and calendar rows

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2389,6 +2389,8 @@ html.theme-fading .settingsSheet {
   padding: 12px 16px;
   cursor: pointer;
   border-bottom: 1px solid var(--border);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 48px;
 }
 
 .wtTimelineRow:last-child {
@@ -3176,6 +3178,8 @@ html.theme-fading .settingsSheet {
   border-radius: 12px;
   border: 1px solid var(--border);
   overflow: hidden;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 200px;
 }
 
 .wtSetRow {
@@ -6066,6 +6070,8 @@ html.theme-fading .settingsSheet {
 
 .calExGroup {
   border-bottom: 1px solid var(--border);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 44px;
 }
 
 .calExGroup:last-child {
@@ -6149,6 +6155,8 @@ html.theme-fading .settingsSheet {
   border-bottom: 1px solid var(--border);
   min-height: 48px;
   transition: background-color 0.12s;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 48px;
 }
 
 .calWeekRow:last-child {

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -427,6 +427,27 @@ describe('CSS regression tests', () => {
     })
   })
 
+  describe('content-visibility: auto for off-screen rendering skip (LIFT-633)', () => {
+    const targets = [
+      { selector: '.wtSetCard', hint: 'timeline date group' },
+      { selector: '.wtTimelineRow', hint: 'timeline set row' },
+      { selector: '.calWeekRow', hint: 'calendar week row' },
+      { selector: '.calExGroup', hint: 'calendar exercise group' },
+    ]
+
+    for (const { selector, hint } of targets) {
+      it(`${selector} (${hint}) has content-visibility: auto`, () => {
+        const lines = getRuleLines(selector)
+        expect(lines.some(l => l.includes('content-visibility') && l.includes('auto'))).toBe(true)
+      })
+
+      it(`${selector} (${hint}) has contain-intrinsic-size`, () => {
+        const lines = getRuleLines(selector)
+        expect(lines.some(l => l.includes('contain-intrinsic-size'))).toBe(true)
+      })
+    }
+  })
+
   describe('WCAG 2.4.11 focus indicators on inputs with outline:none', () => {
     // Regression: 11 input elements had outline:none with only border-color
     // changes as focus replacement. WCAG 2.4.7 (Focus Visible) and 2.4.11


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-633](https://github.com/aschung212/Lift/issues/633)

Implemented LIFT-633: added CSS `content-visibility: auto` with `contain-intrinsic-size` to four off-screen-heavy selectors in the timeline and calendar views. This is a pure CSS optimization that lets the browser skip layout/paint for elements scrolled out of the viewport.

## Changes
- **`src/index.css`**: Added `content-visibility: auto` and `contain-intrinsic-size` to:
  - `.wtSetCard` (timeline date groups, `auto 200px`) — each group wraps multiple set rows for one date
  - `.wtTimelineRow` (individual set rows, `auto 48px`) — the most numerous off-screen elements
  - `.calWeekRow` (week view day rows, `auto 48px`)
  - `.calExGroup` (exercise groups in day detail, `auto 44px`)
- **`src/lib/__tests__/cssRegression.test.ts`**: Added 8 regression tests verifying both properties exist on all 4 selectors

## Verification
- 1782/1782 tests pass (including 8 new CSS regression tests)
- Build succeeds with no new warnings
- Post-commit Gemini review: "No issues found"
- Lint clean

## Screenshots
N/A — pure CSS rendering optimization, no visual changes

## Commits
- [`403a14d`](https://github.com/aschung212/Lift/commit/403a14d) perf(#633): add CSS content-visibility: auto to timeline groups and calendar rows

## Test Results
- Before: 1782 passing
- After: 1790 passing (8 delta)

---
_Automated by overnight pipeline — Mon May 25 23:30:22 PDT 2026_

## Preview
Test on your phone: https://lift-x9i9gluct-aschung212-1101s-projects.vercel.app