### PR TITLE
chore(#531): set Capacitor appId to com.aschung212.lift and pin it with a regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,29 @@ npm run preview  # preview production build locally
 
 Push to GitHub, connect to [Vercel](https://vercel.com), and add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` as environment variables in the Vercel dashboard. Enable Google as an OAuth provider in Supabase and add your Vercel domain to the allowed redirect URLs.
 
+### Native iOS build (Capacitor)
+
+The PWA is wrapped with [Capacitor 8](https://capacitorjs.com) for the App Store. The
+shared config lives in `capacitor.config.ts` (`appId: com.aschung212.lift`). The native
+`ios/` project is generated per-machine and is **not** committed — it depends on a local
+Xcode + CocoaPods toolchain. Generate and run it on the Simulator with:
+
+```bash
+# One-time: generate the native Xcode project (requires Xcode + CocoaPods)
+npx cap add ios
+
+# Build the web bundle and sync it into the native project
+npm run cap:build        # = npm run build && npx cap sync
+
+# Open the project in Xcode, then build & run on a Simulator (e.g. iPhone 15 Pro)
+npm run cap:open:ios
+```
+
+In Xcode, set the **iOS Deployment Target to 16.0** (App target → General → Minimum
+Deployments) for broad device coverage with modern APIs. The app should launch to the
+auth screen with no white screen. Re-run `npm run cap:build` after any web change to
+re-sync the `dist/` bundle into the native shell.
+
 ---
 
 ## Project Structure

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,7 +1,7 @@
 import type { CapacitorConfig } from '@capacitor/cli'
 
 const config: CapacitorConfig = {
-  appId: 'app.lift.tracker',
+  appId: 'com.aschung212.lift',
   appName: 'Lift',
   webDir: 'dist',
   server: {

--- a/src/lib/__tests__/capacitorConfigRegression.test.ts
+++ b/src/lib/__tests__/capacitorConfigRegression.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const capacitorConfig = readFileSync(
+  resolve(__dirname, '../../../capacitor.config.ts'),
+  'utf-8',
+)
+
+// The native iOS/Android bundle identifier is an external identifier that must
+// never drift or be fabricated (see the SEV1 "never fabricate identifiers" rule
+// in CLAUDE.md). `com.aschung212.lift` is a deliberate decision from #216 and is
+// the identity the App Store build will ship under — changing it silently would
+// orphan an installed app's data and break Capacitor plugin allow-lists.
+describe('capacitor.config.ts regression', () => {
+  it('pins the iOS/Android appId to the deliberate com.aschung212.lift bundle id', () => {
+    expect(capacitorConfig).toContain("appId: 'com.aschung212.lift'")
+    // The old placeholder id must never come back.
+    expect(capacitorConfig).not.toContain('app.lift.tracker')
+  })
+
+  it('keeps appName as Lift and webDir pointing at the Vite dist bundle', () => {
+    expect(capacitorConfig).toContain("appName: 'Lift'")
+    expect(capacitorConfig).toContain("webDir: 'dist'")
+  })
+
+  it('keeps the iOS custom scheme so deep links and StatusBar config resolve', () => {
+    expect(capacitorConfig).toContain("scheme: 'Lift'")
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-531](https://github.com/aschung212/Lift/issues/531)

LIFT-531 asks to initialize Capacitor and run Lift on the iOS Simulator. After reading the repo I split the issue into what an unattended headless builder can verifiably commit versus what requires an interactive Mac/Xcode session:

- **Committable & verifiable**: the deliberate `appId` decision from #216, pinned by a regression test, plus a documented runbook.
- **Interactive-only (deferred)**: `npx cap add ios`, setting the Xcode deployment target, and building/launching/smoke-testing on the Simulator — GUI operations a headless run cannot perform, build-verify, or capture in a PR.

## Changes
- `capacitor.config.ts` — `appId` changed from the `app.lift.tracker` placeholder to the deliberate `com.aschung212.lift` (scope item #1), set before the native project is generated so it scaffolds under the correct identity.
- `src/lib/__tests__/capacitorConfigRegression.test.ts` (new) — pins `appId`, `appName`, `webDir`, and the iOS `scheme`; asserts the old placeholder id can never return. Follows the existing `metaRegression`/`buildConfigRegression` pattern and the SEV1 "never fabricate identifiers" rule.
- `README.md` — added a "Native iOS build (Capacitor)" runbook documenting `npx cap add ios`, `npm run cap:build`, the iOS 16 deployment target, and the Simulator launch for Aaron to run locally.

## Verification
- `npm test` — 1844 passed, 1 skipped (+3 new tests)
- `npm run lint` — 0 errors (9 pre-existing warnings, none in changed files)
- `npm run build` — succeeds (PWA precache 44 entries)
- Pre-commit Gemini review: no issues found
- Pushed `enhance/run2-2026-05-29` to origin (pre-push rebase + review passed)

Note: the working tree had unrelated pre-existing changes from other iterations at session start; I staged only my three files and stashed/restored the rest around the rebase-on-push so nothing of theirs was committed.

## Screenshots
None — no UI changes (config + test + docs only). The Simulator smoke-test is the deferred interactive step.

## Commits
- [`5b43339`](https://github.com/aschung212/Lift/commit/5b43339) chore(#531): set Capacitor appId to com.aschung212.lift and pin it with a regression test
- [`be07204`](https://github.com/aschung212/Lift/commit/be07204) chore(deps): Bump supabase/setup-cli (#671)

## Test Results
- Before: 1841 passing
- After: 1844 passing (3 delta)

---
_Automated by overnight pipeline — Fri May 29 23:14:12 PDT 2026_

## Preview
Test on your phone: https://lift-nkbhn9wsc-aschung212-1101s-projects.vercel.app