### PR TITLE
a11y(LIFT-685): expand log-set clear button to 44pt touch target (closes #685)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3946,7 +3946,25 @@ html.theme-fading .settingsSheet {
   cursor: pointer;
   flex-shrink: 0;
   align-self: center;
+  /*
+    The visible chip stays a compact 24px circle so it doesn't crowd the
+    44px weight value, but the actual tap target is expanded to a full 44pt
+    iOS-compliant hit area via the ::before overlay below. position: relative
+    anchors that overlay; it adds no box of its own, so layout never shifts.
+  */
+  position: relative;
   transition: background-color 0.15s, color 0.15s;
+}
+
+/* Invisible 44x44pt hit area centered over the 24px chip (LIFT-685). */
+.logSetSheet .logSetFieldClear::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  transform: translate(-50%, -50%);
 }
 
 .logSetSheet .logSetFieldClear:active {

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -476,4 +476,31 @@ describe('CSS regression tests', () => {
       })
     }
   })
+
+  describe('.logSetFieldClear 44pt touch target (LIFT-685)', () => {
+    // Regression: the inline "clear weight" × chip was a bare 24x24px button
+    // with padding:0 — exactly the WCAG 2.2 SC 2.5.8 floor but well below the
+    // project's own 44pt iOS standard, making it easy to mis-tap during fast
+    // set entry. Fix: keep the compact 24px visible chip but extend the tap
+    // target to 44x44pt via an absolutely-positioned ::before overlay so the
+    // layout (and the 44px weight value next to it) never shifts.
+    const lines = getRuleLines('.logSetSheet .logSetFieldClear')
+    const beforeLines = getRuleLines('.logSetSheet .logSetFieldClear::before')
+
+    it('keeps the visible chip at a compact 24px (no layout growth)', () => {
+      expect(lines.some(l => l.startsWith('width: 24px'))).toBe(true)
+      expect(lines.some(l => l.startsWith('height: 24px'))).toBe(true)
+    })
+
+    it('is position: relative to anchor the hit-area overlay', () => {
+      expect(lines.some(l => l.startsWith('position: relative'))).toBe(true)
+    })
+
+    it('has a ::before overlay sized to the 44pt iOS minimum', () => {
+      expect(beforeLines.length, '::before rule not found').toBeGreaterThan(0)
+      expect(beforeLines.some(l => l.startsWith('position: absolute'))).toBe(true)
+      expect(beforeLines.some(l => l.startsWith('width: 44px'))).toBe(true)
+      expect(beforeLines.some(l => l.startsWith('height: 44px'))).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-685](https://github.com/aschung212/Lift/issues/685)

Fix LIFT-685: the inline "clear weight" × chip in the set-logging sheet was a bare 24×24px button (`padding:0`) — exactly the WCAG 2.2 SC 2.5.8 floor but below the project's own 44pt iOS standard, easy to mis-tap during fast set entry.

## Changes
- `src/index.css` — Added `position: relative` to `.logSetFieldClear` and a transparent `::before` overlay sized 44×44px, centered via `translate(-50%, -50%)`. Visible chip stays 24px; tap target is now 44pt. No layout shift since the overlay is absolutely positioned.
- `src/lib/__tests__/cssRegression.test.ts` — Added a regression suite asserting the chip stays 24px, the button is `position: relative`, and the `::before` overlay is `position: absolute` at 44×44px.

## Verification
- `cssRegression.test.ts`: 65 passed (4 new)
- `npm run lint`: 0 errors (only pre-existing warnings)
- `npm run build`: success
- Pre-push Gemini 3.1 Pro review: No issues found

## Screenshots
None — CSS-only hit-area change with no visible difference (chip stays 24px); verified via structural regression tests.

## Commits
- [`9d96ce6`](https://github.com/aschung212/Lift/commit/9d96ce6) a11y(LIFT-685): expand log-set clear button to 44pt touch target (closes #685)

## Test Results
- Before: 1834 passing
- After: 1837 passing (3 delta)

---
_Automated by overnight pipeline — Mon Jun  1 23:04:46 PDT 2026_

## Preview
Test on your phone: https://lift-dz92d5yza-aschung212-1101s-projects.vercel.app