### PR TITLE
refactor(#502): fold theme/colorMode/weightUnit/restTimer into preferences store for Supabase sync

### DIFF
--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -1,13 +1,18 @@
-import { ref, type Ref } from 'vue'
+import { ref, watch, type Ref } from 'vue'
 import { supabase } from '../lib/supabase'
 import { migrateLocalStorageToSupabase } from '../lib/migrate'
 import { useWorkoutStore } from '../stores/workout'
 import { useBodyweightStore } from '../stores/bodyweight'
 import { usePreferencesStore } from '../stores/preferences'
 import { useProgressionStore } from '../stores/progression'
+import { useTheme } from '../composables/useTheme'
+import { useWeightUnit } from '../composables/useWeightUnit'
+import { useRestTimer } from '../composables/useRestTimer'
 import { syncQueue } from '../lib/syncQueue'
 import { logError } from '../lib/logger'
 import type { User, Provider } from '@supabase/supabase-js'
+import type { ColorMode } from '../lib/themes'
+import type { WeightUnit } from '../lib/themes'
 
 interface AuthError {
   message: string
@@ -32,6 +37,32 @@ const loading: Ref<boolean> = ref(true)
 let _initialized = false
 let _authUnsubscribe: (() => void) | null = null
 
+/**
+ * Push synced settings from the preferences store to the composable module-scope
+ * refs, then set up one-directional watchers so future UI changes flow back into
+ * the store (and from there to Supabase). Called once after all stores are hydrated.
+ */
+function syncSettingsWithComposables(): void {
+  const prefs = usePreferencesStore()
+  const { currentTheme, colorMode } = useTheme()
+  const { weightUnit } = useWeightUnit()
+  const { restTimerEnabled, restTimerAutoStart } = useRestTimer()
+
+  // Push store → composable refs (Supabase values override local)
+  currentTheme.value = prefs.theme
+  colorMode.value = prefs.colorMode as ColorMode
+  weightUnit.value = prefs.weightUnit as WeightUnit
+  restTimerEnabled.value = prefs.restTimerEnabled
+  restTimerAutoStart.value = prefs.restTimerAutoStart
+
+  // Composable refs → store (user interactions sync to Supabase)
+  watch(currentTheme, (v) => { prefs.setTheme(v) })
+  watch(colorMode, (v) => { prefs.setColorMode(v) })
+  watch(weightUnit, (v) => { prefs.setWeightUnit(v) })
+  watch(restTimerEnabled, (v) => { prefs.setRestTimer(v) })
+  watch(restTimerAutoStart, (v) => { prefs.setRestTimerAutoStart(v) })
+}
+
 async function initStores(userId: string): Promise<void> {
   const workoutStore = useWorkoutStore()
   const bodyweightStore = useBodyweightStore()
@@ -44,6 +75,7 @@ async function initStores(userId: string): Promise<void> {
     preferencesStore.init(userId),
     progressionStore.init(userId),
   ])
+  syncSettingsWithComposables()
 }
 
 function init(): void {

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -532,4 +532,137 @@ describe('usePreferencesStore', () => {
       expect(stored.experience).toBeDefined()
     })
   })
