### PR TITLE
a11y(LIFT-680): add prefers-reduced-transparency fallback for glass surfaces (closes #680)

### DIFF
--- a/src/components/PRBurst.vue
+++ b/src/components/PRBurst.vue
@@ -140,6 +140,18 @@ watch(visible, async (v) => {
   pointer-events: none;
 }
 
+/* Reduce Transparency (LIFT-680): swap the blur for a near-opaque dim so the
+   celebration still reads but the busy app behind it isn't shown through glass. */
+@media (prefers-reduced-transparency: reduce) {
+  .prBurstBackdrop {
+    background:
+      radial-gradient(ellipse 90% 70% at 50% 48%, var(--accent-subtle, rgba(212, 175, 55, 0.12)) 0%, transparent 70%),
+      rgba(0, 0, 0, 0.92);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 .prBurstRings {
   position: absolute;
   top: 48%;

--- a/src/index.css
+++ b/src/index.css
@@ -7166,6 +7166,55 @@ html.theme-fading .settingsSheet {
   }
 }
 
+/* ─── Reduced transparency (LIFT-680) ───────────────────────────────────── */
+/*
+  Glass morphism is always on (see CLAUDE.md), but iOS/macOS users who enable
+  Settings → Accessibility → Display & Text Size → Reduce Transparency (and the
+  equivalent on Windows/Android) expect blur and translucency to be replaced
+  with solid surfaces — translucent glass over busy mesh backgrounds hurts text
+  legibility. Honor `prefers-reduced-transparency: reduce` by swapping the
+  backdrop blur for opaque theme fills, mirroring the retired [data-glass="off"]
+  treatment. Placed after the mobile reduction block so it wins when both match.
+  CSS-only; no visual change in the default (no-preference) state.
+*/
+@media (prefers-reduced-transparency: reduce) {
+  /* Floating tab bar + content cards → solid secondary fill, no blur. */
+  .tabBar,
+  .wtCard,
+  .calCard {
+    background: var(--bg-secondary);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border-color: var(--border);
+  }
+
+  /* The active-tab pill blurs the bar behind it — drop the blur. */
+  .tabIndicator {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  /* Modals & bottom sheets → solid elevated fill, no blur. */
+  .repMaxModal,
+  .kbSheet,
+  .legalSheet,
+  .confirmSheet {
+    background: var(--bg-elevated);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    border-color: var(--border-strong);
+  }
+
+  /* Scrim overlays keep their dim tint but lose the blur that made them glass. */
+  .settingsOverlay,
+  .repMaxOverlay,
+  .kbOverlay,
+  .confirmOverlay {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 /* ─── Reduced motion ────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -503,4 +503,70 @@ describe('CSS regression tests', () => {
       expect(beforeLines.some(l => l.startsWith('height: 44px'))).toBe(true)
     })
   })
+
+  describe('prefers-reduced-transparency fallback (LIFT-680)', () => {
+    // Regression: glass morphism is always on, but users who enable Reduce
+    // Transparency (iOS/macOS/Windows) expect blur/translucency swapped for
+    // solid surfaces. Without this media query, text over the always-on glass
+    // stays hard to read on busy mesh backgrounds.
+
+    // Extract the @media (prefers-reduced-transparency: reduce) block body.
+    function getMediaBlock(query: string, source = css): string {
+      const needle = '@media (' + query + ')'
+      const idx = source.indexOf(needle)
+      if (idx === -1) return ''
+      const start = source.indexOf('{', idx) + 1
+      let depth = 1
+      let end = start
+      while (depth > 0 && end < source.length) {
+        if (source[end] === '{') depth++
+        if (source[end] === '}') depth--
+        end++
+      }
+      return source.slice(start, end - 1)
+    }
+
+    const block = getMediaBlock('prefers-reduced-transparency: reduce')
+
+    it('declares a prefers-reduced-transparency: reduce media query', () => {
+      expect(block.length, 'media block not found in index.css').toBeGreaterThan(0)
+    })
+
+    it('disables backdrop-filter on the glass surfaces', () => {
+      // Every backdrop-filter declaration inside the block must be `none`.
+      const filters = block.match(/(?<!-webkit-)backdrop-filter:[^;]+;/g) || []
+      expect(filters.length).toBeGreaterThan(0)
+      for (const f of filters) {
+        expect(f).toContain('none')
+      }
+    })
+
+    it('gives the tab bar and content cards a solid background', () => {
+      expect(block).toMatch(/\.tabBar,[\s\S]*?\.calCard\s*\{[\s\S]*?background:\s*var\(--bg-secondary\)/)
+    })
+
+    it('gives modals and sheets a solid elevated background', () => {
+      expect(block).toMatch(/\.confirmSheet\s*\{[\s\S]*?background:\s*var\(--bg-elevated\)/)
+    })
+
+    it('removes blur from scrim overlays', () => {
+      for (const sel of ['.settingsOverlay', '.repMaxOverlay', '.kbOverlay', '.confirmOverlay']) {
+        expect(block, `${sel} missing from reduced-transparency block`).toContain(sel)
+      }
+    })
+
+    it('comes after the mobile backdrop-filter reduction block so it wins', () => {
+      const mobileIdx = css.indexOf('@media (max-width: 768px)')
+      const reduceIdx = css.indexOf('@media (prefers-reduced-transparency: reduce)')
+      expect(mobileIdx).toBeGreaterThan(-1)
+      expect(reduceIdx).toBeGreaterThan(mobileIdx)
+    })
+
+    it('PRBurst celebration backdrop has a reduced-transparency fallback', () => {
+      const vue = getVueStyleBlock('PRBurst.vue')
+      const prBlock = getMediaBlock('prefers-reduced-transparency: reduce', vue)
+      expect(prBlock.length, 'PRBurst reduced-transparency block not found').toBeGreaterThan(0)
+      expect(prBlock).toContain('backdrop-filter: none')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-680](https://github.com/aschung212/Lift/issues/680)

Fix LIFT-680: the app applies always-on glass morphism (`backdrop-filter: blur()` on the tab bar, modals, sheets, cards, and the PRBurst celebration), but there was zero handling for `prefers-reduced-transparency: reduce` (grep-confirmed absent across `src/`). Users who enable Reduce Transparency on iOS/macOS/Windows expect blur/translucency replaced with solid surfaces; without it, text over glass on busy mesh backgrounds is hard to read — conflicting with the iOS HIG north star. The retired `[data-glass="off"]` rules already encode the exact solid-fill treatment but never fire (glass is hardcoded "on"), so I mirrored that treatment behind the OS media query.

## Changes
- **`src/index.css`** — Added a `@media (prefers-reduced-transparency: reduce)` block after the mobile backdrop-filter reduction block (so it wins on source order when both match). It drops `backdrop-filter` and applies opaque theme fills: tab bar + cards → `--bg-secondary`, modals/sheets → `--bg-elevated`, tab indicator + scrim overlays → blur removed. Uses theme CSS custom properties only, so it works across all 10 themes / light+dark.
- **`src/components/PRBurst.vue`** — Added a matching scoped media query swapping the celebration backdrop's blur for a near-opaque dim (`rgba(0,0,0,0.92)`), preserving the accent glow.
- **`src/lib/__tests__/cssRegression.test.ts`** — 7 new regression tests verifying the media query exists, all `backdrop-filter` declarations inside it are `none`, surfaces get solid backgrounds, scrim overlays lose blur, the block is ordered after the mobile block, and the PRBurst fallback exists.

## Verification
- `npm test` → 1914 passed | 1 skipped (7 new)
- `npm run lint` → 0 errors (pre-existing warnings only)
- `npm run build` → succeeds
- Pre-commit hook + post-commit Gemini 3.1 Pro review: "No issues found"
- CSS-only behind a media query → no visual change in the default (no-preference) state

## Screenshots
None — the change is gated behind an OS-level accessibility preference (`prefers-reduced-transparency: reduce`) that the simulator/headless browser doesn't toggle; verified structurally via regression tests instead.

## Commits
- [`5711a52`](https://github.com/aschung212/Lift/commit/5711a52) a11y(LIFT-680): add prefers-reduced-transparency fallback for glass surfaces (closes #680)

## Test Results
- Before: 1907 passing
- After: 1914 passing (7 delta)

---
_Automated by overnight pipeline — Mon Jun  1 23:45:31 PDT 2026_

## Preview
Test on your phone: https://lift-dtkz55ayi-aschung212-1101s-projects.vercel.app