### PR TITLE
refactor(LIFT-532): make useServiceWorker a safe singleton

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ This app will be wrapped with Capacitor for the App Store. Keep all code compati
 - Use `env(safe-area-inset-*)` for notch and home indicator spacing on all fixed/sticky elements
 - No hard dependencies on browser URL bar, back button, or browser navigation
 - localStorage and IndexedDB are available in Capacitor — these are safe to use
-- Test that service worker behavior degrades gracefully when running in Capacitor (native apps handle caching differently)
+- The service worker is **disabled entirely on the native Capacitor build** (#532). WKWebView serves the web assets bundled in the `.ipa` and refreshes them via `cap sync`, so a Workbox SW is redundant and risks reload loops / stale caches. This is enforced in two layers: `useServiceWorker` skips `registerSW` at runtime when `isNative`, and `vite.config.js` sets `VitePWA({ disable: true })` when `CAPACITOR_BUILD=true`. **Always build the native bundle with `npm run cap:build`** (it sets that env var) — a plain `npm run build` would bundle a SW into the native app.
 - Avoid `position: fixed` layouts that break when the iOS keyboard opens — use `visualViewport` API or bottom-sheet patterns that account for keyboard
 
 ## iOS Compliance

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cap:sync": "npx cap sync",
     "cap:open:ios": "npx cap open ios",
     "cap:run:ios": "npx cap run ios",
-    "cap:build": "npm run build && npx cap sync"
+    "cap:build": "CAPACITOR_BUILD=true npm run build && npx cap sync"
   },
   "dependencies": {
     "@capacitor/core": "^8.3.4",

--- a/src/App.vue
+++ b/src/App.vue
@@ -232,7 +232,7 @@ import { useUndoToast } from './composables/useUndoToast'
 import { useFocusTrap } from './composables/useFocusTrap'
 import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
 import { useInstallPrompt } from './composables/useInstallPrompt'
-import { registerSW } from 'virtual:pwa-register'
+import { useServiceWorker } from './composables/useServiceWorker'
 import { onCrossTabMessage, type StoreKey } from './lib/crossTabSync'
 
 const { currentTheme, THEME_PREVIEWS, resolvedMode, isThemeUnlocked } = useTheme()
@@ -285,35 +285,9 @@ const settingsSheetRef = ref<InstanceType<typeof SettingsSheet> | null>(null)
 const shortcutsFocus = useFocusTrap()
 
 // ── Service worker auto-update ──────────────────────────────────
-let swRegistration: ServiceWorkerRegistration | undefined
-registerSW({
-  onRegisteredSW(_url, registration) {
-    swRegistration = registration ?? undefined
-    // Poll for updates every 10 minutes
-    setInterval(() => registration?.update(), 10 * 60 * 1000)
-  },
-  onOfflineReady() { /* SW installed, app works offline */ },
-})
-
-// Check for SW update on visibility change (tab switch back, app resume)
-document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState === 'visible') swRegistration?.update()
-})
-
-// Expose a function components can call after meaningful user actions
-function checkForSWUpdate() { swRegistration?.update() }
-
-// Listen for the controlling SW changing — means auto-update activated.
-// On first visit currentController is null; skip reload to avoid a surprise refresh.
-// On subsequent changes a new SW took over — reload to pick up fresh chunk hashes
-// (without this, lazy-loaded tabs request old hashed filenames that no longer exist).
-let currentController = navigator.serviceWorker?.controller
-navigator.serviceWorker?.addEventListener('controllerchange', () => {
-  if (currentController) {
-    window.location.reload()
-  }
-  currentController = navigator.serviceWorker?.controller ?? null
-})
+// Registration is skipped entirely on the native Capacitor build (#532);
+// see useServiceWorker for the rationale.
+const { checkForSWUpdate } = useServiceWorker()
 
 // ── Onboarding ──────────────────────────────────────────────────
 const onboardingComplete = ref(!!localStorage.getItem('onboarding-complete'))

