### PR TITLE
fix(#566): move coverage cache restore before test run to prevent overwrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,19 @@ jobs:
               core.warning(`Could not post bundle size comment: ${err.message}`);
             }
 
+      - name: Restore base coverage summary (PR)
+        if: github.event_name == 'pull_request'
+        id: base-coverage
+        uses: actions/cache/restore@v5
+        with:
+          path: coverage/coverage-summary.json
+          key: coverage-summary-master-${{ github.event.pull_request.base.sha }}
+          restore-keys: coverage-summary-master-
+
+      - name: Preserve base coverage summary
+        if: github.event_name == 'pull_request'
+        run: if [ -f coverage/coverage-summary.json ]; then mv coverage/coverage-summary.json base-coverage-summary.json; fi
+
       - run: npx vitest run --coverage
 
       - name: Coverage ratchet check
@@ -253,15 +266,6 @@ jobs:
         with:
           path: coverage/coverage-summary.json
           key: coverage-summary-master-${{ github.sha }}
-
-      - name: Restore base coverage summary (PR)
-        if: github.event_name == 'pull_request'
-        id: base-coverage
-        uses: actions/cache/restore@v5
-        with:
-          path: base-coverage-summary.json
-          key: coverage-summary-master-${{ github.event.pull_request.base.sha }}
-          restore-keys: coverage-summary-master-
 
       - name: Post coverage delta comment
         if: always() && github.event_name == 'pull_request' && hashFiles('coverage/coverage-summary.json') != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,12 +247,147 @@ jobs:
       - name: Coverage ratchet check
         run: node scripts/check-coverage-ratchet.js
 
+      - name: Save coverage summary (master)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@v5
+        with:
+          path: coverage/coverage-summary.json
+          key: coverage-summary-master-${{ github.sha }}
+
+      - name: Restore base coverage summary (PR)
+        if: github.event_name == 'pull_request'
+        id: base-coverage
+        uses: actions/cache/restore@v5
+        with:
+          path: base-coverage-summary.json
+          key: coverage-summary-master-${{ github.event.pull_request.base.sha }}
+          restore-keys: coverage-summary-master-
+
+      - name: Post coverage delta comment
+        if: always() && github.event_name == 'pull_request' && hashFiles('coverage/coverage-summary.json') != ''
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const summary = JSON.parse(fs.readFileSync('coverage/coverage-summary.json', 'utf8'));
+            const baseline = JSON.parse(fs.readFileSync('.coverage-baseline.json', 'utf8'));
+            const metrics = ['statements', 'branches', 'functions', 'lines'];
+
+            let baseFromMaster = null;
+            try {
+              baseFromMaster = JSON.parse(fs.readFileSync('base-coverage-summary.json', 'utf8'));
+            } catch {
+              // No cached master summary — first run or cache expired
+            }
+
+            const fmt = (n) => `${n.toFixed(2)}%`;
+            const delta = (cur, prev) => {
+              const diff = cur - prev;
+              const sign = diff > 0 ? '+' : '';
+              const icon = diff > 2 ? '🟢' : diff > 0 ? '🔵' : diff < -1 ? '🔴' : diff < 0 ? '🟡' : '⚪';
+              return `${icon} ${sign}${diff.toFixed(2)}%`;
+            };
+
+            let body = '## 🔬 Coverage Ratchet Report\n\n';
+            body += '| Metric | Current | Baseline Floor | vs. Master |\n';
+            body += '|--------|---------|----------------|------------|\n';
+
+            for (const m of metrics) {
+              const cur = summary.total[m].pct;
+              const floor = baseline[m];
+              const masterDelta = baseFromMaster ? delta(cur, baseFromMaster.total[m].pct) : '—';
+              const floorDelta = delta(cur, floor);
+              body += `| ${m} | ${fmt(cur)} | ${fmt(floor)} ${floorDelta} | ${masterDelta} |\n`;
+            }
+
+            if (!baseFromMaster) {
+              body += '\n> _No master coverage cached yet. Delta vs master will appear after the next master build._\n';
+            }
+            body += '\n> _Floor = `.coverage-baseline.json` — auto-ratchets up on master merge._\n';
+
+            const marker = '<!-- coverage-ratchet-report -->';
+            body = marker + '\n' + body;
+
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+
+              const existing = comments.find(c => c.body.startsWith(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (err) {
+              core.warning(`Could not post coverage comment: ${err.message}`);
+            }
+
       - name: Coverage report
         if: always() && github.event_name == 'pull_request'
         uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2
         with:
           json-summary-path: coverage/coverage-summary.json
           json-final-path: coverage/coverage-final.json
+
+  # Auto-ratchet the coverage baseline on master merges.
+  # Runs after all tests pass. If coverage improved, commits the updated
+  # .coverage-baseline.json back to master so the floor only ever rises.
+  # Uses [skip ci] to prevent an infinite loop.
+  ratchet-baseline:
+    runs-on: ubuntu-latest
+    needs: [build-and-test, e2e]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Restore node_modules
+        uses: actions/cache/restore@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run tests with coverage
+        run: npx vitest run --coverage
+
+      - name: Ratchet baseline
+        run: node scripts/check-coverage-ratchet.js --update
+
+      - name: Commit updated baseline
+        run: |
+          if git diff --quiet .coverage-baseline.json; then
+            echo "Baseline unchanged — nothing to commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add .coverage-baseline.json
+            git commit -m "chore: ratchet coverage baseline [skip ci]"
+            git push
+          fi
 
   e2e:
     runs-on: ubuntu-latest
@@ -340,7 +475,7 @@ jobs:
   # shell). See GitHub docs: "Understanding the risk of script injections".
   notify-deploy:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, build-and-test, e2e, migrate-db]
+    needs: [lint, typecheck, build-and-test, e2e, migrate-db, ratchet-baseline]
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Notify Slack
@@ -358,7 +493,7 @@ jobs:
   # script-injection guard as `notify-deploy` above.
   notify-failure:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, build-and-test, e2e, migrate-db]