+
+  describe('synced settings (theme, colorMode, weightUnit, restTimer)', () => {
+    it('defaults to expected values', () => {
+      expect(store.theme).toBe('eternal')
+      expect(store.colorMode).toBe('dark')
+      expect(store.weightUnit).toBe('lbs')
+      expect(store.restTimerEnabled).toBe(true)
+      expect(store.restTimerAutoStart).toBe(true)
+    })
+
+    it('setTheme updates and persists', () => {
+      store.setTheme('fire')
+      expect(store.theme).toBe('fire')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.theme).toBe('fire')
+    })
+
+    it('setColorMode updates and persists', () => {
+      store.setColorMode('light')
+      expect(store.colorMode).toBe('light')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.colorMode).toBe('light')
+    })
+
+    it('setWeightUnit updates and persists', () => {
+      store.setWeightUnit('kg')
+      expect(store.weightUnit).toBe('kg')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.weightUnit).toBe('kg')
+    })
+
+    it('setRestTimer updates and persists', () => {
+      store.setRestTimer(false)
+      expect(store.restTimerEnabled).toBe(false)
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.restTimerEnabled).toBe(false)
+    })
+
+    it('setRestTimerAutoStart updates and persists', () => {
+      store.setRestTimerAutoStart(false)
+      expect(store.restTimerAutoStart).toBe(false)
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.restTimerAutoStart).toBe(false)
+    })
+
+    it('_persist writes individual localStorage keys for FOUC prevention', () => {
+      store.setTheme('water')
+      store.setColorMode('auto')
+      store.setWeightUnit('kg')
+      store.setRestTimer(false)
+      store.setRestTimerAutoStart(false)
+
+      expect(localStorageMock.getItem('app-theme')).toBe('water')
+      expect(localStorageMock.getItem('app-mode')).toBe('auto')
+      expect(localStorageMock.getItem('weight-unit')).toBe('kg')
+      expect(localStorageMock.getItem('rest-timer')).toBe('off')
+      expect(localStorageMock.getItem('rest-timer-autostart')).toBe('off')
+    })
+
+    it('init loads synced settings from JSON blob', async () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        theme: 'midnight',
+        colorMode: 'light',
+        weightUnit: 'kg',
+        restTimerEnabled: false,
+        restTimerAutoStart: false,
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.theme).toBe('midnight')
+      expect(freshStore.colorMode).toBe('light')
+      expect(freshStore.weightUnit).toBe('kg')
+      expect(freshStore.restTimerEnabled).toBe(false)
+      expect(freshStore.restTimerAutoStart).toBe(false)
+    })
+
+    it('init migrates from standalone localStorage keys when JSON blob lacks them', async () => {
+      // Simulate an old client that stored settings as individual keys
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+      }))
+      localStorageMock.setItem('app-theme', 'fire')
+      localStorageMock.setItem('app-mode', 'light')
+      localStorageMock.setItem('weight-unit', 'kg')
+      localStorageMock.setItem('rest-timer', 'off')
+      localStorageMock.setItem('rest-timer-autostart', 'off')
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.theme).toBe('fire')
+      expect(freshStore.colorMode).toBe('light')
+      expect(freshStore.weightUnit).toBe('kg')
+      expect(freshStore.restTimerEnabled).toBe(false)
+      expect(freshStore.restTimerAutoStart).toBe(false)
+    })
+
+    it('_reloadFromStorage picks up synced settings', () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        theme: 'love',
+        colorMode: 'auto',
+        weightUnit: 'kg',
+        restTimerEnabled: false,
+        restTimerAutoStart: false,
+      }))
+
+      store._reloadFromStorage()
+
+      expect(store.theme).toBe('love')
+      expect(store.colorMode).toBe('auto')
+      expect(store.weightUnit).toBe('kg')
+      expect(store.restTimerEnabled).toBe(false)
+      expect(store.restTimerAutoStart).toBe(false)
+    })
+
+    it('synced settings are included in persist payload alongside existing fields', () => {
+      store.setTheme('earth')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.theme).toBe('earth')
+      expect(stored.features).toBeDefined()
+      expect(stored.weightGoal).toBeDefined()
+      expect(stored.experience).toBeDefined()
+      expect(stored.filters).toBeDefined()
+    })
+  })
 })

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -121,6 +121,12 @@ export const usePreferencesStore = defineStore('preferences', {
     experience: { ...DEFAULT_EXPERIENCE } as ExperienceFlags,
     filters: { ...DEFAULT_FILTERS } as FilterSettings,
     prBaselineDate: null as string | null,
+    /** Synced appearance/behavior settings (previously standalone localStorage keys). */
+    theme: 'eternal' as string,
+    colorMode: 'dark' as string,
+    weightUnit: 'lbs' as string,
+    restTimerEnabled: true,
+    restTimerAutoStart: true,
     _userId: null as string | null,
   }),
 
