### PR TITLE
a11y(LIFT-684): add aria-expanded to MuscleGroupChart collapse toggle (closes #684)

### DIFF
--- a/src/components/MuscleGroupChart.vue
+++ b/src/components/MuscleGroupChart.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="weeklyVolume.length > 0" class="mgChart">
-    <button class="mgHeader" @click="$emit('toggleCollapsed')">
+    <button class="mgHeader" :aria-expanded="!collapsed" @click="$emit('toggleCollapsed')">
       <p class="mgTitle">Weekly Volume by Tag</p>
       <div class="mgHeaderRight">
         <span v-if="collapsed" class="mgCollapsedSummary">{{ totalSets }} sets</span>

--- a/src/components/__tests__/MuscleGroupChart.test.ts
+++ b/src/components/__tests__/MuscleGroupChart.test.ts
@@ -116,6 +116,16 @@ describe('MuscleGroupChart', () => {
       await wrapper.find('.mgHeader').trigger('click')
       expect(wrapper.emitted('toggleCollapsed')).toHaveLength(1)
     })
+
+    it('sets aria-expanded="true" on the toggle when expanded', () => {
+      const wrapper = mountChart({ collapsed: false })
+      expect(wrapper.find('.mgHeader').attributes('aria-expanded')).toBe('true')
+    })
+
+    it('sets aria-expanded="false" on the toggle when collapsed', () => {
+      const wrapper = mountChart({ collapsed: true })
+      expect(wrapper.find('.mgHeader').attributes('aria-expanded')).toBe('false')
+    })
   })
 
   describe('touch target compliance', () => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-684](https://github.com/aschung212/Lift/issues/684)

Fix LIFT-684: the `.mgHeader` button in MuscleGroupChart.vue collapses/expands the Weekly Volume chart but had no `aria-expanded` binding, unlike every other collapsible toggle in the app (WorkoutTracker, CalendarView, MuscleGroupRecovery, BodyweightTracker). Screen-reader users got an inconsistent experience with no announcement of the control's state.

## Changes
- `src/components/MuscleGroupChart.vue:3` — added `:aria-expanded="!collapsed"` to the `.mgHeader` toggle button.
- `src/components/__tests__/MuscleGroupChart.test.ts` — added two regression tests asserting `aria-expanded` is `"true"` when expanded and `"false"` when collapsed.

## Verification
- `npx vitest run` on MuscleGroupChart.test.ts — 18 passed
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm run build` — built successfully
- Gemini 3.1 Pro pre-push review — No issues found

## Screenshots
N/A — non-visual accessibility attribute change (no rendered appearance change).

## Commits
- [`98043c5`](https://github.com/aschung212/Lift/commit/98043c5) a11y(LIFT-684): add aria-expanded to MuscleGroupChart collapse toggle (closes #684)

## Test Results
- Before: 1834 passing
- After: 1836 passing (2 delta)

---
_Automated by overnight pipeline — Mon Jun  1 23:09:33 PDT 2026_

## Preview
Test on your phone: https://lift-476laxdta-aschung212-1101s-projects.vercel.app