+    needs: [lint, typecheck, build-and-test, e2e, migrate-db, ratchet-baseline]
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Notify Slack

--- a/scripts/check-coverage-ratchet.js
+++ b/scripts/check-coverage-ratchet.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Coverage ratchet: prevents coverage from dropping below the committed baseline.
+ * Coverage ratchet CLI: prevents coverage from dropping below the committed baseline.
  *
  * Reads coverage-summary.json (produced by vitest --coverage) and compares it
  * against .coverage-baseline.json. Fails if any metric drops by more than
@@ -17,13 +17,13 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { compareBaseline, formatResults } from './coverage-ratchet.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
 const COVERAGE_SUMMARY = resolve(root, 'coverage/coverage-summary.json');
 const BASELINE_FILE = resolve(root, '.coverage-baseline.json');
-const METRICS = ['statements', 'branches', 'functions', 'lines'];
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -54,62 +54,15 @@ try {
   process.exit(1);
 }
 
-// Compare
-const current = {};
-for (const metric of METRICS) {
-  current[metric] = summary.total[metric].pct;
+// Compare and report
+const result = compareBaseline(summary, baseline, { margin, update: shouldUpdate });
+console.log(formatResults(result, { margin }));
+
+// Write updated baseline if ratcheted
+if (result.updatedBaseline) {
+  writeFileSync(BASELINE_FILE, JSON.stringify(result.updatedBaseline, null, 2) + '\n');
 }
 
-let failed = false;
-const improved = {};
-
-console.log('Coverage ratchet check:');
-console.log(`  Margin: ${margin}%\n`);
-console.log('  Metric       Baseline   Current    Delta');
-console.log('  ──────────── ────────── ────────── ──────');
-
-for (const metric of METRICS) {
-  const base = baseline[metric];
-  const cur = current[metric];
-  const delta = cur - base;
-  const sign = delta >= 0 ? '+' : '';
-  const status = delta < -margin ? ' ✗ REGRESSION' : delta > 0 ? ' ↑ improved' : '';
-
-  console.log(
-    `  ${metric.padEnd(12)} ${base.toFixed(2).padStart(8)}%  ${cur.toFixed(2).padStart(8)}%  ${sign}${delta.toFixed(2)}%${status}`
-  );
-
-  if (delta < -margin) {
-    failed = true;
-  }
-  if (delta > 0) {
-    improved[metric] = cur;
-  }
-}
-
-console.log();
-
-if (failed) {
-  console.error(
-    `Coverage dropped below baseline (margin: ${margin}%). ` +
-    'Add tests to restore coverage before merging.'
-  );
+if (result.failed) {
   process.exit(1);
-}
-
-// Ratchet up if any metric improved and --update was passed
-if (shouldUpdate && Object.keys(improved).length > 0) {
-  const newBaseline = { ...baseline };
-  for (const [metric, value] of Object.entries(improved)) {
-    // Round to 2 decimal places; toFixed avoids floating-point jitter
-    // (e.g., 80.14 * 100 → 8013.999... which Math.floor would truncate)
-    newBaseline[metric] = Number(value.toFixed(2));
-  }
-  writeFileSync(BASELINE_FILE, JSON.stringify(newBaseline, null, 2) + '\n');
-  console.log('Baseline ratcheted up. New values:');
-  console.log(JSON.stringify(newBaseline, null, 2));
-} else if (Object.keys(improved).length > 0) {
-  console.log('Coverage improved! Run with --update to ratchet up the baseline.');
-} else {
-  console.log('Coverage matches baseline. No changes needed.');
 }

--- a/scripts/coverage-ratchet.js
+++ b/scripts/coverage-ratchet.js
@@ -1,0 +1,100 @@
+/**
+ * Coverage ratchet — pure logic module.
+ *
+ * Compares current coverage metrics against a baseline and determines whether
+ * coverage has regressed beyond the allowed margin. Optionally computes an
+ * updated baseline when coverage improves.
+ *
+ * This module is intentionally side-effect-free (no file I/O or process.exit)
+ * so it can be unit-tested.
+ */
+
+/** @type {readonly string[]} */
+export const METRICS = /** @type {const} */ (['statements', 'branches', 'functions', 'lines']);
+
+/**
+ * @typedef {{ statements: number, branches: number, functions: number, lines: number }} CoverageBaseline
+ * @typedef {{ total: Record<string, { pct: number }> }} CoverageSummary
+ * @typedef {{ metric: string, baseline: number, current: number, delta: number, regressed: boolean, improved: boolean }} MetricResult
+ * @typedef {{ results: MetricResult[], failed: boolean, updatedBaseline: CoverageBaseline | null }} RatchetResult
+ */
+
+/**
+ * Compare current coverage against baseline.
+ *
+ * @param {CoverageSummary} summary   — parsed coverage-summary.json
+ * @param {CoverageBaseline} baseline — parsed .coverage-baseline.json
+ * @param {{ margin?: number, update?: boolean }} [opts]
+ * @returns {RatchetResult}
+ */
+export function compareBaseline(summary, baseline, opts = {}) {
+  const { margin = 0, update = false } = opts;
+
+  const results = /** @type {MetricResult[]} */ ([]);
+  let failed = false;
+  const improved = /** @type {Record<string, number>} */ ({});
+
+  for (const metric of METRICS) {
+    const base = baseline[metric];
+    const cur = summary.total[metric].pct;
+    const delta = cur - base;
+    const regressed = delta < -margin;
+    const isImproved = delta > 0;
+
+    results.push({ metric, baseline: base, current: cur, delta, regressed, improved: isImproved });
+
+    if (regressed) failed = true;
+    if (isImproved) improved[metric] = cur;
+  }
+
+  let updatedBaseline = null;
+  if (update && Object.keys(improved).length > 0) {
+    updatedBaseline = { ...baseline };
+    for (const [metric, value] of Object.entries(improved)) {
+      updatedBaseline[metric] = Number(value.toFixed(2));
+    }
+  }
+
+  return { results, failed, updatedBaseline };
+}
+
+/**
+ * Format ratchet results as a human-readable string for console output.
+ *
+ * @param {RatchetResult} result
+ * @param {{ margin: number }} opts
+ * @returns {string}
+ */
+export function formatResults(result, opts) {
+  const lines = [];
+  lines.push('Coverage ratchet check:');
+  lines.push(`  Margin: ${opts.margin}%\n`);
+  lines.push('  Metric       Baseline   Current    Delta');
+  lines.push('  ──────────── ────────── ────────── ──────');
+
+  for (const r of result.results) {
+    const sign = r.delta >= 0 ? '+' : '';
+    const status = r.regressed ? ' ✗ REGRESSION' : r.improved ? ' ↑ improved' : '';
+    lines.push(
+      `  ${r.metric.padEnd(12)} ${r.baseline.toFixed(2).padStart(8)}%  ${r.current.toFixed(2).padStart(8)}%  ${sign}${r.delta.toFixed(2)}%${status}`
+    );
+  }
+
+  lines.push('');
+
+  if (result.failed) {
+    lines.push(
+      `Coverage dropped below baseline (margin: ${opts.margin}%). ` +
+      'Add tests to restore coverage before merging.'
+    );
+  } else if (result.updatedBaseline) {
+    lines.push('Baseline ratcheted up. New values:');
+    lines.push(JSON.stringify(result.updatedBaseline, null, 2));
+  } else if (result.results.some(r => r.improved)) {
+    lines.push('Coverage improved! Run with --update to ratchet up the baseline.');
+  } else {
+    lines.push('Coverage matches baseline. No changes needed.');
+  }
+
+  return lines.join('\n');
+}

--- a/src/lib/__tests__/coverageRatchet.test.ts
+++ b/src/lib/__tests__/coverageRatchet.test.ts
@@ -6,34 +6,62 @@ const ROOT = resolve(__dirname, '../../..')
 const BASELINE_PATH = resolve(ROOT, '.coverage-baseline.json')
 const SCRIPT_PATH = resolve(ROOT, 'scripts/check-coverage-ratchet.js')
 const CI_PATH = resolve(ROOT, '.github/workflows/ci.yml')
-const METRICS = ['statements', 'branches', 'functions', 'lines'] as const
+const FILE_METRICS = ['statements', 'branches', 'functions', 'lines'] as const
 
-describe('coverage ratchet', () => {
+// Import pure logic from the ratchet module for unit testing
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let compareBaseline: any, formatResults: any, METRICS: any
+beforeAll(async () => {
+  const mod = await import('../../../scripts/coverage-ratchet.js')
+  compareBaseline = mod.compareBaseline
+  formatResults = mod.formatResults
+  METRICS = mod.METRICS
+})
+
+/** Helper: create a coverage-summary.json structure from metric values */
+function makeSummary(values: { statements: number; branches: number; functions: number; lines: number }) {
+  return {
+    total: {
+      statements: { pct: values.statements },
+      branches: { pct: values.branches },
+      functions: { pct: values.functions },
+      lines: { pct: values.lines },
+    },
+  }
+}
+
+const baseline = { statements: 70, branches: 55, functions: 60, lines: 72 }
+
+describe('coverage ratchet — structural', () => {
   it('baseline file exists and is valid JSON', () => {
     expect(existsSync(BASELINE_PATH)).toBe(true)
-    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
-    for (const metric of METRICS) {
-      expect(baseline).toHaveProperty(metric)
-      expect(typeof baseline[metric]).toBe('number')
-      expect(baseline[metric]).toBeGreaterThanOrEqual(0)
-      expect(baseline[metric]).toBeLessThanOrEqual(100)
+    const bl = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
+    for (const metric of FILE_METRICS) {
+      expect(bl).toHaveProperty(metric)
+      expect(typeof bl[metric]).toBe('number')
+      expect(bl[metric]).toBeGreaterThanOrEqual(0)
+      expect(bl[metric]).toBeLessThanOrEqual(100)
     }
   })
 
   it('baseline thresholds are at least as high as vitest static thresholds', () => {
-    const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
+    const bl = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'))
     // Static thresholds from vitest.config.js — the ratchet should always be >= these
     const staticThresholds = { statements: 60, branches: 50, functions: 55, lines: 60 }
-    for (const metric of METRICS) {
-      expect(baseline[metric]).toBeGreaterThanOrEqual(
+    for (const metric of FILE_METRICS) {
+      expect(bl[metric]).toBeGreaterThanOrEqual(
         staticThresholds[metric],
-        `Baseline ${metric} (${baseline[metric]}%) is below the static threshold (${staticThresholds[metric]}%)`
+        `Baseline ${metric} (${bl[metric]}%) is below the static threshold (${staticThresholds[metric]}%)`
       )
     }
   })
 
   it('ratchet script exists', () => {
     expect(existsSync(SCRIPT_PATH)).toBe(true)
+  })
+
+  it('ratchet logic module exists', () => {
+    expect(existsSync(resolve(ROOT, 'scripts/coverage-ratchet.js'))).toBe(true)
   })
 
   it('CI workflow runs the ratchet check after coverage', () => {
@@ -43,5 +71,172 @@ describe('coverage ratchet', () => {
     const coverageIdx = ci.indexOf('npx vitest run --coverage')
     const ratchetIdx = ci.indexOf('node scripts/check-coverage-ratchet.js')
     expect(ratchetIdx).toBeGreaterThan(coverageIdx)
+  })
+
+  it('CI workflow auto-ratchets on master push', () => {
+    const ci = readFileSync(CI_PATH, 'utf8')
+    expect(ci).toContain('check-coverage-ratchet.js --update')
+  })
+})
+
+describe('coverage ratchet — compareBaseline', () => {
+  it('exports the four standard coverage metrics', () => {
+    expect(METRICS).toEqual(['statements', 'branches', 'functions', 'lines'])
+  })
+
+  it('passes when coverage matches baseline exactly', () => {
+    const summary = makeSummary(baseline)
+    const result = compareBaseline(summary, baseline)
+
+    expect(result.failed).toBe(false)
+    expect(result.updatedBaseline).toBeNull()
+    for (const r of result.results) {
+      expect(r.delta).toBe(0)
+      expect(r.regressed).toBe(false)
+      expect(r.improved).toBe(false)
+    }
+  })
+
+  it('passes when coverage improves', () => {
+    const summary = makeSummary({ statements: 75, branches: 60, functions: 65, lines: 78 })
+    const result = compareBaseline(summary, baseline)
+
+    expect(result.failed).toBe(false)
+    for (const r of result.results) {
+      expect(r.delta).toBeGreaterThan(0)
+      expect(r.improved).toBe(true)
+    }
+  })
+
+  it('fails when any metric drops below baseline (margin=0)', () => {
+    const summary = makeSummary({ statements: 69, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { margin: 0 })
+
+    expect(result.failed).toBe(true)
+    const stmts = result.results.find((r: { metric: string }) => r.metric === 'statements')
+    expect(stmts.regressed).toBe(true)
+    expect(stmts.delta).toBe(-1)
+  })
+
+  it('allows drops within the configured margin', () => {
+    const summary = makeSummary({ statements: 69, branches: 54, functions: 59, lines: 71 })
+    const result = compareBaseline(summary, baseline, { margin: 2 })
+
+    expect(result.failed).toBe(false)
+    for (const r of result.results) {
+      expect(r.regressed).toBe(false)
+    }
+  })
+
+  it('fails when drop exceeds the configured margin', () => {
+    const summary = makeSummary({ statements: 67, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { margin: 2 })
+
+    expect(result.failed).toBe(true)
+    const stmts = result.results.find((r: { metric: string }) => r.metric === 'statements')
+    expect(stmts.regressed).toBe(true)
+    expect(stmts.delta).toBe(-3)
+  })
+
+  it('does not produce updatedBaseline without update flag', () => {
+    const summary = makeSummary({ statements: 75, branches: 60, functions: 65, lines: 78 })
+    const result = compareBaseline(summary, baseline, { update: false })
+
+    expect(result.updatedBaseline).toBeNull()
+  })
+
+  it('produces updatedBaseline with update flag when coverage improves', () => {
+    const summary = makeSummary({ statements: 75, branches: 60, functions: 65, lines: 78 })
+    const result = compareBaseline(summary, baseline, { update: true })
+
+    expect(result.updatedBaseline).toEqual({ statements: 75, branches: 60, functions: 65, lines: 78 })
+  })
+
+  it('only ratchets up metrics that actually improved', () => {
+    const summary = makeSummary({ statements: 75, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { update: true })
+
+    expect(result.updatedBaseline).toEqual({
+      statements: 75,  // improved
+      branches: 55,    // unchanged
+      functions: 60,   // unchanged
+      lines: 72,       // unchanged
+    })
+  })
+
+  it('rounds updated values to 2 decimal places', () => {
+    const summary = makeSummary({ statements: 70.126, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { update: true })
+
+    expect(result.updatedBaseline).not.toBeNull()
+    expect(result.updatedBaseline.statements).toBe(70.13)
+  })
+
+  it('does not produce updatedBaseline when no metrics improved', () => {
+    const summary = makeSummary({ statements: 70, branches: 54, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { update: true })
+
+    expect(result.updatedBaseline).toBeNull()
+  })
+
+  it('can both fail and detect improvements simultaneously', () => {
+    // statements dropped (fail), but branches improved
+    const summary = makeSummary({ statements: 69, branches: 60, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { margin: 0, update: true })
+
+    expect(result.failed).toBe(true)
+    const branches = result.results.find((r: { metric: string }) => r.metric === 'branches')
+    expect(branches.improved).toBe(true)
+  })
+})
+
+describe('coverage ratchet — formatResults', () => {
+  it('includes REGRESSION marker for failed metrics', () => {
+    const summary = makeSummary({ statements: 69, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { margin: 0 })
+    const output = formatResults(result, { margin: 0 })
+
+    expect(output).toContain('✗ REGRESSION')
+    expect(output).toContain('Add tests to restore coverage before merging')
+  })
+
+  it('includes improved marker for improved metrics', () => {
+    const summary = makeSummary({ statements: 75, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline)
+    const output = formatResults(result, { margin: 0 })
+
+    expect(output).toContain('↑ improved')
+  })
+
+  it('shows ratchet message when baseline was updated', () => {
+    const summary = makeSummary({ statements: 75, branches: 60, functions: 65, lines: 78 })
+    const result = compareBaseline(summary, baseline, { update: true })
+    const output = formatResults(result, { margin: 0 })
+
+    expect(output).toContain('Baseline ratcheted up')
+  })
+
+  it('shows no-change message when coverage matches exactly', () => {
+    const summary = makeSummary(baseline)
+    const result = compareBaseline(summary, baseline)
+    const output = formatResults(result, { margin: 0 })
+
+    expect(output).toContain('Coverage matches baseline. No changes needed.')
+  })
+
+  it('shows run-with-update hint when improved but not updating', () => {
+    const summary = makeSummary({ statements: 75, branches: 55, functions: 60, lines: 72 })
+    const result = compareBaseline(summary, baseline, { update: false })
+    const output = formatResults(result, { margin: 0 })
+
+    expect(output).toContain('Run with --update to ratchet up the baseline')
+  })
+
+  it('displays the configured margin', () => {
+    const summary = makeSummary(baseline)
+    const result = compareBaseline(summary, baseline, { margin: 2 })
+    const output = formatResults(result, { margin: 2 })
+
+    expect(output).toContain('Margin: 2%')
   })
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-566](https://github.com/aschung212/Lift/issues/566)



## Changes




## Commits
- [`7a22739`](https://github.com/aschung212/Lift/commit/7a22739) fix(#566): move coverage cache restore before test run to prevent overwrite
- [`b2cd2f0`](https://github.com/aschung212/Lift/commit/b2cd2f0) ci(#566): add coverage threshold ratcheting with auto-update and PR delta comments

## Test Results
- Before: 1782 passing
- After: 1802 passing (20 delta)

---
_Automated by overnight pipeline — Tue May 26 00:13:34 PDT 2026_