### PR TITLE
test(#652): replace real-time polling with deterministic async flushing in composable tests

### DIFF
--- a/src/composables/__tests__/usePRBurst.test.ts
+++ b/src/composables/__tests__/usePRBurst.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 // Mock useHaptics before we import the module under test so its inline
@@ -24,10 +24,17 @@ import { usePreferencesStore } from '../../stores/preferences'
 
 describe('usePRBurst', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     setActivePinia(createPinia())
     notifySuccessMock.mockClear()
     const { dismissPRBurst } = usePRBurst()
     dismissPRBurst()
+    // Flush the 200ms dismiss timeout so it doesn't leak across tests
+    vi.advanceTimersByTime(200)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('presents when new e1RM beats old and celebrations are enabled', () => {
@@ -116,7 +123,6 @@ describe('usePRBurst', () => {
   })
 
   it('dismissPRBurst clears pending timeout on re-dismiss', () => {
-    vi.useFakeTimers()
     const { presentPRBurst, dismissPRBurst, payload } = usePRBurst()
     presentPRBurst({
       exerciseName: 'Hack Squat',
@@ -144,7 +150,6 @@ describe('usePRBurst', () => {
     vi.advanceTimersByTime(200)
     // Payload should be null (only one timeout fired)
     expect(payload.value).toBeNull()
-    vi.useRealTimers()
   })
 
   it('dismissPRBurst hides the overlay', () => {

--- a/src/composables/__tests__/useWakeLock.test.ts
+++ b/src/composables/__tests__/useWakeLock.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 
 // Re-import fresh module state for each test
 let useWakeLock: typeof import('../useWakeLock').useWakeLock
@@ -73,9 +74,8 @@ describe('useWakeLock', () => {
 
     shouldLock.value = true
     await nextTick()
-    await vi.waitFor(() => {
-      expect(navigator.wakeLock.request).toHaveBeenCalledWith('screen')
-    })
+    await flushPromises()
+    expect(navigator.wakeLock.request).toHaveBeenCalledWith('screen')
   })
 
   it('does not acquire when enabled is false', async () => {
@@ -94,15 +94,13 @@ describe('useWakeLock', () => {
     const enabled = ref(true)
     useWakeLock(shouldLock, enabled)
     await nextTick()
-    await vi.waitFor(() => {
-      expect(navigator.wakeLock.request).toHaveBeenCalled()
-    })
+    await flushPromises()
+    expect(navigator.wakeLock.request).toHaveBeenCalled()
 
     shouldLock.value = false
     await nextTick()
-    await vi.waitFor(() => {
-      expect(mockSentinel.release).toHaveBeenCalled()
-    })
+    await flushPromises()
+    expect(mockSentinel.release).toHaveBeenCalled()
   })
 
   it('releases wake lock when enabled becomes false', async () => {
@@ -110,15 +108,13 @@ describe('useWakeLock', () => {
     const enabled = ref(true)
     useWakeLock(shouldLock, enabled)
     await nextTick()
-    await vi.waitFor(() => {
-      expect(navigator.wakeLock.request).toHaveBeenCalled()
-    })
+    await flushPromises()
+    expect(navigator.wakeLock.request).toHaveBeenCalled()
 
     enabled.value = false
     await nextTick()
-    await vi.waitFor(() => {
-      expect(mockSentinel.release).toHaveBeenCalled()
-    })
+    await flushPromises()
+    expect(mockSentinel.release).toHaveBeenCalled()
   })
 
   it('exposes wakeLockActive as reactive state', async () => {
@@ -126,9 +122,8 @@ describe('useWakeLock', () => {
     const enabled = ref(true)
     const { wakeLockActive } = useWakeLock(shouldLock, enabled)
     await nextTick()
-    await vi.waitFor(() => {
-      expect(wakeLockActive.value).toBe(true)
-    })
+    await flushPromises()
+    expect(wakeLockActive.value).toBe(true)
   })
 
   it('handles request failure gracefully', async () => {
@@ -138,9 +133,8 @@ describe('useWakeLock', () => {
     const { wakeLockActive } = useWakeLock(shouldLock, enabled)
     // Flush the watcher and let the rejected promise settle
     await nextTick()
-    await vi.waitFor(() => {
-      expect(wakeLockActive.value).toBe(false)
-    })
+    await flushPromises()
+    expect(wakeLockActive.value).toBe(false)
   })
 
   it('releases the just-acquired sentinel if shouldLock toggles off mid-request', async () => {
@@ -172,10 +166,9 @@ describe('useWakeLock', () => {
     // 3. Resolve the request. The cancellation signal threaded through
     //    acquireLock should release the sentinel rather than orphan it.
     resolveRequest(lateSentinel)
+    await flushPromises()
 
-    await vi.waitFor(() => {
-      expect(lateSentinel.release).toHaveBeenCalled()
-    })
+    expect(lateSentinel.release).toHaveBeenCalled()
     expect(wakeLockActive.value).toBe(false)
   })
 
@@ -210,13 +203,12 @@ describe('useWakeLock', () => {
     expect(navigator.wakeLock.request).toHaveBeenCalledTimes(1)
 
     resolveFirst(firstSentinel)
+    await flushPromises()
 
     // The first sentinel is released (orphan prevention), then the
     // second request fires for the still-active toggle.
-    await vi.waitFor(() => {
-      expect(firstSentinel.release).toHaveBeenCalled()
-      expect(navigator.wakeLock.request).toHaveBeenCalledTimes(2)
-    })
+    expect(firstSentinel.release).toHaveBeenCalled()
+    expect(navigator.wakeLock.request).toHaveBeenCalledTimes(2)
     expect(secondSentinel.release).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-652](https://github.com/aschung212/Lift/issues/652)


**Plan:** Fix LIFT-652 — replace real-time polling (`vi.waitFor()`) in useWakeLock tests with deterministic `flushPromises()`, and standardize fake timers in usePRBurst tests where `beforeEach` leaked real `setTimeout` calls.

**Changes:**
- `src/composables/__tests__/useWakeLock.test.ts`: Replaced all 7 `vi.waitFor()` calls with `await flushPromises()` from `@vue/test-utils`. This eliminates real-time polling that could flake on overloaded CI runners.

## Changes




## Commits
- [`1f4acf8`](https://github.com/aschung212/Lift/commit/1f4acf8) test(#652): replace real-time polling with deterministic async flushing in composable tests

## Test Results
- Before: 1831 passing
- After: 1831 passing (0 delta)

---
_Automated by overnight pipeline — Wed May 27 23:10:58 PDT 2026_

## Preview
Test on your phone: https://lift-mfavof9vt-aschung212-1101s-projects.vercel.app