### PR TITLE
feat(LIFT-603): gate raw CSV/JSON export behind Supporter entitlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Lift lets you track any strength exercise over time. Log a set (weight + reps + 
 - Undo toast for destructive actions (delete exercise, delete set, clear data)
 - Service worker update prompt — "New version available" banner with one-tap update
 - Keyboard shortcuts for power users — press `?` to view the shortcut help dialog
-- CSV and JSON data export from settings
+- CSV and JSON data export from settings (Supporter perk; free tier gets the training report)
 - Active tab persisted across sessions
 - All touch targets meet iOS 44pt minimum
 - All text meets 11pt minimum font size

--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -431,11 +431,18 @@
         <div class="settingsGroup">
           <div class="settingsHeader">Data</div>
           <div class="settingsRow">
-            <span class="settingsLabel">Export</span>
+            <span class="settingsLabel">
+              Export
+              <span v-if="!isSupporter" class="supporterPill">Supporter</span>
+            </span>
             <div class="exportBtnGroup">
-              <button class="exportBtn" @click="exportData('csv')" aria-label="Export data as CSV">CSV</button>
-              <button class="exportBtn" @click="exportData('json')" aria-label="Export data as JSON">JSON</button>
+              <button class="exportBtn" @click="exportData('csv')" :aria-label="isSupporter ? 'Export data as CSV' : 'Export data as CSV (Supporter perk)'">CSV</button>
+              <button class="exportBtn" @click="exportData('json')" :aria-label="isSupporter ? 'Export data as JSON' : 'Export data as JSON (Supporter perk)'">JSON</button>
             </div>
+          </div>
+          <div v-if="exportUpsellVisible && !isSupporter" class="settingsExportUpsell" role="status">
+            <p class="settingsExportUpsellText">Raw CSV &amp; JSON export is a Supporter perk — your full training log, portable and yours. Free training reports stay available below.</p>
+            <button type="button" class="exportBtn exportBtnPrimary" @click="scrollToSupport">Become a Supporter</button>
           </div>
           <div class="settingsRow">
             <span class="settingsLabel">Import</span>
@@ -472,7 +479,7 @@
         </div>
 
 
-        <div class="settingsGroup">
+        <div class="settingsGroup" ref="supportSectionEl">
           <div class="settingsHeader">Support</div>
           <a class="settingsRow settingsRowBtn settingsLink" href="https://github.com/sponsors/aschung212" target="_blank" rel="noopener">
             <span class="settingsLabel">
@@ -542,7 +549,7 @@
                 <li><strong>Vercel</strong> — hosting and anonymous analytics</li>
               </ul>
               <h4 class="legalH4">Data Deletion</h4>
-              <p>You can export or delete your data at any time. Use the Export feature in Settings to download your data as CSV or JSON. To delete your account and all associated data, contact us at the email below.</p>
+              <p>You can export or delete your data at any time. Generate a training report from Settings, or — as a Supporter — download your full data as CSV or JSON. To request a copy of your data or to delete your account and all associated data, contact us at the email below.</p>
               <h4 class="legalH4">Contact</h4>
               <p>For privacy questions, email <strong>aaronschung@gmail.com</strong>.</p>
             </template>
@@ -751,6 +758,7 @@ import { useWorkoutStore } from '../stores/workout'
 import { useBodyweightStore } from '../stores/bodyweight'
 import { useSwipeToDismiss } from '../composables/useSwipeToDismiss'
 import { useFocusTrap } from '../composables/useFocusTrap'
+import { useSupporter } from '../composables/useSupporter'
 
 const props = defineProps<{
   modelValue: boolean
@@ -766,6 +774,7 @@ const { prBaselineDate, setPRBaseline, startNewTrainingBlock, clearPRBaseline } 
 const progressionStore = useProgressionStore()
 const { celebrateUnlocks } = useXPCeremony()
 const { user } = useAuth()
+const { isSupporter } = useSupporter()
 const { logEvent } = useAnalytics()
 const prefs = usePreferencesStore()
 const workoutStore = useWorkoutStore()
@@ -1086,6 +1095,17 @@ function scrollToProgressionToggle() {
   setTimeout(() => el.classList.remove('settingsRowHighlight'), 2000)
 }
 
+const supportSectionEl = ref<HTMLElement | null>(null)
+
+function scrollToSupport() {
+  const el = supportSectionEl.value
+  if (!el) return
+  el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  el.classList.add('settingsRowHighlight')
+  setTimeout(() => el.classList.remove('settingsRowHighlight'), 2000)
+  logEvent('supporter_upsell_tap', { source: 'data_export' })
+}
+
 const resetConfirmVisible = ref(false)
 
 function confirmResetProgress() {
@@ -1360,7 +1380,16 @@ function clearGoalValues() {
 }
 
 // ── Data export/import ─────────────────────────────────────────
+// Raw CSV/JSON export of the full training log is a Supporter perk (#603).
+// Free users keep the training report below; supporters get portable data.
+const exportUpsellVisible = ref(false)
+
 async function exportData(format: 'csv' | 'json') {
+  if (!isSupporter.value) {
+    exportUpsellVisible.value = true
+    logEvent('data_export_blocked', { format })
+    return
+  }
   const timestamp = new Date().toISOString().slice(0, 10)
   const appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'unknown'
   const userIdHash = user.value?.id ? await hashUserId(user.value.id) : 'anonymous'

--- a/src/composables/__tests__/useSupporter.test.ts
+++ b/src/composables/__tests__/useSupporter.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { useSupporter } from '../useSupporter'
+
+describe('useSupporter', () => {
+  it('defaults to locked (not a supporter) so paid perks are never free by accident', () => {
+    // Safety property for gated perks (#601 watermark, #603 data export):
+    // until the IAP entitlement (#598) flips this on, EVERYONE is free tier.
+    // A regression to default-true would hand out supporter perks for free.
+    const { isSupporter } = useSupporter()
+    expect(isSupporter.value).toBe(false)
+  })
+
+  it('exposes the same module-level singleton across calls', () => {
+    const a = useSupporter()
+    const b = useSupporter()
+    expect(a.isSupporter).toBe(b.isSupporter)
+  })
+
+  it('returns a read-only ref that cannot be mutated by consumers', () => {
+    const { isSupporter } = useSupporter()
+    // readonly() refs warn and refuse writes in dev; the value must not change.
+    ;(isSupporter as unknown as { value: boolean }).value = true
+    expect(isSupporter.value).toBe(false)
+  })
+})

--- a/src/index.css
+++ b/src/index.css
@@ -1892,6 +1892,36 @@ html.theme-fading .settingsSheet {
   opacity: 0;
 }
 
+.supporterPill {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 8px;
+  font-size: var(--font-caption2);
+  font-weight: 600;
+  color: var(--accent);
+  background: var(--accent-subtle);
+  border-radius: 999px;
+  vertical-align: middle;
+}
+
+.settingsExportUpsell {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 16px 4px;
+}
+
+.settingsExportUpsellText {
+  margin: 0;
+  font-size: var(--font-caption2);
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.settingsExportUpsell .exportBtn {
+  align-self: flex-start;
+}
+
 .settingsImportResult {
   padding: 8px 16px;
   font-size: var(--font-caption2);


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-603](https://github.com/aschung212/Lift/issues/603)

LIFT-603 asked to make raw data export (CSV/JSON) a Supporter perk. On reading the repo I found the export pipeline was **already fully built and shipped to everyone**: `src/lib/dataExport.ts` (pure builders, tested) wired into `SettingsSheet.vue` via `exportData()`. The only missing piece was the entitlement gate. `useSupporter` (the `#601` watermark entitlement) was the established single source of truth, so I gated export behind it — keeping the free training report as the free-tier export path, exactly as the issue specifies.

## Changes
- **`src/components/SettingsSheet.vue`** — imported `useSupporter`; `exportData()` now early-returns with an upsell (and a `data_export_blocked` analytics event) for non-supporters. Added a "Supporter" pill on the Export row, perk-aware aria-labels, and an inline upsell block whose CTA scrolls to the Support section (`scrollToSupport`, mirroring the existing `scrollToProgressionToggle`). Reconciled the privacy/legal "Data Deletion" copy so it no longer claims free CSV/JSON export and preserves a data-rights path via email.
- **`src/index.css`** — `.supporterPill`, `.settingsExportUpsell` styles using theme custom properties; upsell button reuses the 44pt `.exportBtn`.
- **`src/composables/__tests__/useSupporter.test.ts`** — new contract test pinning the gate's safety property: entitlement defaults to **locked**, is a shared singleton, and is read-only (a regression to default-true would hand out paid perks for free).
- **`README.md`** — export feature noted as a Supporter perk.

## Verification
- `npm run lint` — 0 errors (only pre-existing warnings, none in touched files)
- `npx vitest run` — 1910 passed / 1 skipped (+3 new useSupporter tests)
- `npm run build` — succeeds
- Gemini pre-commit and pre-push reviews — **No issues found**

## Screenshots
None (CSS/logic gating; visual change is a pill + inline upsell that only renders for free-tier users). All themes use existing `var(--accent)` / `var(--accent-subtle)` / `var(--text-muted)` tokens.

## Commits
- [`51225fa`](https://github.com/aschung212/Lift/commit/51225fa) feat(LIFT-603): gate raw CSV/JSON export behind Supporter entitlement

## Test Results
- Before: 1907 passing
- After: 1910 passing (3 delta)

---
_Automated by overnight pipeline — Mon Jun  1 23:56:34 PDT 2026_

## Preview
Test on your phone: https://lift-coezj6xss-aschung212-1101s-projects.vercel.app