### PR TITLE
feat(#601): add "Made with Lift" watermark to free share cards

### DIFF
--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -40,6 +40,7 @@
           <div class="spThumbCard" :class="{ spThumbCardStory: format === 'story' }">
             <div class="spThumbInner" :class="{ spThumbInnerStory: format === 'story' }">
               <component :is="card.component" :summary="summary" />
+              <span v-if="showWatermark" class="spWatermark" aria-hidden="true">{{ WATERMARK_TEXT }}</span>
             </div>
           </div>
           <span class="spThumbLabel">{{ card.label }}</span>
@@ -72,11 +73,12 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { SessionSummary } from '../../lib/sessionSummary'
-import type { CardFormat } from '../../lib/shareImage'
+import { WATERMARK_TEXT, type CardFormat } from '../../lib/shareImage'
 import { eligibleSquareCards, eligibleStoryCards } from './cardRegistry'
 import { useWorkoutShare } from '../../composables/useWorkoutShare'
 import { useTheme } from '../../composables/useTheme'
 import { useModal } from '../../composables/useModal'
+import { useSupporter } from '../../composables/useSupporter'
 
 const props = defineProps<{ summary: SessionSummary }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
@@ -84,6 +86,10 @@ const emit = defineEmits<{ (e: 'close'): void }>()
 const { open: activateTrap, close: deactivateTrap } = useModal({ selector: '.spOverlay' })
 const { currentTheme, resolvedMode } = useTheme()
 const { shareCard, downloadCard, isSharing } = useWorkoutShare()
+const { isSupporter } = useSupporter()
+
+// Free tier gets the "Made with Lift" watermark; supporters get clean cards.
+const showWatermark = computed(() => !isSupporter.value)
 
 const FORMAT_OPTIONS: { value: CardFormat; label: string }[] = [
   { value: 'square', label: 'Post' },
@@ -116,6 +122,7 @@ async function onShare() {
     summary: props.summary,
     theme: currentTheme.value,
     mode: resolvedMode.value,
+    watermark: showWatermark.value,
   })
   if (res.kind === 'downloaded') lastResult.value = `Saved ${res.filename}`
   else if (res.kind === 'shared') emit('close')
@@ -131,6 +138,7 @@ async function onSave() {
     summary: props.summary,
     theme: currentTheme.value,
     mode: resolvedMode.value,
+    watermark: showWatermark.value,
   })
   if (res.kind === 'downloaded') lastResult.value = `Saved ${res.filename}`
   else if (res.kind === 'error') lastResult.value = 'Save failed — try again'
@@ -308,6 +316,23 @@ onUnmounted(() => {
   width: 360px;
   height: 640px;
   transform: scale(0.5);
+}
+
+/* Mirrors createWatermarkElement() in shareImage.ts so the preview matches
+   the exported PNG exactly. Lives inside .spThumbInner (the 360px card
+   surface) so it scales down with the thumbnail. */
+.spWatermark {
+  position: absolute;
+  right: 14px;
+  bottom: 12px;
+  z-index: 10;
+  pointer-events: none;
+  font-family: var(--ff-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
 .spThumbLabel {

--- a/src/composables/__tests__/useWorkoutShare.test.ts
+++ b/src/composables/__tests__/useWorkoutShare.test.ts
@@ -388,4 +388,42 @@ describe('useWorkoutShare', () => {
       expect(hostNode.style.position).toBe('absolute')
     })
   })
+
+  // ── Watermark (#601) ───────────────────────────────────────────────
+
+  describe('watermark', () => {
+    it('injects the "Made with Lift" watermark when watermark is true', async () => {
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest({ watermark: true }))
+
+      const hostNode = mockRenderNodeToBlob.mock.calls[0][0]
+      const mark = hostNode.querySelector('[data-share-watermark]')
+      expect(mark).not.toBeNull()
+      expect(mark?.textContent).toBe('Made with Lift')
+    })
+
+    it('omits the watermark when watermark is false', async () => {
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest({ watermark: false }))
+
+      const hostNode = mockRenderNodeToBlob.mock.calls[0][0]
+      expect(hostNode.querySelector('[data-share-watermark]')).toBeNull()
+    })
+
+    it('omits the watermark by default (no opt-in)', async () => {
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest())
+
+      const hostNode = mockRenderNodeToBlob.mock.calls[0][0]
+      expect(hostNode.querySelector('[data-share-watermark]')).toBeNull()
+    })
+
+    it('injects the watermark on the download path too', async () => {
+      const { downloadCard } = await getComposable()
+      await downloadCard(makeRequest({ watermark: true }))
+
+      const hostNode = mockRenderNodeToBlob.mock.calls[0][0]
+      expect(hostNode.querySelector('[data-share-watermark]')).not.toBeNull()
+    })
+  })
 })

