### PR TITLE
ci(coverage): bump default ratchet margin from 0% to 0.5%

### DIFF
--- a/scripts/check-coverage-ratchet.js
+++ b/scripts/check-coverage-ratchet.js
@@ -5,8 +5,9 @@
  *
  * Reads coverage-summary.json (produced by vitest --coverage) and compares it
  * against .coverage-baseline.json. Fails if any metric drops by more than
- * the allowed margin (default 0%). On CI with --update, writes a new baseline
- * when coverage improves — so the floor only ever ratchets up.
+ * the allowed margin (default 0.5%, to absorb sub-percent jitter from test
+ * ordering and flaky branch coverage). On CI with --update, writes a new
+ * baseline when coverage improves — so the floor only ever ratchets up.
  *
  * Usage:
  *   node scripts/check-coverage-ratchet.js              # compare only
@@ -29,7 +30,7 @@ const METRICS = ['statements', 'branches', 'functions', 'lines'];
 const args = process.argv.slice(2);
 const shouldUpdate = args.includes('--update');
 const marginIdx = args.indexOf('--margin');
-const margin = marginIdx !== -1 ? parseFloat(args[marginIdx + 1]) : 0;
+const margin = marginIdx !== -1 ? parseFloat(args[marginIdx + 1]) : 0.5;
 
 if (Number.isNaN(margin)) {
   console.error('Error: --margin requires a numeric value');


### PR DESCRIPTION
## Summary
- All 9 open PRs (including Dependabot's deps-only bump #637) are currently blocked by the same `build-and-test` failure: the coverage ratchet at `margin: 0%` flagging a -0.09% jitter on branch coverage.
- Bumps the default margin in `scripts/check-coverage-ratchet.js` from `0` → `0.5`. The ratchet still only moves up via `--update`, so sustained improvements are preserved.
- Once merged, re-running CI on the existing PRs should unblock them.

## Why
- The Dependabot PR is the smoking gun — a deps-only change can't move source-file branch coverage, so the regression is jitter (test ordering, flaky branch detection), not real signal.
- 0.5% is wide enough to absorb sub-percent noise but small enough to still catch a real coverage drop.

## Test plan
- [ ] CI green on this PR
- [ ] Re-run `build-and-test` on PRs #638–#645 and #637 and confirm they go green
- [ ] Spot-check that the ratchet still fails on a synthetic >1% drop (manual, locally if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)