### PR TITLE
a11y(LIFT-682): add forced-colors and prefers-contrast borders for glass surfaces (closes #682)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7177,3 +7177,52 @@ html.theme-fading .settingsSheet {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ─── Forced colors / Windows High Contrast Mode (LIFT-682) ─────────────── */
+/* In forced-colors mode the browser drops backdrop-filter and translucent
+   backgrounds, so glass surfaces that lean on blur for separation can blend
+   into adjacent content and lose their visible boundaries. Pin explicit
+   borders using CSS system color keywords so every glass surface keeps a
+   distinct edge. WCAG 2.2 SC 1.4.11 Non-text Contrast. */
+
+@media (forced-colors: active) {
+  .tabBar,
+  .repMaxModal,
+  .kbSheet,
+  .legalSheet,
+  .confirmSheet,
+  .settingsSheet,
+  .wtCard,
+  .calCard,
+  .wtSetCard,
+  .wtGraphWrap,
+  .unlockModal {
+    border: 1px solid CanvasText;
+  }
+
+  /* The active-tab pill carries no border and signals selection only through
+     its translucent accent fill, which forced-colors strips. Outline it with
+     the system Highlight color so the current tab stays identifiable. */
+  .tabIndicator {
+    border: 1px solid Highlight;
+  }
+}
+
+/* ─── Increased contrast ────────────────────────────────────────────────── */
+/* Users who request more contrast get stronger, fully-opaque glass edges so
+   surface boundaries read clearly over busy backgrounds. */
+
+@media (prefers-contrast: more) {
+  .tabBar,
+  .repMaxModal,
+  .kbSheet,
+  .legalSheet,
+  .confirmSheet,
+  .settingsSheet,
+  .wtCard,
+  .calCard,
+  .wtSetCard,
+  .wtGraphWrap {
+    border-color: var(--border-strong);
+  }
+}

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -477,6 +477,70 @@ describe('CSS regression tests', () => {
     }
   })
 
+  describe('forced-colors / High Contrast Mode glass borders (LIFT-682)', () => {
+    // Regression: in forced-colors mode the UA drops backdrop-filter and
+    // translucent backgrounds, so glass surfaces that rely on blur for
+    // separation blend into adjacent content (WCAG 2.2 SC 1.4.11). A
+    // @media (forced-colors: active) block must pin explicit system-color
+    // borders on every glass surface so boundaries stay visible.
+
+    function getAtRuleBody(query: string): string {
+      const needle = '@media (' + query + ') {'
+      const idx = css.indexOf(needle)
+      if (idx === -1) return ''
+      const start = css.indexOf('{', idx) + 1
+      let depth = 1
+      let end = start
+      while (depth > 0 && end < css.length) {
+        if (css[end] === '{') depth++
+        if (css[end] === '}') depth--
+        end++
+      }
+      return css.slice(start, end - 1)
+    }
+
+    const forcedBody = getAtRuleBody('forced-colors: active')
+
+    it('has a @media (forced-colors: active) block', () => {
+      expect(forcedBody.length).toBeGreaterThan(0)
+    })
+
+    const glassSurfaces = [
+      '.tabBar',
+      '.repMaxModal',
+      '.kbSheet',
+      '.legalSheet',
+      '.confirmSheet',
+      '.settingsSheet',
+      '.wtCard',
+      '.calCard',
+      '.wtSetCard',
+      '.wtGraphWrap',
+    ]
+
+    for (const selector of glassSurfaces) {
+      it(`forced-colors block targets ${selector}`, () => {
+        expect(forcedBody).toContain(selector)
+      })
+    }
+
+    it('uses a system color keyword (CanvasText) for the border', () => {
+      expect(forcedBody).toMatch(/border:\s*1px solid CanvasText/)
+    })
+
+    it('outlines the active-tab indicator with the Highlight system color', () => {
+      expect(forcedBody).toContain('.tabIndicator')
+      expect(forcedBody).toMatch(/border:\s*1px solid Highlight/)
+    })
+
+    it('has a @media (prefers-contrast: more) block strengthening glass edges', () => {
+      const contrastBody = getAtRuleBody('prefers-contrast: more')
+      expect(contrastBody.length).toBeGreaterThan(0)
+      expect(contrastBody).toContain('.tabBar')
+      expect(contrastBody).toContain('--border-strong')
+    })
+  })
+
   describe('.logSetFieldClear 44pt touch target (LIFT-685)', () => {
     // Regression: the inline "clear weight" × chip was a bare 24x24px button
     // with padding:0 — exactly the WCAG 2.2 SC 2.5.8 floor but well below the


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-682](https://github.com/aschung212/Lift/issues/682)

Fix LIFT-682: in Windows High Contrast / `forced-colors` mode the browser drops `backdrop-filter` and translucent backgrounds, so the app's always-on glass surfaces (tab bar, modals, sheets, cards) that rely on blur for separation lose their visible boundaries and blend into adjacent content — failing WCAG 2.2 SC 1.4.11 Non-text Contrast. No `forced-colors`, `prefers-contrast`, or `prefers-reduced-transparency` media queries existed anywhere in `src/`.

## Changes
- `src/index.css` — Added `@media (forced-colors: active)` pinning explicit `1px solid CanvasText` borders on every glass surface (`.tabBar`, `.repMaxModal`, `.kbSheet`, `.legalSheet`, `.confirmSheet`, `.settingsSheet`, `.wtCard`, `.calCard`, `.wtSetCard`, `.wtGraphWrap`, `.unlockModal`), plus a `1px solid Highlight` outline on `.tabIndicator` (the active-tab pill has no border and signals selection only via a translucent accent fill that forced-colors strips). Added `@media (prefers-contrast: more)` strengthening glass edges to `--border-strong`.
- `src/lib/__tests__/cssRegression.test.ts` — Added 14 regression tests asserting both media blocks exist, target all glass surfaces, and use system color keywords (`CanvasText`, `Highlight`).

## Verification
- `npm run lint` — 0 errors (only pre-existing unrelated warnings)
- `npm test` — 1921 passed | 1 skipped (was 1907; +14 new tests)
- `npm run build` — built successfully
- Gemini 3.1 Pro pre-push review — "No issues found."

## Screenshots
N/A — forced-colors/high-contrast behavior is not reproducible in the standard browser dev environment; change is CSS-media-query-gated and verified structurally via regression tests.

## Commits
- [`f3eb49f`](https://github.com/aschung212/Lift/commit/f3eb49f) a11y(LIFT-682): add forced-colors and prefers-contrast borders for glass surfaces (closes #682)

## Test Results
- Before: 1907 passing
- After: 1921 passing (14 delta)

---
_Automated by overnight pipeline — Mon Jun  1 23:29:26 PDT 2026_

## Preview
Test on your phone: https://lift-exabdkr4j-aschung212-1101s-projects.vercel.app