--- a/src/composables/useSupporter.ts
+++ b/src/composables/useSupporter.ts
@@ -1,0 +1,26 @@
+/**
+ * Supporter (paid tier) entitlement — single source of truth (issue #601).
+ *
+ * Read this anywhere the free vs. paid experience diverges. Today the only
+ * consumer is the share-card "Made with Lift" watermark: free users get the
+ * watermark, supporters get clean cards.
+ *
+ * Module-level singleton ref so the value is global, not per-component.
+ */
+
+import { readonly, ref, type Ref } from 'vue'
+
+// TODO(LIFT-598): wire this to the RevenueCat / Capacitor IAP entitlement
+// (or the Supabase profile flag synced from it) once App Store purchases
+// ship. Stubbed to `false` so the free tier — including the watermark — is
+// the default for everyone until then.
+const _isSupporter = ref(false)
+
+export interface UseSupporterReturn {
+  /** True when the user has an active supporter entitlement. */
+  isSupporter: Readonly<Ref<boolean>>
+}
+
+export function useSupporter(): UseSupporterReturn {
+  return { isSupporter: readonly(_isSupporter) }
+}

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -14,6 +14,7 @@
 import { ref, createApp, h, type Component, type Ref, nextTick } from 'vue'
 import {
   renderNodeToBlob,
+  createWatermarkElement,
   defaultShareFilename,
   PREVIEW_SIZE,
   EXPORT_PIXEL_RATIO,
@@ -31,6 +32,12 @@ export interface ShareCardRequest {
   /** Used to scope the offscreen container's data-theme/data-mode. */
   theme: string
   mode: 'dark' | 'light'
+  /**
+   * Stamp the free-tier "Made with Lift" watermark onto the rendered card.
+   * Set by the caller from the supporter entitlement (#601). Defaults to
+   * off so callers must opt in explicitly.
+   */
+  watermark?: boolean
 }
 
 export type ShareResult =
@@ -138,6 +145,10 @@ async function renderCardOffscreen(req: ShareCardRequest): Promise<Blob> {
 
   try {
     app.mount(inner)
+    // Stamp the watermark on top of the mounted card. `inner` is the
+    // position:relative containing block, so the absolute watermark anchors
+    // to the card's bottom-right corner.
+    if (req.watermark) inner.appendChild(createWatermarkElement())
     // Two ticks: first to flush mount, second to flush any computed/CSS
     // recalculation triggered by the freshly-applied theme vars.
     await nextTick()

--- a/src/lib/__tests__/shareImage.test.ts
+++ b/src/lib/__tests__/shareImage.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { defaultShareFilename, PREVIEW_SIZE, EXPORT_PIXEL_RATIO } from '../shareImage'
+import {
+  defaultShareFilename,
+  PREVIEW_SIZE,
+  EXPORT_PIXEL_RATIO,
+  WATERMARK_TEXT,
+  createWatermarkElement,
+} from '../shareImage'
 
 describe('shareImage', () => {
   describe('defaultShareFilename', () => {
@@ -23,6 +29,26 @@ describe('shareImage', () => {
       expect(PREVIEW_SIZE.story.width).toBe(360)
       expect(PREVIEW_SIZE.story.height).toBe(640)
       expect(PREVIEW_SIZE.story.height * EXPORT_PIXEL_RATIO).toBe(1920)
+    })
+  })
+
+  describe('createWatermarkElement', () => {
+    it('renders the watermark text', () => {
+      expect(createWatermarkElement().textContent).toBe(WATERMARK_TEXT)
+    })
+
+    it('tags the element with a data attribute for lookup', () => {
+      expect(createWatermarkElement().hasAttribute('data-share-watermark')).toBe(true)
+    })
+
+    it('inlines positioning styles so they survive html-to-image cloning', () => {
+      // Class-based styles are stripped in the cloned subtree; inline styles
+      // are not. The watermark must be anchored bottom-right and non-interactive.
+      const { style } = createWatermarkElement()
+      expect(style.position).toBe('absolute')
+      expect(style.right).toBe('14px')
+      expect(style.bottom).toBe('12px')
+      expect(style.pointerEvents).toBe('none')
     })
   })
 })

--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -62,6 +62,50 @@ export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): 
 }
 
 /**
+ * Free-tier branding stamped onto share cards (issue #601). Supporters get
+ * clean cards; everyone else gets this small mark in the corner. Keeping the
+ * text and styling here (rather than in each of the 11 card templates) means
+ * there is a single injection point shared by the export pipeline and the
+ * picker preview, so what the user previews is exactly what ships.
+ */
+export const WATERMARK_TEXT = 'Made with Lift'
+
+/**
+ * Build the watermark element used by the offscreen export pipeline.
+ *
+ * Styles are inlined (not class-based) so they survive `html-to-image`'s
+ * clone-and-rehome step, which strips selectors that don't match in the
+ * cloned subtree. Positioned absolute in the bottom-right corner of the
+ * card's `position:relative` host.
+ *
+ * The color is intentionally a fixed semi-transparent white with a drop
+ * shadow rather than a theme variable: this mark is baked into an exported
+ * image that sits over arbitrary (often bold/dark) card backgrounds, so it
+ * needs to read on anything. A theme var like `--text-on-accent` can resolve
+ * to a dark color on light themes and vanish. This is the conventional
+ * social-watermark treatment, not app chrome.
+ */
+export function createWatermarkElement(): HTMLDivElement {
+  const el = document.createElement('div')
+  el.textContent = WATERMARK_TEXT
+  el.setAttribute('data-share-watermark', '')
+  el.style.cssText = [
+    'position:absolute',
+    'right:14px',
+    'bottom:12px',
+    'z-index:10',
+    'pointer-events:none',
+    'font-family:var(--ff-mono, ui-monospace, monospace)',
+    'font-size:11px',
+    'font-weight:600',
+    'letter-spacing:0.06em',
+    'color:rgba(255,255,255,0.85)',
+    'text-shadow:0 1px 3px rgba(0,0,0,0.5)',
+  ].join(';')
+  return el
+}
+
+/**
  * Build a default `share-summary-YYYY-MM-DD.png` filename.
  * Used for the download fallback path on browsers without `navigator.share`.
  */


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-601](https://github.com/aschung212/Lift/issues/601)

Implement LIFT-601: free share cards carry a subtle "Made with Lift" watermark; supporters get clean cards. Single injection point, gated on a supporter flag stubbed `false` until IAP (#598) ships.

## Changes
- **`src/composables/useSupporter.ts`** (new) — module-level `isSupporter` ref stubbed `false`, exposed read-only. TODO ties it to RevenueCat/Capacitor IAP (#598).
- **`src/lib/shareImage.ts`** — added `WATERMARK_TEXT` and `createWatermarkElement()` (inline-styled, `data-share-watermark` tagged, semi-transparent white + drop shadow so it reads over any card background; survives html-to-image cloning).
- **`src/composables/useWorkoutShare.ts`** — added optional `watermark` flag to `ShareCardRequest`; appends the watermark onto the offscreen render host for both share and download paths.
- **`src/components/share/SharePickerSheet.vue`** — wires `useSupporter`, passes `watermark: !isSupporter`, and renders a matching watermark in the picker preview thumbnails (scoped CSS mirrors the export styles, so preview == export).
- **Tests** — 7 new: watermark inject/omit on share & download paths + default-off, and `createWatermarkElement` text/attribute/inline-style coverage.

## Verification
- `npx vitest run` — 1841 passed, 1 skipped (was 1834; +7 new)
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm run build` — vue-tsc typecheck + build pass

## Discoveries
ISSUE_DISCOVER:chore:Delete stray untracked scratch file `src/components/__tests__/_axe_probe.test.ts` left behind by the in-progress LIFT-665 axe work — it's a skipped placeholder that couldn't be removed in that sandbox. Not committed here (out of scope); should be cleaned up.

## Commits
- [`1a0c1a2`](https://github.com/aschung212/Lift/commit/1a0c1a2) feat(#601): add "Made with Lift" watermark to free share cards

## Test Results
- Before: 1834 passing
- After: 1841 passing (7 delta)

---
_Automated by overnight pipeline — Thu May 28 23:46:29 PDT 2026_

## Preview
Test on your phone: https://lift-rk23ynx17-aschung212-1101s-projects.vercel.app