### PR TITLE
feat(LIFT-602): request App Store review at high-satisfaction moments

### DIFF
--- a/src/composables/__tests__/useAppReview.test.ts
+++ b/src/composables/__tests__/useAppReview.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Native by default so the policy logic is exercised; individual tests can
+// re-mock platform as web to assert the no-op path.
+vi.mock('../../lib/platform', () => ({ isNative: true, isIOS: true, platform: 'ios' }))
+
+// Spy on the native bridge so tests stay independent of StoreKit.
+const requestNativeReview = vi.fn(() => Promise.resolve(true))
+vi.mock('../../lib/appReview', () => ({ requestNativeReview }))
+
+let useAppReview: typeof import('../useAppReview').useAppReview
+let canRequestReview: typeof import('../useAppReview').canRequestReview
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const NOW = Date.UTC(2026, 4, 30) // fixed reference instant
+
+beforeEach(async () => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  localStorage.clear()
+  vi.doMock('../../lib/platform', () => ({ isNative: true, isIOS: true, platform: 'ios' }))
+  vi.doMock('../../lib/appReview', () => ({ requestNativeReview }))
+  const mod = await import('../useAppReview')
+  useAppReview = mod.useAppReview
+  canRequestReview = mod.canRequestReview
+})
+
+describe('useAppReview', () => {
+  it('allows a review on a fresh install', () => {
+    expect(canRequestReview(NOW)).toBe(true)
+    const { requestReviewAtMoment } = useAppReview()
+    expect(requestReviewAtMoment('pr', NOW)).toBe(true)
+    expect(requestNativeReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('records each prompt in history', () => {
+    const { requestReviewAtMoment, getPromptHistory } = useAppReview()
+    requestReviewAtMoment('pr', NOW)
+    expect(getPromptHistory(NOW)).toEqual([NOW])
+  })
+
+  it('enforces a minimum spacing between prompts', () => {
+    const { requestReviewAtMoment } = useAppReview()
+    expect(requestReviewAtMoment('pr', NOW)).toBe(true)
+    // Two days later — too soon.
+    expect(requestReviewAtMoment('theme_unlock', NOW + 2 * DAY_MS)).toBe(false)
+    expect(requestNativeReview).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows another prompt once the spacing window passes', () => {
+    const { requestReviewAtMoment } = useAppReview()
+    expect(requestReviewAtMoment('pr', NOW)).toBe(true)
+    expect(requestReviewAtMoment('theme_unlock', NOW + 20 * DAY_MS)).toBe(true)
+    expect(requestNativeReview).toHaveBeenCalledTimes(2)
+  })
+
+  it('caps prompts at 3 per rolling year', () => {
+    const { requestReviewAtMoment } = useAppReview()
+    expect(requestReviewAtMoment('pr', NOW)).toBe(true)
+    expect(requestReviewAtMoment('pr', NOW + 30 * DAY_MS)).toBe(true)
+    expect(requestReviewAtMoment('pr', NOW + 60 * DAY_MS)).toBe(true)
+    // Fourth within the year is blocked.
+    expect(requestReviewAtMoment('pr', NOW + 90 * DAY_MS)).toBe(false)
+    expect(requestNativeReview).toHaveBeenCalledTimes(3)
+  })
+
+  it('frees up budget once old prompts age past a year', () => {
+    const { requestReviewAtMoment } = useAppReview()
+    requestReviewAtMoment('pr', NOW)
+    requestReviewAtMoment('pr', NOW + 30 * DAY_MS)
+    requestReviewAtMoment('pr', NOW + 60 * DAY_MS)
+    // 400 days after the first prompt: NOW (+400d old) and NOW+30 (+370d old)
+    // are pruned, only NOW+60 (340d old) remains — so budget reopens.
+    const later = NOW + 400 * DAY_MS
+    expect(canRequestReview(later)).toBe(true)
+    expect(requestReviewAtMoment('theme_unlock', later)).toBe(true)
+  })
+
+  it('ignores corrupt history in storage', () => {
+    localStorage.setItem('app-review-history', '{not json')
+    expect(canRequestReview(NOW)).toBe(true)
+  })
+
+  it('does nothing on web (no native review API)', async () => {
+    vi.resetModules()
+    vi.doMock('../../lib/platform', () => ({ isNative: false, isIOS: false, platform: 'web' }))
+    vi.doMock('../../lib/appReview', () => ({ requestNativeReview }))
+    const mod = await import('../useAppReview')
+    const { requestReviewAtMoment, getPromptHistory } = mod.useAppReview()
+    expect(requestReviewAtMoment('pr', NOW)).toBe(false)
+    expect(requestNativeReview).not.toHaveBeenCalled()
+    // Budget is untouched on web.
+    expect(getPromptHistory(NOW)).toEqual([])
+  })
+})

--- a/src/composables/useAppReview.ts
+++ b/src/composables/useAppReview.ts
@@ -1,0 +1,105 @@
+/**
+ * useAppReview — decides when to ask for an App Store rating.
+ *
+ * Apple's HIG (and StoreKit itself) limit review prompts to 3 per 365-day
+ * window and recommend only prompting at moments of genuine satisfaction —
+ * never mid-task and never via a custom "please rate us" button. This
+ * composable encodes that policy and is the single gate in front of the native
+ * StoreKit call:
+ *
+ *   - prompt only at high-satisfaction moments (a new PR, a theme unlock, or a
+ *     workout-count milestone)
+ *   - at most 3 prompts per rolling 365 days
+ *   - at least 14 days between prompts, so two unlocks in one session can't
+ *     double-prompt
+ *   - never on web (no review API exists) — `requestNativeReview` no-ops there
+ *
+ * The actual StoreKit bridge lives in `src/lib/appReview.ts`; wiring it into the
+ * native build + on-device verification depends on the Capacitor iOS setup
+ * (#531). The eligibility logic here is platform-independent and fully tested.
+ */
+import { requestNativeReview } from '../lib/appReview'
+import { isNative } from '../lib/platform'
+import { logError } from '../lib/logger'
+
+/** The satisfaction moments at which a review may be requested. */
+export type ReviewMoment = 'pr' | 'theme_unlock' | 'workout_milestone'
+
+const STORAGE_KEY = 'app-review-history'
+const MAX_PROMPTS_PER_YEAR = 3
+const MIN_DAYS_BETWEEN_PROMPTS = 14
+const DAY_MS = 24 * 60 * 60 * 1000
+const YEAR_MS = 365 * DAY_MS
+
+/** Read the recorded prompt timestamps (ms), pruning anything older than a year. */
+function loadPrompts(now: number): number[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((t): t is number => typeof t === 'number' && now - t < YEAR_MS)
+  } catch {
+    return []
+  }
+}
+
+function savePrompts(prompts: number[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prompts))
+  } catch (e) {
+    logError(e, { source: 'useAppReview.savePrompts' })
+  }
+}
+
+/**
+ * Whether a review prompt is allowed right now, given the recorded history.
+ * Exported for direct testing of the policy.
+ */
+export function canRequestReview(now: number = Date.now()): boolean {
+  const prompts = loadPrompts(now)
+  if (prompts.length >= MAX_PROMPTS_PER_YEAR) return false
+  const last = prompts.length > 0 ? Math.max(...prompts) : null
+  if (last !== null && now - last < MIN_DAYS_BETWEEN_PROMPTS * DAY_MS) return false
+  return true
+}
+
+export interface UseAppReviewReturn {
+  /**
+   * Request a native review prompt for the given satisfaction moment.
+   * Returns `true` if the prompt was requested (and the attempt recorded),
+   * `false` if it was suppressed by the rate-limit policy or the platform.
+   */
+  requestReviewAtMoment: (moment: ReviewMoment, now?: number) => boolean
+  /** Current prompt history (ms timestamps within the last year). */
+  getPromptHistory: (now?: number) => number[]
+}
+
+export function useAppReview(): UseAppReviewReturn {
+  function requestReviewAtMoment(moment: ReviewMoment, now: number = Date.now()): boolean {
+    // Web has no review API — never prompt and never spend the prompt budget.
+    if (!isNative) return false
+    if (!canRequestReview(now)) return false
+
+    // Record the attempt before firing so a slow/failed native call can't lead
+    // to a burst of retries from rapid successive moments.
+    const prompts = loadPrompts(now)
+    prompts.push(now)
+    savePrompts(prompts)
+
+    // Fire-and-forget: StoreKit owns the actual presentation + its own caps.
+    void requestNativeReview().catch(() => { /* swallowed in wrapper */ })
+
+    // `moment` is currently advisory (all moments share one policy) but is kept
+    // in the signature so callers self-document the trigger and future tuning
+    // can weight moments differently.
+    void moment
+    return true
+  }
+
+  function getPromptHistory(now: number = Date.now()): number[] {
+    return loadPrompts(now)
+  }
+
+  return { requestReviewAtMoment, getPromptHistory }
+}

