### PR TITLE
a11y(LIFT-681): add scroll-padding-bottom so focus clears fixed tab bar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -987,6 +987,13 @@ button, [role="tab"], [role="switch"], a {
   padding-top: 12px;
   /* Reserve room for the floating tab bar: 58h + 26 offset + 16 padding + safe area */
   padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 120px);
+  /*
+    Keep keyboard/screen-reader focus clear of the fixed tab bar (WCAG 2.2 SC
+    2.4.11 Focus Not Obscured). The bar's top edge sits at 26 + 58 = 84px above
+    the bottom (plus safe area); add a 16px gap so focused rows scroll fully
+    into view rather than tucking under the glass bar.
+  */
+  scroll-padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 100px);
 }
 
 html.modal-open .tabContent {

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -52,6 +52,17 @@ describe('CSS regression tests', () => {
     it('has overflow-y: auto for scrolling', () => {
       expect(lines.some(l => l.includes('overflow-y') && l.includes('auto'))).toBe(true)
     })
+
+    // Regression: keyboard/screen-reader focus must clear the fixed tab bar
+    // (WCAG 2.2 SC 2.4.11 Focus Not Obscured). Without scroll-padding-bottom the
+    // browser scrolls focused rows flush to the viewport edge, tucking them
+    // under the floating glass bar (LIFT-681).
+    it('has scroll-padding-bottom so focus clears the fixed tab bar', () => {
+      const rule = lines.find(l => l.startsWith('scroll-padding-bottom'))
+      expect(rule).toBeTruthy()
+      // Must account for the safe-area inset on notched devices
+      expect(rule).toContain('safe-area-inset-bottom')
+    })
   })
 
   describe('html.modal-open .tabContent override', () => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-681](https://github.com/aschung212/Lift/issues/681)

Fix LIFT-681: the floating glass `.tabBar` (`position: fixed`, top edge ~84px + safe-area above the bottom) overlaps the `.tabContent` scroll container. With no `scroll-padding-bottom` anywhere in the codebase, the browser scrolls keyboard/screen-reader-focused elements flush to the viewport edge, tucking them under the bar — failing WCAG 2.2 SC 2.4.11 Focus Not Obscured (Minimum). The existing `padding-bottom` only reserves layout space; it does not affect scroll-into-view positioning.

## Changes
- `src/index.css` — added `scroll-padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 100px)` to `.tabContent` (bar's 84px occluded height + 16px gap + safe-area inset), with an explanatory comment.
- `src/lib/__tests__/cssRegression.test.ts` — added a regression test asserting `.tabContent` declares `scroll-padding-bottom` accounting for the safe-area inset.

## Verification
- `cssRegression.test.ts`: 66 passed
- `npm run lint`: 0 errors (9 pre-existing warnings, unrelated)
- `npm run build`: succeeds
- Pre-push Gemini 3.1 Pro review: No issues found

## Screenshots
N/A — CSS-only scroll behavior change; no visual change in normal rendering (only affects scroll-into-view offset when an element gains focus near the bottom).

## Commits
- [`65996d3`](https://github.com/aschung212/Lift/commit/65996d3) a11y(LIFT-681): add scroll-padding-bottom so focus clears fixed tab bar

## Test Results
- Before: 1907 passing
- After: 1908 passing (1 delta)

---
_Automated by overnight pipeline — Mon Jun  1 23:34:40 PDT 2026_

## Preview
Test on your phone: https://lift-qfps7vlb7-aschung212-1101s-projects.vercel.app