### PR TITLE
chore(LIFT-533): gate Vercel telemetry off native + harden Sentry PII scrubbing

### DIFF
--- a/src/__tests__/telemetryGating.test.ts
+++ b/src/__tests__/telemetryGating.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test for LIFT-533: Capacitor-aware telemetry gating + Sentry PII
+ * scrubbing.
+ *
+ * - Vercel Analytics + Speed Insights must NOT fire on the native iOS Capacitor
+ *   build (keeps the App Store privacy story simple — no analytics network calls
+ *   on device). They stay enabled on the web build.
+ * - Sentry must scrub PII consistently: sendDefaultPii disabled, IP address
+ *   stripped in beforeSend, and releases tagged so web crashes are
+ *   distinguishable from iOS crashes.
+ *
+ * main.ts mounts the app as an import side effect, so we scan the source rather
+ * than execute it — the same approach as analyticsDeferral.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const mainSrc = readFileSync(resolve(__dirname, '../main.ts'), 'utf-8')
+
+describe('telemetry gating + PII scrubbing (LIFT-533)', () => {
+  it('imports the native-platform flag', () => {
+    expect(mainSrc).toMatch(/import\s*\{\s*isNative\s*\}\s*from\s*['"]\.\/lib\/platform['"]/)
+  })
+
+  it('gates Vercel Analytics + Speed Insights behind a native-platform check', () => {
+    // The inject() / injectSpeedInsights() calls must sit inside an `if (!isNative)`
+    // block so they never run on the iOS Capacitor build.
+    const gateBlock = mainSrc.match(/if\s*\(\s*!isNative\s*\)\s*\{([\s\S]*?)\}/)
+    expect(gateBlock).not.toBeNull()
+    expect(gateBlock![1]).toContain('inject()')
+    expect(gateBlock![1]).toContain('injectSpeedInsights()')
+  })
+
+  it('disables Sentry default PII collection', () => {
+    expect(mainSrc).toMatch(/sendDefaultPii:\s*false/)
+  })
+
+  it('scrubs the IP address in Sentry beforeSend', () => {
+    expect(mainSrc).toMatch(/delete\s+event\.user\.ip_address/)
+  })
+
+  it('tags Sentry releases to distinguish web from iOS builds', () => {
+    // release: `${isNative ? 'ios' : 'web'}@${__APP_VERSION__}`
+    expect(mainSrc).toMatch(/release:\s*`\$\{isNative\s*\?\s*'ios'\s*:\s*'web'\}@\$\{__APP_VERSION__\}`/)
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { injectSpeedInsights } from '@vercel/speed-insights'
 import { initNativePlugins } from './lib/native'
 import { initTheme } from './composables/useTheme'
 import { setSentryCaptureException, logError } from './lib/logger'
+import { isNative } from './lib/platform'
 import App from './App.vue'
 import './index.css'
 
@@ -20,8 +21,13 @@ const deferAfterPaint = (fn: () => void): void => {
 }
 
 deferAfterPaint(() => {
-  inject()
-  injectSpeedInsights()
+  // Vercel Analytics + Speed Insights are web-only (LIFT-533): keep them out of
+  // the iOS Capacitor build so the native app makes no analytics network calls,
+  // simplifying any future App Store privacy declarations.
+  if (!isNative) {
+    inject()
+    injectSpeedInsights()
+  }
 })
 
 initNativePlugins()
@@ -42,8 +48,12 @@ if (sentryDsn && import.meta.env.PROD) {
       app,
       dsn: sentryDsn,
       environment: import.meta.env.MODE,
+      // Distinguish web vs. iOS crashes in Sentry releases (LIFT-533).
+      release: `${isNative ? 'ios' : 'web'}@${__APP_VERSION__}`,
       tracesSampleRate: 0.1,
       enabled: true,
+      // Never attach default PII (IP, headers, cookies) on web or native (LIFT-533).
+      sendDefaultPii: false,
       denyUrls: [
         // Bot probes for CMS/REST endpoints that don't exist in this SPA
         /\/js\/rest\//,
@@ -52,6 +62,8 @@ if (sentryDsn && import.meta.env.PROD) {
       ],
       beforeSend(event) {
         if (event.request?.cookies) delete event.request.cookies
+        // Scrub IP address — defensive even with sendDefaultPii:false (LIFT-533).
+        if (event.user) delete event.user.ip_address
         return event
       },
     })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-533](https://github.com/aschung212/Lift/issues/533)

LIFT-533 asks to keep Vercel telemetry out of the native iOS Capacitor build and harden Sentry PII handling. I assessed the headless-implementable scope versus the simulator-only verification:
- **Implementable & verifiable headless** (done): gate analytics behind `!isNative`, configure Sentry (`sendDefaultPii: false`, IP scrub, web-vs-ios release tag), regression test.
- **Simulator-only** (deferred): confirming via Safari DevTools that zero analytics requests fire on device — requires #531's interactive Xcode build, which a headless run cannot perform.

Capacitor (`@capacitor/core`), Sentry (`@sentry/vue`), and `src/lib/platform.ts`'s `isNative` flag already existed, so no new dependencies were needed.

## Changes
- `src/main.ts` — import `isNative`; wrap `inject()` / `injectSpeedInsights()` in `if (!isNative)` inside the existing deferred-after-paint block (preserves LIFT-636 deferral); add `sendDefaultPii: false`, `release: \`${isNative ? 'ios' : 'web'}@${__APP_VERSION__}\``, and `delete event.user.ip_address` in `beforeSend`.
- `src/__tests__/telemetryGating.test.ts` (new) — source-scan regression test (mirrors `analyticsDeferral.test.ts`) locking in the native gate, PII disablement, IP scrub, and web/ios release tagging.

## Verification
- `npm test` → 1839 passed, 1 skipped (90 files)
- `npm run lint` → 0 errors (pre-existing warnings only, none in changed files)
- `npm run typecheck` → clean
- `npm run build` → succeeds, PWA generated
- Pre-push + post-commit Gemini 3.1 Pro review → "No issues found"

## Screenshots
None — change is build/telemetry configuration with no UI surface.

## Discovery
ISSUE_DISCOVER:Stranded untracked files persist on the working tree at session start (`.run-browser-probe.sh`, `src/components/__tests__/_axe_probe.test.ts`, `supabase/migrations/20260529000000_add_notes.sql`) — same artifacts flagged by run2/run3 (LIFT-666/665/619 work never committed to a branch). They should be recovered into proper PRs or removed so each iteration starts from a clean tree.

## Commits
- [`5921f6b`](https://github.com/aschung212/Lift/commit/5921f6b) chore(LIFT-533): gate Vercel telemetry off native + harden Sentry PII scrubbing

## Test Results
- Before: 1834 passing
- After: 1839 passing (5 delta)

---
_Automated by overnight pipeline — Fri May 29 23:42:41 PDT 2026_

## Preview
Test on your phone: https://lift-m1lrhrc7t-aschung212-1101s-projects.vercel.app