### PR TITLE
perf(#636): defer Vercel Analytics and Speed Insights to after first paint

### DIFF
--- a/src/__tests__/analyticsDeferral.test.ts
+++ b/src/__tests__/analyticsDeferral.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression test for LIFT-636: Vercel Analytics and Speed Insights must be
+ * deferred to after first paint via requestIdleCallback / setTimeout, not
+ * called synchronously in main.ts.  This prevents analytics from competing
+ * with the critical rendering path.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const mainSrc = readFileSync(resolve(__dirname, '../main.ts'), 'utf-8')
+
+describe('analytics deferral (LIFT-636)', () => {
+  it('wraps analytics calls in requestIdleCallback or setTimeout', () => {
+    expect(mainSrc).toMatch(/requestIdleCallback/)
+    expect(mainSrc).toMatch(/setTimeout/)
+  })
+
+  it('calls inject() and injectSpeedInsights() inside the deferred callback', () => {
+    // Both calls should appear inside the deferAfterPaint callback block
+    const deferBlock = mainSrc.match(/deferAfterPaint\(\(\)\s*=>\s*\{([\s\S]*?)\}\)/)
+    expect(deferBlock).not.toBeNull()
+    expect(deferBlock![1]).toContain('inject()')
+    expect(deferBlock![1]).toContain('injectSpeedInsights()')
+  })
+
+  it('does not call inject() or injectSpeedInsights() outside the deferred block', () => {
+    // Remove the deferred block, then check no standalone calls remain
+    const withoutDeferBlock = mainSrc.replace(
+      /deferAfterPaint\(\(\)\s*=>\s*\{[\s\S]*?\}\)/,
+      '',
+    )
+    // Should not find bare inject() calls (import statements are fine)
+    const hasBareSyncInject = /(?<!import .*)(?<!\w)inject\(\)/.test(withoutDeferBlock)
+    const hasBareSyncSpeedInsights = /(?<!\w)injectSpeedInsights\(\)/.test(withoutDeferBlock)
+    expect(hasBareSyncInject).toBe(false)
+    expect(hasBareSyncSpeedInsights).toBe(false)
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,22 @@ import { setSentryCaptureException, logError } from './lib/logger'
 import App from './App.vue'
 import './index.css'
 
-inject()
-injectSpeedInsights()
+// Defer analytics injection to after first paint — analytics should never
+// compete with rendering.  Sentry already uses a lazy import().then() pattern;
+// Vercel Analytics and Speed Insights follow the same principle here.
+const deferAfterPaint = (fn: () => void): void => {
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(fn)
+  } else {
+    setTimeout(fn, 0)
+  }
+}
+
+deferAfterPaint(() => {
+  inject()
+  injectSpeedInsights()
+})
+
 initNativePlugins()
 
 // Initialize theme before mounting to prevent FOUC (flash of unstyled content).


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-636](https://github.com/aschung212/Lift/issues/636)

Implemented LIFT-636: deferred Vercel Analytics (`inject()`) and Speed Insights (`injectSpeedInsights()`) initialization to after first paint by wrapping them in `requestIdleCallback` (with `setTimeout` fallback). This follows the same deferred-loading pattern already used for Sentry via dynamic `import().then()`.

## Changes
- **`src/main.ts`**: Replaced synchronous top-level `inject()` and `injectSpeedInsights()` calls with a `deferAfterPaint()` wrapper that uses `requestIdleCallback` (or `setTimeout` as fallback). Analytics now initializes after the browser is idle post-first-paint instead of blocking the critical rendering path.
- **`src/__tests__/analyticsDeferral.test.ts`** (new): 3 regression tests verifying analytics calls are wrapped in the deferred block, that `requestIdleCallback`/`setTimeout` are present, and that no synchronous analytics calls exist outside the deferred block.

## Verification
- All 1785 tests pass (3 new)
- Production build succeeds
- ESLint clean
- Gemini 3.1 Pro review: no issues found
- Branch pushed to `origin/enhance/run5-2026-05-25`

ISSUE_DONE:LIFT-636:Deferred Vercel Analytics and Speed Insights injection to after first paint via requestIdleCallback. Added 3 regression tests.
  📊 Output tokens: 7616 | Nightly total: 16121/500000 | Run 5/12
✅ Run 5 finished at Mon May 25 23:38:27 PDT 2026 — 1 new commit(s)
remote: This repository moved. Please use the new location:        
remote:   https://github.com/aschung212/Lift.git        
remote: 
remote: Create a pull request for 'enhance/LIFT-636-2026-05-25' on GitHub by visiting:        
remote:      https://github.com/aschung212/Lift/pull/new/enhance/LIFT-636-2026-05-25        
remote: 
To https://github.com/aschung212/lift.git
 * [new branch]      enhance/LIFT-636-2026-05-25 -> enhance/LIFT-636-2026-05-25
branch 'enhance/LIFT-636-2026-05-25' set up to track 'origin/enhance/LIFT-636-2026-05-25'.
✅ CI passed (build + tests)

## Commits
- [`22751a1`](https://github.com/aschung212/Lift/commit/22751a1) perf(#636): defer Vercel Analytics and Speed Insights to after first paint

## Test Results
- Before: 1782 passing
- After: 1785 passing (3 delta)

---
_Automated by overnight pipeline — Mon May 25 23:39:06 PDT 2026_

## Preview
Test on your phone: https://lift-imf3t42qh-aschung212-1101s-projects.vercel.app