### PR TITLE
feat(#618): add one-tap set duplication from previous session

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -408,15 +408,16 @@
             </span>
           </p>
 
-          <!-- Recent sets (quick-fill) -->
-          <div v-if="!isEditMode && isLogForExercise && recentSets.length > 0" class="wtPrevSession">
-            <span class="wtPrevSessionLabel">Recent</span>
+          <!-- Last session sets (quick-fill) -->
+          <div v-if="!isEditMode && isLogForExercise && lastSession" class="wtPrevSession">
+            <span class="wtPrevSessionLabel">Last session · {{ formatDate(lastSession.date + 'T12:00:00') }}</span>
             <div class="wtPrevSessionChips">
               <button
-                v-for="(s, i) in recentSets"
+                v-for="(s, i) in lastSession.sets"
                 :key="i"
                 class="wtPrevSessionChip"
-                @click="fillFromPrevious(s)"
+                :class="{ wtPrevSessionChipUsed: lastSessionUsed[i] }"
+                @click="fillFromLastSession(s, i)"
               >{{ displayWeight(s.weight) }} × {{ s.reps }}</button>
             </div>
           </div>
@@ -1548,34 +1549,18 @@ const showModal = ref(false)
 const editingSet = ref<{ exerciseId: string; setId: string } | null>(null)
 const selectedExerciseId = ref('')
 
-// ── Previous sets for quick-fill ─────────────────────────────────
-const RECENT_SET_LIMIT = 5
-
-const recentSets = computed(() => {
-  const ex = store.exercises.find(e => e.id === selectedExerciseId.value)
-  if (!ex || ex.sets.length === 0) return []
-  // Sort by date descending, skip today
-  const today = todayISO()
-  const prior = [...ex.sets]
-    .filter(s => toLocalDateKey(s.date) !== today)
-    .sort((a, b) => b.date.localeCompare(a.date))
-  // Deduplicate by weight×reps, keep most recent of each
-  const seen = new Set<string>()
-  const result: { weight: number; reps: number }[] = []
-  for (const s of prior) {
-    const key = `${s.weight}x${s.reps}`
-    if (!seen.has(key)) {
-      seen.add(key)
-      result.push({ weight: s.weight, reps: s.reps })
-    }
-    if (result.length >= RECENT_SET_LIMIT) break
-  }
-  return result
+// ── Last session for quick-fill ──────────────────────────────────
+const lastSession = computed(() => {
+  return store.getLastSession(selectedExerciseId.value, todayISO())
 })
 
-function fillFromPrevious(set: { weight: number; reps: number }) {
+// Track which last-session sets the user has already tapped (visual feedback)
+const lastSessionUsed = ref<Record<number, boolean>>({})
+
+function fillFromLastSession(set: { weight: number; reps: number }, index: number) {
   weightStr.value = String(displayWeight(set.weight))
   repsStr.value = String(set.reps)
+  lastSessionUsed.value = { ...lastSessionUsed.value, [index]: true }
 }
 
 // ── Plate calculator state ──────────────────────────────────────
@@ -1887,6 +1872,7 @@ function pickNewExerciseFromPicker() {
 function openLogForExercise(exerciseId: string) {
   editingSet.value = null
   selectedExerciseId.value = exerciseId
+  lastSessionUsed.value = {}
   date.value = lastLogDate.value
   // Initialize plate calculator from last set if plate-loaded
   const exercise = store.exercises.find(e => e.id === exerciseId)

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -141,6 +141,7 @@ vi.mock('../../stores/workout', () => ({
     getExercisePR,
     getExercisePRSet,
     getOverloadSuggestion: () => null,
+    getLastSession: () => null,
     addExercise: mockAddExercise,
     logSet: mockLogSet,
     updateSet: mockUpdateSet,

--- a/src/index.css
+++ b/src/index.css
@@ -5210,6 +5210,12 @@ html.theme-fading .settingsSheet {
   color: var(--accent);
 }
 
+.wtPrevSessionChipUsed {
+  opacity: 0.45;
+  text-decoration: line-through;
+  border-style: dashed;
+}
+
 .wtInputRow {
   display: flex;
   gap: 12px;

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -566,6 +566,62 @@ describe('workout store', () => {
     })
   })
 
+  describe('getLastSession', () => {
+    it('returns sets from the most recent prior day', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Squat')!
+      store.logSet(id, 135, 10, '2026-05-20')
+      store.logSet(id, 185, 8, '2026-05-20')
+      store.logSet(id, 225, 5, '2026-05-22')
+      const session = store.getLastSession(id, '2026-05-25')
+      expect(session).not.toBeNull()
+      expect(session!.date).toBe('2026-05-22')
+      expect(session!.sets).toHaveLength(1)
+      expect(session!.sets[0].weight).toBe(225)
+    })
+
+    it('returns multiple sets from the same day', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Bench')!
+      store.logSet(id, 135, 10, '2026-05-20')
+      store.logSet(id, 155, 8, '2026-05-20')
+      store.logSet(id, 175, 5, '2026-05-20')
+      const session = store.getLastSession(id, '2026-05-25')
+      expect(session).not.toBeNull()
+      expect(session!.date).toBe('2026-05-20')
+      expect(session!.sets).toHaveLength(3)
+    })
+
+    it('excludes today from last session', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Deadlift')!
+      store.logSet(id, 315, 5, '2026-05-25')
+      store.logSet(id, 275, 8, '2026-05-23')
+      const session = store.getLastSession(id, '2026-05-25')
+      expect(session).not.toBeNull()
+      expect(session!.date).toBe('2026-05-23')
+      expect(session!.sets).toHaveLength(1)
+    })
+
+    it('returns null for non-existent exercise', () => {
+      const store = useWorkoutStore()
+      expect(store.getLastSession('fake')).toBeNull()
+    })
+
+    it('returns null when all sets are from today', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('OHP')!
+      store.logSet(id, 95, 10, '2026-05-25')
+      expect(store.getLastSession(id, '2026-05-25')).toBeNull()
+    })
+
+    it('returns null for exercise with no sets', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Rows')!
+      expect(store.getLastSession(id, '2026-05-25')).toBeNull()
+    })
+  })
+
   describe('getOverloadSuggestion', () => {
     function addSetsOnDays(store: ReturnType<typeof useWorkoutStore>, exId: string, entries: Array<{ date: string; weight: number; reps: number }>) {
       for (const e of entries) {

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -989,6 +989,29 @@ export const useWorkoutStore = defineStore('workout', () => {
   }
 
   /**
+   * Returns the sets from the most recent session (day) for an exercise,
+   * excluding today. Used for "Last Session" quick-fill in the log modal.
+   * Returns { date, sets } or null if no prior session exists.
+   */
+  function getLastSession(exerciseId: string, today?: string): { date: string; sets: WorkoutSet[] } | null {
+    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
+    if (!exercise || exercise.sets.length === 0) return null
+    const todayStr = today ?? new Date().toISOString().slice(0, 10)
+    // Group sets by day
+    const byDay = new Map<string, WorkoutSet[]>()
+    for (const set of exercise.sets) {
+      const day = set.date.slice(0, 10)
+      if (day === todayStr) continue
+      if (!byDay.has(day)) byDay.set(day, [])
+      byDay.get(day)!.push(set)
+    }
+    if (byDay.size === 0) return null
+    // Find the most recent day
+    const latestDay = [...byDay.keys()].sort().pop()!
+    return { date: latestDay, sets: byDay.get(latestDay)! }
+  }
+
+  /**
    * Progressive overload suggestion for an exercise.
    * Analyzes recent sessions to suggest the next weight × reps.
    *
@@ -1138,6 +1161,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     getExercisePR,
     getExercisePRSet,
     getRecentSets,
+    getLastSession,
     getOverloadSuggestion
   }
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-618](https://github.com/aschung212/Lift/issues/618)



## Changes




## Commits
- [`f6923df`](https://github.com/aschung212/Lift/commit/f6923df) feat(#618): add one-tap set duplication from previous session

## Test Results
- Before: 1782 passing
- After: 1788 passing (6 delta)

---
_Automated by overnight pipeline — Tue May 26 01:05:48 PDT 2026_

## Preview
Test on your phone: https://lift-hl2o6dwig-aschung212-1101s-projects.vercel.app