@@ -132,10 +138,22 @@ export const usePreferencesStore = defineStore('preferences', {
         experience: this.experience,
         filters: this.filters,
         prBaselineDate: this.prBaselineDate,
+        theme: this.theme,
+        colorMode: this.colorMode,
+        weightUnit: this.weightUnit,
+        restTimerEnabled: this.restTimerEnabled,
+        restTimerAutoStart: this.restTimerAutoStart,
       }
       const data = JSON.stringify(payload)
       try {
         localStorage.setItem(STORAGE_KEY, data)
+        // Write individual keys so initTheme() can read them before Pinia
+        // for FOUC prevention on the next page load.
+        localStorage.setItem('app-theme', this.theme)
+        localStorage.setItem('app-mode', this.colorMode)
+        localStorage.setItem('weight-unit', this.weightUnit)
+        localStorage.setItem('rest-timer', this.restTimerEnabled ? 'on' : 'off')
+        localStorage.setItem('rest-timer-autostart', this.restTimerAutoStart ? 'on' : 'off')
       } catch (e) {
         logError(e, { source: 'preferences._persist' })
       }
@@ -164,6 +182,11 @@ export const usePreferencesStore = defineStore('preferences', {
         if (parsed.weightGoal) this.weightGoal = _migrateWeightGoal(parsed.weightGoal)
         if (parsed.experience) this.experience = { ...DEFAULT_EXPERIENCE, ...parsed.experience }
         if (parsed.filters) this.filters = { ...DEFAULT_FILTERS, ...parsed.filters }
+        if (typeof parsed.theme === 'string') this.theme = parsed.theme
+        if (typeof parsed.colorMode === 'string') this.colorMode = parsed.colorMode
+        if (typeof parsed.weightUnit === 'string') this.weightUnit = parsed.weightUnit
+        if (typeof parsed.restTimerEnabled === 'boolean') this.restTimerEnabled = parsed.restTimerEnabled
+        if (typeof parsed.restTimerAutoStart === 'boolean') this.restTimerAutoStart = parsed.restTimerAutoStart
       } catch { /* ignore corrupt data */ }
     },
 
@@ -188,8 +211,36 @@ export const usePreferencesStore = defineStore('preferences', {
           if (typeof parsed.prBaselineDate === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(parsed.prBaselineDate)) {
             this.prBaselineDate = parsed.prBaselineDate
           }
+          // Load synced settings from JSON blob
+          if (typeof parsed.theme === 'string') this.theme = parsed.theme
+          if (typeof parsed.colorMode === 'string') this.colorMode = parsed.colorMode
+          if (typeof parsed.weightUnit === 'string') this.weightUnit = parsed.weightUnit
+          if (typeof parsed.restTimerEnabled === 'boolean') this.restTimerEnabled = parsed.restTimerEnabled
+          if (typeof parsed.restTimerAutoStart === 'boolean') this.restTimerAutoStart = parsed.restTimerAutoStart
         } catch { /* ignore corrupt data */ }
       }
+
+      // Migrate standalone localStorage keys into the synced payload.
+      // These keys predate the preferences store — read them as fallbacks
+      // when the JSON blob doesn't contain them yet.
+      try {
+        if (this.theme === 'eternal') {
+          const legacy = localStorage.getItem('app-theme')
+          if (legacy && legacy !== 'eternal') this.theme = legacy
+        }
+        if (this.colorMode === 'dark') {
+          const legacy = localStorage.getItem('app-mode')
+          if (legacy && legacy !== 'dark') this.colorMode = legacy
+        }
+        if (this.weightUnit === 'lbs') {
+          const legacy = localStorage.getItem('weight-unit')
+          if (legacy && legacy !== 'lbs') this.weightUnit = legacy
+        }
+        const legacyTimer = localStorage.getItem('rest-timer')
+        if (legacyTimer === 'off') this.restTimerEnabled = false
+        const legacyAutoStart = localStorage.getItem('rest-timer-autostart')
+        if (legacyAutoStart === 'off') this.restTimerAutoStart = false
+      } catch { /* ignore */ }
 
       // Migrate from old standalone localStorage key (pre-sync era)
       if (this.prBaselineDate === null) {
@@ -228,7 +279,20 @@ export const usePreferencesStore = defineStore('preferences', {
             } else if ('prBaselineDate' in prefs && prefs.prBaselineDate === null) {
               this.prBaselineDate = null
             }
-            const synced = JSON.stringify({ features: this.features, weightGoal: this.weightGoal, experience: this.experience, filters: this.filters, prBaselineDate: this.prBaselineDate })
+            // Sync appearance/behavior settings from Supabase
+            if (typeof prefs.theme === 'string') this.theme = prefs.theme as string
+            if (typeof prefs.colorMode === 'string') this.colorMode = prefs.colorMode as string
+            if (typeof prefs.weightUnit === 'string') this.weightUnit = prefs.weightUnit as string
+            if (typeof prefs.restTimerEnabled === 'boolean') this.restTimerEnabled = prefs.restTimerEnabled as boolean
+            if (typeof prefs.restTimerAutoStart === 'boolean') this.restTimerAutoStart = prefs.restTimerAutoStart as boolean
+            const synced = JSON.stringify({
+              features: this.features, weightGoal: this.weightGoal,
+              experience: this.experience, filters: this.filters,
+              prBaselineDate: this.prBaselineDate,
+              theme: this.theme, colorMode: this.colorMode,
+              weightUnit: this.weightUnit, restTimerEnabled: this.restTimerEnabled,
+              restTimerAutoStart: this.restTimerAutoStart,
+            })
             localStorage.setItem(STORAGE_KEY, synced)
             backupToIDB(STORAGE_KEY, synced)
           }
@@ -296,6 +360,31 @@ export const usePreferencesStore = defineStore('preferences', {
 
     clearPRBaseline() {
       this.prBaselineDate = null
+      this._persist()
+    },
+
+    setTheme(id: string) {
+      this.theme = id
+      this._persist()
+    },
+
+    setColorMode(mode: string) {
+      this.colorMode = mode
+      this._persist()
+    },
+
+    setWeightUnit(unit: string) {
+      this.weightUnit = unit
+      this._persist()
+    },
+
+    setRestTimer(enabled: boolean) {
+      this.restTimerEnabled = enabled
+      this._persist()
+    },
+
+    setRestTimerAutoStart(autoStart: boolean) {
+      this.restTimerAutoStart = autoStart
       this._persist()
     },
   },


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-502](https://github.com/aschung212/Lift/issues/502)



## Changes




## Commits
- [`6a3a2e1`](https://github.com/aschung212/Lift/commit/6a3a2e1) refactor(#502): fold theme/colorMode/weightUnit/restTimer into preferences store for Supabase sync

## Test Results
- Before: 1782 passing
- After: 1793 passing (11 delta)

---
_Automated by overnight pipeline — Tue May 26 00:52:05 PDT 2026_

## Preview
Test on your phone: https://lift-6goeep131-aschung212-1101s-projects.vercel.app