### PR TITLE
fix(LIFT-306): reconcile native app icon with synced preference

### DIFF
--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -731,9 +731,9 @@ import { ref, computed, watch, nextTick, type ComponentPublicInstance } from 'vu
 import { useTheme } from '../composables/useTheme'
 import type { ThemeId } from '../lib/themes'
 import { usePRBaseline } from '../composables/usePRBaseline'
-import { useProgressionStore, UNLOCK_TIERS, showXPToast, getUnlockedThemeIds } from '../stores/progression'
+import { useProgressionStore, UNLOCK_TIERS, showXPToast } from '../stores/progression'
 import { isNative } from '../lib/platform'
-import { APP_ICONS, getAppIcon, isAppIconUnlocked, type AppIconId } from '../lib/appIcons'
+import { APP_ICONS, getAppIcon, isAppIconUnlocked, resolveAppIconId, type AppIconId } from '../lib/appIcons'
 import { setNativeAppIcon } from '../lib/nativeAppIcon'
 import { computeThemeStats, type ThemeStats } from '../lib/themeStats'
 import { useXPCeremony } from '../composables/useXPCeremony'
@@ -775,7 +775,11 @@ const progressionActive = computed(() => progressionStore.progressionEnabled)
 
 // ── App icon picker (native iOS only) ──────────────────────────
 const showAppIconPicker = isNative