--- a/src/composables/useXPCeremony.ts
+++ b/src/composables/useXPCeremony.ts
@@ -12,6 +12,7 @@ import { THEMES } from './useTheme'
 import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stores/progression'
 import { XP_CONFIG } from '../lib/xp'
 import { logXPEvent, logBodyweightXPEvent } from '../lib/xpInstrumentation'
+import { useAppReview } from './useAppReview'
 import type { ThemeId } from './useTheme'
 
 export interface SetXPCeremonyInput {
@@ -44,6 +45,7 @@ export interface UseXPCeremonyReturn {
 
 export function useXPCeremony(): UseXPCeremonyReturn {
   const progressionStore = useProgressionStore()
+  const { requestReviewAtMoment } = useAppReview()
 
   /**
    * Run the full XP ceremony for a logged workout set.
@@ -121,6 +123,13 @@ export function useXPCeremony(): UseXPCeremonyReturn {
 
       showXPToast(parts.join(' · '), progressionStore.progressPercent, progressionStore.totalXP, progressionStore.nextUnlockThreshold)
     }
+
+    // High-satisfaction moment: hitting a real PR is a peak moment to ask for
+    // an App Store rating. The composable enforces Apple's per-year caps and
+    // no-ops on web; a tie is not celebratory enough to prompt.
+    if (isPR && !isTie) {
+      requestReviewAtMoment('pr')
+    }
   }
 
   /**
@@ -160,6 +169,9 @@ export function useXPCeremony(): UseXPCeremonyReturn {
         setTimeout(() => {
           showUnlockCelebration(theme.id, theme.label)
           onUnlock?.()
+          // Unlocking a new theme is a high-satisfaction moment — ask for a
+          // rating once the celebration is on screen. Rate-limited + web no-op.
+          requestReviewAtMoment('theme_unlock')
         }, progressionStore.showProgression ? 1500 : 500)
       }
     }

--- a/src/lib/appReview.ts
+++ b/src/lib/appReview.ts
@@ -1,0 +1,49 @@
+/**
+ * Native App Store review prompt wrapper.
+ *
+ * Wraps StoreKit's `SKStoreReviewController.requestReview` (exposed on iOS via
+ * the `@capacitor-community/app-review` plugin). On web there is no equivalent
+ * API, so this is a no-op — PWA users never see a review prompt.
+ *
+ * The plugin is loaded through a runtime-constructed dynamic import so the web
+ * bundle does not statically depend on it. The plugin itself is installed and
+ * wired into the native build as part of the Capacitor iOS setup (#531); until
+ * then this resolves to a no-op on every platform. The decision of *when* to
+ * prompt (rolling caps, satisfaction moments) lives in `useAppReview` and is
+ * fully exercised in tests independent of the native bridge.
+ */
+import { isNative } from './platform'
+import { logWarn } from './logger'
+
+// Constructed at runtime so the bundler does not attempt to resolve the
+// native-only plugin during the web build.
+const APP_REVIEW_PLUGIN = ['@capacitor-community', 'app-review'].join('/')
+
+interface AppReviewPlugin {
+  requestReview: () => Promise<void>
+}
+
+/**
+ * Ask the OS to present its native "Rate this app" prompt.
+ *
+ * Returns `true` when the native bridge was invoked, `false` when skipped
+ * (web platform, or the plugin is not available in the current build). Apple
+ * still decides whether to actually surface the prompt and silently rate-limits
+ * to a few prompts per year regardless of how often this is called.
+ */
+export async function requestNativeReview(): Promise<boolean> {
+  if (!isNative) return false
+  try {
+    const mod = (await import(/* @vite-ignore */ APP_REVIEW_PLUGIN)) as {
+      AppReview?: AppReviewPlugin
+    }
+    if (!mod.AppReview?.requestReview) return false
+    await mod.AppReview.requestReview()
+    return true
+  } catch (e) {
+    // Plugin not installed yet (pending native setup) or the bridge failed —
+    // never let a review prompt break the calling flow.
+    logWarn('Native review prompt unavailable', { error: String(e) })
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-602](https://github.com/aschung212/Lift/issues/602)

LIFT-602 asks to request an App Store review at high-satisfaction moments (post-PR, theme unlock, workout milestone) via StoreKit's `SKStoreReviewController`, capped at 3 prompts/year per Apple's guidelines. I split the work the same way runs 4–5 handled Capacitor-dependent issues:
- **Headless-implementable & testable** (done this run): the *when-to-prompt* policy engine and its wiring into the satisfaction-moment pipeline, plus a platform-gated native wrapper that no-ops on web.
- **Native-only** (deferred to #531): installing/bundling `@capacitor-community/app-review` and verifying the actual StoreKit overlay on an iOS Simulator — out of reach for a headless run since the Capacitor iOS build isn't set up yet.

## Changes
- **`src/lib/appReview.ts`** (new) — `requestNativeReview()` wraps `@capacitor-community/app-review`, loaded through a runtime-constructed dynamic import (`['@capacitor-community','app-review'].join('/')` + `/* @vite-ignore */`) so the web bundle carries no static dependency on the not-yet-installed plugin. No-ops on web and when the plugin is absent; swallows errors so a review prompt can never break the calling flow.
- **`src/composables/useAppReview.ts`** (new) — `requestReviewAtMoment(moment)` enforces Apple's policy: never on web, max 3 prompts per rolling 365 days, ≥14-day spacing (so two unlocks in one session can't double-prompt). History persisted in `localStorage`, corrupt data tolerated. Exposes `canRequestReview` / `getPromptHistory`.
- **`src/composables/useXPCeremony.ts`** — wired the two strongest, deterministic moments: a real PR (`isPR && !isTie`) in `logSetXPCeremony`, and a live theme unlock in `_checkUnlocksAndCelebrate` (fired once the celebration is on screen; retroactive migration unlocks via `celebrateUnlocks` intentionally not hooked).
- **`src/composables/__tests__/useAppReview.test.ts`** (new) — 8 tests: fresh-install allow, history recording, min-spacing, spacing-window reopen, 3/year cap, year-pruning, corrupt-storage tolerance, web no-op (budget untouched).

## Verification
- `npm run lint` — 0 errors (9 pre-existing warnings in unrelated files; my files clean)
- `npm run typecheck` — clean
- `npm test` — 1842 passed | 1 skipped (was 1834; +8 new)
- `npm run build` — succeeds, no dynamic-import warnings (the `@vite-ignore` construction keeps the plugin out of the web bundle)
- Pre-push hook: Gemini rate-limited and Codex unavailable (ENOENT) this run, so no automated findings to address; CI will gate the PR.

## Screenshots
None — the feature is a native StoreKit system overlay with no web UI surface (it no-ops on web/PWA by design).

## Commits
- [`1ca13a8`](https://github.com/aschung212/Lift/commit/1ca13a8) feat(LIFT-602): request App Store review at high-satisfaction moments

## Test Results
- Before: 1834 passing
- After: 1842 passing (8 delta)

---
_Automated by overnight pipeline — Sat May 30 00:11:35 PDT 2026_

## Preview
Test on your phone: https://lift-pyp94baeg-aschung212-1101s-projects.vercel.app