--- a/src/__tests__/stubs/pwaRegister.ts
+++ b/src/__tests__/stubs/pwaRegister.ts
@@ -1,0 +1,7 @@
+import { vi } from 'vitest'
+
+// Test stub for the `virtual:pwa-register` module provided by vite-plugin-pwa
+// at build time. The plugin's virtual module does not exist in the Vitest
+// environment, so vitest.config.js aliases `virtual:pwa-register` here.
+// Tests import this same `registerSW` instance to assert registration behavior.
+export const registerSW = vi.fn()

--- a/src/composables/__tests__/useServiceWorker.test.ts
+++ b/src/composables/__tests__/useServiceWorker.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-// vitest.config.js aliases `virtual:pwa-register` to a stub, so the composable
-// and this test share the same `registerSW` spy instance.
-import { registerSW } from 'virtual:pwa-register'
-
-const registerSWMock = vi.mocked(registerSW)
+import type { Mock } from 'vitest'
 
 // Mutable platform mock — flipped per test via the `setNative` helper below.
 let nativeFlag = false
@@ -15,14 +11,21 @@ function setNative(value: boolean) {
   nativeFlag = value
 }
 
-// `isNative` is read through the mocked getter on each access (ESM live binding),
-// so no module reset is needed — flipping `nativeFlag` is enough between tests.
-import { useServiceWorker } from '../useServiceWorker'
+// vitest.config.js aliases `virtual:pwa-register` to a stub. The composable holds
+// module-scoped singleton state (it registers the SW exactly once), so each test
+// resets the module graph and re-grabs the freshly evaluated stub spik so the
+// composable and the test share the same `registerSW` spy instance.
+let useServiceWorker: typeof import('../useServiceWorker').useServiceWorker
+let registerSWMock: Mock
 
 describe('useServiceWorker', () => {
-  beforeEach(() => {
-    registerSWMock.mockReset()
+  beforeEach(async () => {
     setNative(false)
+    vi.resetModules()
+    const pwa = await import('virtual:pwa-register')
+    registerSWMock = vi.mocked(pwa.registerSW) as unknown as Mock
+    registerSWMock.mockReset()
+    ;({ useServiceWorker } = await import('../useServiceWorker'))
   })
 
   afterEach(() => {
@@ -56,6 +59,22 @@ describe('useServiceWorker', () => {
     // visibilitychange listener is registered to poll for updates on resume.
     expect(addDocListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
     expect(typeof checkForSWUpdate).toBe('function')
+  })
+
+  it('registers the SW only once even when called from multiple components (web)', () => {
+    setNative(false)
+    const addDocListener = vi.spyOn(document, 'addEventListener')
+
+    useServiceWorker()
+    useServiceWorker()
+    useServiceWorker()
+
+    // Singleton guard: registration + listeners are wired exactly once.
+    expect(registerSWMock).toHaveBeenCalledTimes(1)
+    const visibilityCalls = addDocListener.mock.calls.filter(
+      ([event]) => event === 'visibilitychange'
+    )
+    expect(visibilityCalls).toHaveLength(1)
   })
 
   it('checkForSWUpdate triggers a registration update once the SW is registered (web)', () => {

--- a/src/composables/__tests__/useServiceWorker.test.ts
+++ b/src/composables/__tests__/useServiceWorker.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+// vitest.config.js aliases `virtual:pwa-register` to a stub, so the composable
+// and this test share the same `registerSW` spy instance.
+import { registerSW } from 'virtual:pwa-register'
+
+const registerSWMock = vi.mocked(registerSW)
+
+// Mutable platform mock — flipped per test via the `setNative` helper below.
+let nativeFlag = false
+vi.mock('../../lib/platform', () => ({
+  get isNative() { return nativeFlag },
+}))
+
+function setNative(value: boolean) {
+  nativeFlag = value
+}
+
+// `isNative` is read through the mocked getter on each access (ESM live binding),
+// so no module reset is needed — flipping `nativeFlag` is enough between tests.
+import { useServiceWorker } from '../useServiceWorker'
+
+describe('useServiceWorker', () => {
+  beforeEach(() => {
+    registerSWMock.mockReset()
+    setNative(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does NOT register the service worker on the native Capacitor build (#532)', () => {
+    setNative(true)
+    const addDocListener = vi.spyOn(document, 'addEventListener')
+
+    const { checkForSWUpdate } = useServiceWorker()
+
+    expect(registerSWMock).not.toHaveBeenCalled()
+    // No visibilitychange listener wired on native.
+    expect(addDocListener).not.toHaveBeenCalledWith('visibilitychange', expect.anything())
+    // checkForSWUpdate is a safe no-op.
+    expect(() => checkForSWUpdate()).not.toThrow()
+  })
+
+  it('registers the service worker on the web build', () => {
+    setNative(false)
+    const addDocListener = vi.spyOn(document, 'addEventListener')
+
+    const { checkForSWUpdate } = useServiceWorker()
+
+    expect(registerSWMock).toHaveBeenCalledTimes(1)
+    // Update polling is wired through the onRegisteredSW callback.
+    const opts = registerSWMock.mock.calls[0][0]
+    expect(opts).toHaveProperty('onRegisteredSW')
+    expect(opts).toHaveProperty('onOfflineReady')
+    // visibilitychange listener is registered to poll for updates on resume.
+    expect(addDocListener).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+    expect(typeof checkForSWUpdate).toBe('function')
+  })
+
+  it('checkForSWUpdate triggers a registration update once the SW is registered (web)', () => {
+    setNative(false)
+    const update = vi.fn()
+
+    useServiceWorker()
+
+    // Simulate the PWA plugin invoking onRegisteredSW with a registration.
+    const opts = registerSWMock.mock.calls[0][0] as {
+      onRegisteredSW: (url: string, reg: { update: () => void }) => void
+    }
+    vi.useFakeTimers()
+    opts.onRegisteredSW('/sw.js', { update })
+    // The 10-minute polling interval fires an update.
+    vi.advanceTimersByTime(10 * 60 * 1000)
+    expect(update).toHaveBeenCalled()
+    vi.useRealTimers()
+  })
+})

--- a/src/composables/useServiceWorker.ts
+++ b/src/composables/useServiceWorker.ts
@@ -1,0 +1,57 @@
+import { registerSW } from 'virtual:pwa-register'
+import { isNative } from '../lib/platform'
+
+/**
+ * Service worker lifecycle management for the web (PWA) build.
+ *
+ * On the native Capacitor build (#532) the entire service worker is skipped:
+ * WKWebView serves the web assets bundled inside the .ipa at build time, and
+ * those assets are refreshed via `cap sync` — not through a web caching layer.
+ * Registering Workbox there is at best redundant and at worst harmful: the
+ * `controllerchange → window.location.reload()` handler can trigger reload
+ * loops in the native shell, and a stale SW cache could shadow the freshly
+ * bundled native assets. The Vite PWA plugin is also disabled at build time
+ * for Capacitor builds (see `CAPACITOR_BUILD` in `vite.config.js`), so this
+ * runtime guard is the belt-and-suspenders second layer.
+ *
+ * @returns `checkForSWUpdate` — call after meaningful user actions to poll for
+ *          a new version. A no-op on native.
+ */
+export function useServiceWorker(): { checkForSWUpdate: () => void } {
+  // Native Capacitor build: no service worker at all.
+  if (isNative) {
+    return { checkForSWUpdate: () => {} }
+  }
+
+  let swRegistration: ServiceWorkerRegistration | undefined
+  registerSW({
+    onRegisteredSW(_url, registration) {
+      swRegistration = registration ?? undefined
+      // Poll for updates every 10 minutes
+      setInterval(() => registration?.update(), 10 * 60 * 1000)
+    },
+    onOfflineReady() { /* SW installed, app works offline */ },
+  })
+
+  // Check for SW update on visibility change (tab switch back, app resume)
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') swRegistration?.update()
+  })
+
+  // Listen for the controlling SW changing — means auto-update activated.
+  // On first visit currentController is null; skip reload to avoid a surprise refresh.
+  // On subsequent changes a new SW took over — reload to pick up fresh chunk hashes
+  // (without this, lazy-loaded tabs request old hashed filenames that no longer exist).
+  let currentController = navigator.serviceWorker?.controller
+  navigator.serviceWorker?.addEventListener('controllerchange', () => {
+    if (currentController) {
+      window.location.reload()
+    }
+    currentController = navigator.serviceWorker?.controller ?? null
+  })
+
+  // Expose a function components can call after meaningful user actions
+  function checkForSWUpdate() { swRegistration?.update() }
+
+  return { checkForSWUpdate }
+}

--- a/src/composables/useServiceWorker.ts
+++ b/src/composables/useServiceWorker.ts
@@ -17,13 +17,28 @@ import { isNative } from '../lib/platform'
  * @returns `checkForSWUpdate` — call after meaningful user actions to poll for
  *          a new version. A no-op on native.
  */
+// Module-scoped singleton state. The SW must be registered exactly once per
+// document; guarding here keeps the composable safe to call from multiple
+// components without leaking duplicate listeners or overlapping update polls.
+let swRegistration: ServiceWorkerRegistration | undefined
+let registered = false
+
 export function useServiceWorker(): { checkForSWUpdate: () => void } {
   // Native Capacitor build: no service worker at all.
   if (isNative) {
     return { checkForSWUpdate: () => {} }
   }
 
-  let swRegistration: ServiceWorkerRegistration | undefined
+  // Expose a function components can call after meaningful user actions.
+  // Reads the module-scoped registration so it stays valid across callers.
+  const checkForSWUpdate = () => swRegistration?.update()
+
+  // Already wired up by an earlier caller — reuse the existing registration.
+  if (registered) {
+    return { checkForSWUpdate }
+  }
+  registered = true
+
   registerSW({
     onRegisteredSW(_url, registration) {
       swRegistration = registration ?? undefined
@@ -49,9 +64,6 @@ export function useServiceWorker(): { checkForSWUpdate: () => void } {
     }
     currentController = navigator.serviceWorker?.controller ?? null
   })
-
-  // Expose a function components can call after meaningful user actions
-  function checkForSWUpdate() { swRegistration?.update() }
 
   return { checkForSWUpdate }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,6 +35,11 @@ export default defineConfig({
     vue(),
     themeStripPlugin(),
     VitePWA({
+      // Disable the service worker entirely for the native Capacitor build (#532).
+      // WKWebView serves the web assets bundled in the .ipa and refreshes them via
+      // `cap sync`, so a Workbox SW is redundant and can cause reload loops / stale
+      // caches. `npm run cap:build` sets CAPACITOR_BUILD=true.
+      disable: process.env.CAPACITOR_BUILD === 'true',
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png'],
       manifest: {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,8 +1,18 @@
 import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
+import { fileURLToPath } from 'node:url'
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      // vite-plugin-pwa injects `virtual:pwa-register` only during a real build.
+      // Alias it to a test stub so composables that register the SW are testable.
+      'virtual:pwa-register': fileURLToPath(
+        new URL('./src/__tests__/stubs/pwaRegister.ts', import.meta.url)
+      ),
+    },
+  },
   test: {
     environment: 'happy-dom',
     globals: true,


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-532](https://github.com/aschung212/Lift/issues/532)

LIFT-532 asks to fix service-worker / WKWebView compatibility for the Capacitor build. I split the work into the headless-implementable engineering (disable the SW on native + lock it in with a test) versus the simulator-only acceptance criteria (verifying on iOS Simulator), which depend on #531's interactive Xcode build and are out of reach for a headless run.

The codebase already had `src/lib/platform.ts` (`isNative`) and `vite-plugin-pwa`, so no new dependencies were needed. I confirmed `vite-plugin-pwa` supports the `disable` option (node_modules type def, default `false`).

## Changes
- **`src/composables/useServiceWorker.ts`** (new) — extracts the SW registration, 10-min update polling, `visibilitychange`, and `controllerchange → reload` logic out of `App.vue`. No-ops entirely when `isNative`. Module-scoped singleton guard so repeated calls never leak duplicate listeners/intervals.
- **`src/App.vue`** — replaces ~30 lines of inline SW wiring with `const { checkForSWUpdate } = useServiceWorker()`.
- **`vite.config.js`** — `VitePWA({ disable: process.env.CAPACITOR_BUILD === 'true' })` so the native build emits no `sw.js` at all (belt-and-suspenders with the runtime guard).
- **`package.json`** — `cap:build` now passes `CAPACITOR_BUILD=true`.
- **`vitest.config.js`** + **`src/__tests__/stubs/pwaRegister.ts`** (new) — aliases the build-only `virtual:pwa-register` virtual module to a test stub so SW code is testable.
- **`src/composables/__tests__/useServiceWorker.test.ts`** (new) — 4 regression tests: SW skipped on native, wired on web, registered exactly once across repeated calls, and update polling fires.
- **`CLAUDE.md`** — documents the SW-disabled-on-native decision and the `npm run cap:build` requirement.

## Verification
- `npm test` — 1838 passed, 1 skipped (was 1834; +4 new tests).
- `npm run typecheck` — clean (vue-tsc).
- `npm run lint` — 0 errors (only pre-existing warnings, none in new files).
- `npm run build` (web) — succeeds, still emits `dist/sw.js` + workbox → web PWA behavior unchanged.
- Capacitor build path: `disable` option confirmed in `vite-plugin-pwa` types; runtime guard covered by tests. (Could not run `CAPACITOR_BUILD=true vite build` to completion in the sandbox, but the `disable: true` semantics are documented and the runtime layer is test-covered.)
- Pre-push Gemini review: "No issues found" after addressing the singleton P2.

## Discoveries
ISSUE_DISCOVER:The Gemini pre-push/post-commit review chokes on `package.json` whenever it's in the diff — it tries to `stat` the `lint-staged` glob keys (e.g. `src/**/*.{js,ts,vue}`) as file paths and emits `ENAMETOOLONG: name too long`. Any PR touching `package.json` floods the review with this noise. Consider excluding `package.json` from the review's path-stat step (same class as run3's lockfile-noise discovery).

ISSUE_DISCOVER:Stray untracked files remain on the working tree at session start (`.run-browser-probe.sh`, `src/components/__tests__/_axe_probe.test.ts`, `supabase/migrations/20260529000000_add_notes.sql`) — orphaned from earlier browser-mode/axe/notes work (LIFT-666/665/619) that was never committed to a branch. They should be recovered into proper PRs or removed; `_axe_probe.test.ts` in particular risks being picked up by the default vitest run.

## Commits
- [`2116b01`](https://github.com/aschung212/Lift/commit/2116b01) refactor(LIFT-532): make useServiceWorker a safe singleton
- [`63c49c5`](https://github.com/aschung212/Lift/commit/63c49c5) fix(LIFT-532): disable service worker on native Capacitor build

## Test Results
- Before: 1834 passing
- After: 1838 passing (4 delta)

---
_Automated by overnight pipeline — Sat May 30 00:00:08 PDT 2026_

## Preview
Test on your phone: https://lift-j6qwa6y6n-aschung212-1101s-projects.vercel.app