-const unlockedThemeIds = computed(() => getUnlockedThemeIds(progressionStore.unlockedThemes))
+// Mirror the theme-grid unlock rules (incl. the trial period) so a starter's
+// matching icon unlocks exactly when its theme does.
+const unlockedThemeIds = computed<ThemeId[]>(() =>
+  THEMES.filter(t => isThemeUnlocked(t.id)).map(t => t.id)
+)
 const appIconOptions = computed(() =>
   APP_ICONS.map(icon => ({
     id: icon.id,
@@ -786,13 +790,32 @@ const appIconOptions = computed(() =>
   }))
 )
 
-async function selectAppIcon(id: AppIconId) {
+function selectAppIcon(id: AppIconId) {
   const icon = getAppIcon(id)
   if (!isAppIconUnlocked(icon, unlockedThemeIds.value)) return
   if (prefs.appIcon === id) return
+  // Local-first: persist the choice; the reconcile watcher applies it to the OS.
   prefs.setAppIcon(id)
   logEvent('app_icon_change', { icon: id })
-  await setNativeAppIcon(icon.nativeName)
+}
+
+// Keep the native OS icon in sync with the stored preference. Runs on mount
+// (immediate) so a preference synced from another device is applied, and on any
+// change — including reverting to the default icon if its theme was re-locked by
+// a progression/prestige reset (resolveAppIconId handles the fallback).
+if (isNative) {
+  watch(
+    () => [prefs.appIcon, unlockedThemeIds.value.join(',')] as const,
+    () => {
+      const resolved = resolveAppIconId(prefs.appIcon, unlockedThemeIds.value)
+      if (resolved !== prefs.appIcon) {
+        prefs.setAppIcon(resolved) // reverts a now-locked icon; re-triggers this watcher
+        return
+      }
+      void setNativeAppIcon(getAppIcon(resolved).nativeName)
+    },
+    { immediate: true }
+  )
 }
 
 // ── Swipe-to-dismiss for settings sheet ────────────────────────

--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -89,6 +89,32 @@
               <button :class="['modeSegBtn', { active: weightUnit === 'kg' }]" @click="weightUnit = 'kg'" aria-label="Use kilograms" :aria-pressed="weightUnit === 'kg'">kg</button>
             </div>
           </div>
+          <!-- App icon picker (native iOS only — alternate icons can't be set on web) -->
+          <template v-if="showAppIconPicker">
+            <div class="appIconHeader">
+              <span class="settingsLabel">App Icon</span>
+              <span class="settingsHint">Unlocks with matching themes</span>
+            </div>
+            <div class="settingsThemeGrid">
+              <button
+                v-for="icon in appIconOptions"
+                :key="icon.id"
+                :class="['themePreview', { active: icon.active, locked: !icon.unlocked }]"
+                @click="icon.unlocked ? selectAppIcon(icon.id) : undefined"
+                :aria-label="icon.unlocked ? 'Use ' + icon.label + ' app icon' : icon.label + ' app icon — locked'"
+                :aria-pressed="icon.active"
+              >
+                <span
+                  class="themePreviewDot"
+                  :style="{ background: 'linear-gradient(135deg, ' + THEME_PREVIEWS[icon.previewTheme]?.[resolvedMode]?.accent + ', ' + THEME_PREVIEWS[icon.previewTheme]?.[resolvedMode]?.bg + ')' }"
+                >
+                  <svg v-if="!icon.unlocked" class="themePreviewLock" viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                  <svg v-else-if="icon.active" class="themePreviewCheck" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                </span>
+                <span class="themePreviewLabel">{{ icon.label }}</span>
+              </button>
+            </div>
+          </template>
         </div>
 
         <div class="settingsGroup">
@@ -705,7 +731,10 @@ import { ref, computed, watch, nextTick, type ComponentPublicInstance } from 'vu
 import { useTheme } from '../composables/useTheme'
 import type { ThemeId } from '../lib/themes'
 import { usePRBaseline } from '../composables/usePRBaseline'
-import { useProgressionStore, UNLOCK_TIERS, showXPToast } from '../stores/progression'
+import { useProgressionStore, UNLOCK_TIERS, showXPToast, getUnlockedThemeIds } from '../stores/progression'
+import { isNative } from '../lib/platform'
+import { APP_ICONS, getAppIcon, isAppIconUnlocked, type AppIconId } from '../lib/appIcons'
+import { setNativeAppIcon } from '../lib/nativeAppIcon'
 import { computeThemeStats, type ThemeStats } from '../lib/themeStats'
 import { useXPCeremony } from '../composables/useXPCeremony'
 import { isMigrated, markMigrated, clearMigrationFlag, computeRetroactiveXP } from '../lib/xpMigration'
@@ -743,6 +772,28 @@ const workoutStore = useWorkoutStore()
 const bodyweightStore = useBodyweightStore()
 
 const progressionActive = computed(() => progressionStore.progressionEnabled)
+
+// ── App icon picker (native iOS only) ──────────────────────────
+const showAppIconPicker = isNative
+const unlockedThemeIds = computed(() => getUnlockedThemeIds(progressionStore.unlockedThemes))
+const appIconOptions = computed(() =>
+  APP_ICONS.map(icon => ({
+    id: icon.id,
+    label: icon.label,
+    previewTheme: icon.previewTheme,
+    unlocked: isAppIconUnlocked(icon, unlockedThemeIds.value),
+    active: prefs.appIcon === icon.id,
+  }))
+)
+
+async function selectAppIcon(id: AppIconId) {
+  const icon = getAppIcon(id)
+  if (!isAppIconUnlocked(icon, unlockedThemeIds.value)) return
+  if (prefs.appIcon === id) return
+  prefs.setAppIcon(id)
+  logEvent('app_icon_change', { icon: id })
+  await setNativeAppIcon(icon.nativeName)
+}
 
 // ── Swipe-to-dismiss for settings sheet ────────────────────────
 const settingsEl = ref<HTMLElement | null>(null)

--- a/src/index.css
+++ b/src/index.css
@@ -1163,6 +1163,14 @@ html.modal-open .tabContent {
   padding: 4px 16px 12px;
 }
 
+.appIconHeader {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 16px 0;
+}
+
 .themePreview {
   display: flex;
   flex-direction: column;

--- a/src/lib/__tests__/appIcons.test.ts
+++ b/src/lib/__tests__/appIcons.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import {
+  APP_ICONS,
+  DEFAULT_APP_ICON_ID,
+  getAppIcon,
+  isAppIconUnlocked,
+  getUnlockedAppIcons,
+  resolveAppIconId,
+} from '../appIcons'
+import { THEMES, type ThemeId } from '../themes'
+
+describe('app icon catalog', () => {
+  it('includes a default icon that is always available', () => {
+    const def = APP_ICONS.find(i => i.id === DEFAULT_APP_ICON_ID)
+    expect(def).toBeDefined()
+    expect(def!.requiresTheme).toBeNull()
+    expect(def!.nativeName).toBeNull()
+  })
+
+  it('has unique ids', () => {
+    const ids = APP_ICONS.map(i => i.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('provides one icon per theme plus the default', () => {
+    const themeIds = THEMES.map(t => t.id)
+    const themedIcons = APP_ICONS.filter(i => i.id !== DEFAULT_APP_ICON_ID)
+    for (const themeId of themeIds) {
+      expect(themedIcons.some(i => i.id === themeId)).toBe(true)
+    }
+    expect(APP_ICONS).toHaveLength(themeIds.length + 1)
+  })
+
+  it('gates each themed icon on its own theme and gives it a native name', () => {
+    for (const icon of APP_ICONS) {
+      if (icon.id === DEFAULT_APP_ICON_ID) continue
+      expect(icon.requiresTheme).toBe(icon.id)
+      expect(icon.nativeName).toBeTruthy()
+    }
+  })
+
+  it('references real theme previews for every swatch', () => {
+    const themeIds = new Set<ThemeId>(THEMES.map(t => t.id))
+    for (const icon of APP_ICONS) {
+      expect(themeIds.has(icon.previewTheme)).toBe(true)
+    }
+  })
+})
+
+describe('getAppIcon', () => {
+  it('returns the matching option', () => {
+    expect(getAppIcon('fire').id).toBe('fire')
+  })
+
+  it('falls back to the default for unknown ids', () => {
+    expect(getAppIcon('nonexistent').id).toBe(DEFAULT_APP_ICON_ID)
+  })
+})
+
+describe('isAppIconUnlocked', () => {
+  it('treats the default icon as always unlocked', () => {
+    expect(isAppIconUnlocked(getAppIcon('default'), [])).toBe(true)
+  })
+
+  it('locks a themed icon until its theme is unlocked', () => {
+    const fire = getAppIcon('fire')
+    expect(isAppIconUnlocked(fire, [])).toBe(false)
+    expect(isAppIconUnlocked(fire, ['fire'])).toBe(true)
+  })
+
+  it('does not unlock an icon from an unrelated theme', () => {
+    expect(isAppIconUnlocked(getAppIcon('love'), ['fire', 'water'])).toBe(false)
+  })
+})
+
+describe('getUnlockedAppIcons', () => {
+  it('returns only the default when no themes are unlocked', () => {
+    const unlocked = getUnlockedAppIcons([])
+    expect(unlocked.map(i => i.id)).toEqual([DEFAULT_APP_ICON_ID])
+  })
+
+  it('includes themed icons for unlocked themes', () => {
+    const unlocked = getUnlockedAppIcons(['fire', 'water'])
+    const ids = unlocked.map(i => i.id)
+    expect(ids).toContain('default')
+    expect(ids).toContain('fire')
+    expect(ids).toContain('water')
+    expect(ids).not.toContain('love')
+  })
+})
+
+describe('resolveAppIconId', () => {
+  it('keeps a valid, unlocked selection', () => {
+    expect(resolveAppIconId('fire', ['fire'])).toBe('fire')
+  })
+
+  it('falls back to default when the theme is no longer unlocked (e.g. prestige reset)', () => {
+    expect(resolveAppIconId('fire', [])).toBe(DEFAULT_APP_ICON_ID)
+  })
+
+  it('falls back to default for an unknown id', () => {
+    expect(resolveAppIconId('bogus', ['fire'])).toBe(DEFAULT_APP_ICON_ID)
+  })
+})

--- a/src/lib/__tests__/nativeAppIcon.test.ts
+++ b/src/lib/__tests__/nativeAppIcon.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const setIcon = vi.fn()
+const getIcon = vi.fn()
+
+async function loadModule(isNative: boolean) {
+  vi.resetModules()
+  setIcon.mockReset()
+  getIcon.mockReset()
+  vi.doMock('../platform', () => ({ isNative }))
+  vi.doMock('@capacitor/core', () => ({
+    registerPlugin: () => ({ setIcon, getIcon }),
+  }))
+  vi.doMock('../logger', () => ({ logError: vi.fn() }))
+  return import('../nativeAppIcon')
+}
+
+describe('nativeAppIcon on web', () => {
+  beforeEach(() => vi.resetModules())
+
+  it('setNativeAppIcon is a no-op and never touches the plugin', async () => {
+    const { setNativeAppIcon } = await loadModule(false)
+    await expect(setNativeAppIcon('AppIcon-fire')).resolves.toBeUndefined()
+    expect(setIcon).not.toHaveBeenCalled()
+  })
+
+  it('getNativeAppIcon returns null without touching the plugin', async () => {
+    const { getNativeAppIcon } = await loadModule(false)
+    await expect(getNativeAppIcon()).resolves.toBeNull()
+    expect(getIcon).not.toHaveBeenCalled()
+  })
+})
+
+describe('nativeAppIcon on native', () => {
+  beforeEach(() => vi.resetModules())
+
+  it('setNativeAppIcon forwards the name to the plugin', async () => {
+    const { setNativeAppIcon } = await loadModule(true)
+    setIcon.mockResolvedValue(undefined)
+    await setNativeAppIcon('AppIcon-fire')
+    expect(setIcon).toHaveBeenCalledWith({ name: 'AppIcon-fire' })
+  })
+
+  it('setNativeAppIcon passes null to restore the primary icon', async () => {
+    const { setNativeAppIcon } = await loadModule(true)
+    setIcon.mockResolvedValue(undefined)
+    await setNativeAppIcon(null)
+    expect(setIcon).toHaveBeenCalledWith({ name: null })
+  })
+
+  it('setNativeAppIcon swallows plugin errors', async () => {
+    const { setNativeAppIcon } = await loadModule(true)
+    setIcon.mockRejectedValue(new Error('not implemented'))
+    await expect(setNativeAppIcon('AppIcon-fire')).resolves.toBeUndefined()
+  })
+
+  it('getNativeAppIcon returns the active icon name', async () => {
+    const { getNativeAppIcon } = await loadModule(true)
+    getIcon.mockResolvedValue({ name: 'AppIcon-water' })
+    await expect(getNativeAppIcon()).resolves.toBe('AppIcon-water')
+  })
+
+  it('getNativeAppIcon returns null when the plugin throws', async () => {
+    const { getNativeAppIcon } = await loadModule(true)
+    getIcon.mockRejectedValue(new Error('boom'))
+    await expect(getNativeAppIcon()).resolves.toBeNull()
+  })
+})

--- a/src/lib/appIcons.ts
+++ b/src/lib/appIcons.ts
@@ -1,0 +1,79 @@
+import type { ThemeId } from './themes'
+
+/**
+ * Alternate app-icon catalog.
+ *
+ * Each elemental theme has a matching home-screen icon. Picking an alternate
+ * icon is a native-only capability (iOS `setAlternateIconName`) — the picker is
+ * hidden on web/PWA where alternate icons cannot be applied. Icons are unlocked
+ * alongside their matching theme, reusing the existing XP progression model
+ * rather than introducing a parallel entitlement.
+ *
+ * The pure catalog + unlock policy lives here so it can be tested independently
+ * of the native bridge. The iOS asset-catalog wiring (CFBundleAlternateIcons)
+ * and on-device verification are handled in the Capacitor iOS build (#531/#216).
+ */
+
+/** Identifier for an alternate app icon. `'default'` = the primary app icon. */
+export type AppIconId = 'default' | ThemeId
+
+export interface AppIconOption {
+  /** Stable id persisted in preferences. */
+  id: AppIconId
+  /** User-facing label shown in the picker. */
+  label: string
+  /**
+   * iOS alternate-icon name as configured in the asset catalog
+   * (`CFBundleAlternateIcons`). `null` selects the primary icon.
+   */
+  nativeName: string | null
+  /**
+   * Theme whose unlock gates this icon. `null` means always available.
+   * The default icon is always available; themed icons unlock with their theme.
+   */
+  requiresTheme: ThemeId | null
+  /** Theme id used to render the gradient swatch in the in-app picker. */
+  previewTheme: ThemeId
+}
+
+export const DEFAULT_APP_ICON_ID: AppIconId = 'default'
+
+export const APP_ICONS: AppIconOption[] = [
+  { id: 'default',  label: 'Classic',    nativeName: null,              requiresTheme: null,       previewTheme: 'eternal' },
+  { id: 'fire',     label: 'Intensity',  nativeName: 'AppIcon-fire',     requiresTheme: 'fire',     previewTheme: 'fire' },
+  { id: 'water',    label: 'Flow',       nativeName: 'AppIcon-water',    requiresTheme: 'water',    previewTheme: 'water' },
+  { id: 'luck',     label: 'Luck',       nativeName: 'AppIcon-luck',     requiresTheme: 'luck',     previewTheme: 'luck' },
+  { id: 'air',      label: 'Energy',     nativeName: 'AppIcon-air',      requiresTheme: 'air',      previewTheme: 'air' },
+  { id: 'amethyst', label: 'Focus',      nativeName: 'AppIcon-amethyst', requiresTheme: 'amethyst', previewTheme: 'amethyst' },
+  { id: 'midnight', label: 'Fortitude',  nativeName: 'AppIcon-midnight', requiresTheme: 'midnight', previewTheme: 'midnight' },
+  { id: 'earth',    label: 'Stability',  nativeName: 'AppIcon-earth',    requiresTheme: 'earth',    previewTheme: 'earth' },
+  { id: 'love',     label: 'Love',       nativeName: 'AppIcon-love',     requiresTheme: 'love',     previewTheme: 'love' },
+  { id: 'pearl',    label: 'Origin',     nativeName: 'AppIcon-pearl',    requiresTheme: 'pearl',    previewTheme: 'pearl' },
+  { id: 'eternal',  label: 'Eternal',    nativeName: 'AppIcon-eternal',  requiresTheme: 'eternal',  previewTheme: 'eternal' },
+]
+
+/** Look up an icon option by id, falling back to the default icon. */
+export function getAppIcon(id: string): AppIconOption {
+  return APP_ICONS.find(icon => icon.id === id) ?? APP_ICONS[0]
+}
+
+/** Whether an icon is unlocked given the set of unlocked theme ids. */
+export function isAppIconUnlocked(icon: AppIconOption, unlockedThemeIds: readonly ThemeId[]): boolean {
+  return icon.requiresTheme === null || unlockedThemeIds.includes(icon.requiresTheme)
+}
+
+/** The subset of icons currently available to the user. */
+export function getUnlockedAppIcons(unlockedThemeIds: readonly ThemeId[]): AppIconOption[] {
+  return APP_ICONS.filter(icon => isAppIconUnlocked(icon, unlockedThemeIds))
+}
+
+/**
+ * Resolve a stored icon id to one the user is actually allowed to use.
+ * Falls back to the default icon if the stored id is unknown or its theme is
+ * no longer unlocked (e.g. after a progression/prestige reset).
+ */
+export function resolveAppIconId(id: string, unlockedThemeIds: readonly ThemeId[]): AppIconId {
+  const icon = APP_ICONS.find(i => i.id === id)
+  if (icon && isAppIconUnlocked(icon, unlockedThemeIds)) return icon.id
+  return DEFAULT_APP_ICON_ID
+}

--- a/src/lib/nativeAppIcon.ts
+++ b/src/lib/nativeAppIcon.ts
@@ -1,0 +1,42 @@
+/**
+ * Native bridge for changing the iOS app icon (`setAlternateIconName`).
+ *
+ * Uses Capacitor's `registerPlugin` so the web build has zero static dependency
+ * on a native-only plugin — the proxy is only ever invoked inside a real native
+ * shell. On web (and in tests) every call is a no-op. The matching iOS plugin
+ * and asset-catalog entries are wired up in the Capacitor iOS build (#531/#216).
+ */
+import { registerPlugin } from '@capacitor/core'
+import { isNative } from './platform'
+import { logError } from './logger'
+
+interface AppIconPlugin {
+  /** Set the active alternate icon. `name: null` restores the primary icon. */
+  setIcon(options: { name: string | null }): Promise<void>
+  /** Get the currently active alternate icon name (`null` = primary). */
+  getIcon(): Promise<{ name: string | null }>
+}
+
+const AppIconNative = registerPlugin<AppIconPlugin>('AppIcon')
+
+/** Apply an alternate app icon. No-ops on web; swallows native failures. */
+export async function setNativeAppIcon(nativeName: string | null): Promise<void> {
+  if (!isNative) return
+  try {
+    await AppIconNative.setIcon({ name: nativeName })
+  } catch (e) {
+    logError(e, { source: 'nativeAppIcon.setNativeAppIcon', nativeName })
+  }
+}
+
+/** Read the active alternate app icon name. Returns `null` on web or failure. */
+export async function getNativeAppIcon(): Promise<string | null> {
+  if (!isNative) return null
+  try {
+    const { name } = await AppIconNative.getIcon()
+    return name
+  } catch (e) {
+    logError(e, { source: 'nativeAppIcon.getNativeAppIcon' })
+    return null
+  }
+}

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -664,5 +664,41 @@ describe('usePreferencesStore', () => {
       expect(stored.experience).toBeDefined()
       expect(stored.filters).toBeDefined()
     })
+
+    it('appIcon defaults to "default"', () => {
+      expect(store.appIcon).toBe('default')
+    })
+
+    it('setAppIcon updates and persists', () => {
+      store.setAppIcon('fire')
+      expect(store.appIcon).toBe('fire')
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.appIcon).toBe('fire')
+    })
+
+    it('init loads appIcon from JSON blob', async () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        appIcon: 'midnight',
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.appIcon).toBe('midnight')
+    })
+
+    it('_reloadFromStorage picks up appIcon', () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        appIcon: 'love',
+      }))
+
+      store._reloadFromStorage()
+
+      expect(store.appIcon).toBe('love')
+    })
   })
 })

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -127,6 +127,7 @@ export const usePreferencesStore = defineStore('preferences', {
     weightUnit: 'lbs' as string,
     restTimerEnabled: true,
     restTimerAutoStart: true,
+    appIcon: 'default' as string,
     _userId: null as string | null,
   }),
 
@@ -143,6 +144,7 @@ export const usePreferencesStore = defineStore('preferences', {
         weightUnit: this.weightUnit,
         restTimerEnabled: this.restTimerEnabled,
         restTimerAutoStart: this.restTimerAutoStart,
+        appIcon: this.appIcon,
       }
       const data = JSON.stringify(payload)
       try {
@@ -187,6 +189,7 @@ export const usePreferencesStore = defineStore('preferences', {
         if (typeof parsed.weightUnit === 'string') this.weightUnit = parsed.weightUnit
         if (typeof parsed.restTimerEnabled === 'boolean') this.restTimerEnabled = parsed.restTimerEnabled
         if (typeof parsed.restTimerAutoStart === 'boolean') this.restTimerAutoStart = parsed.restTimerAutoStart
+        if (typeof parsed.appIcon === 'string') this.appIcon = parsed.appIcon
       } catch { /* ignore corrupt data */ }
     },
 
@@ -217,6 +220,7 @@ export const usePreferencesStore = defineStore('preferences', {
           if (typeof parsed.weightUnit === 'string') this.weightUnit = parsed.weightUnit
           if (typeof parsed.restTimerEnabled === 'boolean') this.restTimerEnabled = parsed.restTimerEnabled
           if (typeof parsed.restTimerAutoStart === 'boolean') this.restTimerAutoStart = parsed.restTimerAutoStart
+          if (typeof parsed.appIcon === 'string') this.appIcon = parsed.appIcon
         } catch { /* ignore corrupt data */ }
       }
 
@@ -285,13 +289,14 @@ export const usePreferencesStore = defineStore('preferences', {
             if (typeof prefs.weightUnit === 'string') this.weightUnit = prefs.weightUnit as string
             if (typeof prefs.restTimerEnabled === 'boolean') this.restTimerEnabled = prefs.restTimerEnabled as boolean
             if (typeof prefs.restTimerAutoStart === 'boolean') this.restTimerAutoStart = prefs.restTimerAutoStart as boolean
+            if (typeof prefs.appIcon === 'string') this.appIcon = prefs.appIcon as string
             const synced = JSON.stringify({
               features: this.features, weightGoal: this.weightGoal,
               experience: this.experience, filters: this.filters,
               prBaselineDate: this.prBaselineDate,
               theme: this.theme, colorMode: this.colorMode,
               weightUnit: this.weightUnit, restTimerEnabled: this.restTimerEnabled,
-              restTimerAutoStart: this.restTimerAutoStart,
+              restTimerAutoStart: this.restTimerAutoStart, appIcon: this.appIcon,
             })
             localStorage.setItem(STORAGE_KEY, synced)
             backupToIDB(STORAGE_KEY, synced)
@@ -385,6 +390,11 @@ export const usePreferencesStore = defineStore('preferences', {
 
     setRestTimerAutoStart(autoStart: boolean) {
       this.restTimerAutoStart = autoStart
+      this._persist()
+    },
+
+    setAppIcon(id: string) {
+      this.appIcon = id
       this._persist()
     },
   },


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-306](https://github.com/aschung212/Lift/issues/306)



## Changes




## Commits
- [`2734fad`](https://github.com/aschung212/Lift/commit/2734fad) fix(LIFT-306): reconcile native app icon with synced preference
- [`66aea15`](https://github.com/aschung212/Lift/commit/66aea15) feat(LIFT-306): add custom app icon selection (native iOS cosmetic)

## Test Results
- Before: 1834 passing
- After: 1860 passing (26 delta)

---
_Automated by overnight pipeline — Sat May 30 00:46:03 PDT 2026_

## Preview
Test on your phone: https://lift-4gkaeopm0-aschung212-1101s-projects.vercel.app