### PR TITLE
a11y(LIFT-697): add og:image:alt, twitter:image:alt, and og:locale to social meta (closes #697)

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,9 +21,11 @@
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
+  <meta property="og:locale" content="en_US" />
   <meta property="og:title" content="Lift — Workout Tracker" />
   <meta property="og:description" content="Log sets, track estimated 1RM progress, and hit new PRs. Free, offline-capable PWA." />
   <meta property="og:image" content="https://spa-rho-sandy.vercel.app/og-image.png" />
+  <meta property="og:image:alt" content="Lift workout tracker — set logging and 1RM progress charts on iPhone." />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:url" content="https://spa-rho-sandy.vercel.app" />
@@ -34,6 +36,7 @@
   <meta name="twitter:title" content="Lift — Workout Tracker" />
   <meta name="twitter:description" content="Log sets, track estimated 1RM progress, and hit new PRs. Free, offline-capable PWA." />
   <meta name="twitter:image" content="https://spa-rho-sandy.vercel.app/og-image.png" />
+  <meta name="twitter:image:alt" content="Lift workout tracker — set logging and 1RM progress charts on iPhone." />
 
   <title>Lift — Workout Tracker</title>
 </head>

--- a/src/lib/__tests__/metaRegression.test.ts
+++ b/src/lib/__tests__/metaRegression.test.ts
@@ -44,6 +44,26 @@ describe('index.html meta tag regression tests', () => {
     })
   })
 
+  describe('social preview accessibility and locale metadata', () => {
+    it('og:image has descriptive alt text for screen readers on social unfurls', () => {
+      const match = html.match(/<meta property="og:image:alt" content="([^"]+)"/)
+      expect(match).not.toBeNull()
+      expect(match![1].trim().length).toBeGreaterThan(0)
+    })
+
+    it('twitter:image has descriptive alt text for screen readers on social unfurls', () => {
+      const match = html.match(/<meta name="twitter:image:alt" content="([^"]+)"/)
+      expect(match).not.toBeNull()
+      expect(match![1].trim().length).toBeGreaterThan(0)
+    })
+
+    it('og:locale gives crawlers an explicit language signal', () => {
+      const match = html.match(/<meta property="og:locale" content="([^"]+)"/)
+      expect(match).not.toBeNull()
+      expect(match![1]).toBe('en_US')
+    })
+  })
+
   describe('no references to domains we do not own', () => {
     it('does not reference liftracker.app (competitor domain)', () => {
       expect(html).not.toContain('liftracker.app')


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-697](https://github.com/aschung212/Lift/issues/697)

LIFT-697 asked to add `og:image:alt`, `twitter:image:alt`, and `og:locale` to the social meta block in `index.html`. These improve social-preview accessibility (screen readers on Twitter/LinkedIn/Slack unfurls) and give crawlers an explicit language signal. The existing OG/Twitter block already had image/url/dimensions, so this was a focused additive change plus regression coverage.

## Changes
- `index.html:24` — added `og:locale` = `en_US`
- `index.html:28` — added `og:image:alt` describing the share image
- `index.html:38` — added `twitter:image:alt` (same descriptive copy)
- `src/lib/__tests__/metaRegression.test.ts` — new "social preview accessibility and locale metadata" describe block pinning all three tags (non-empty alt text, `og:locale === en_US`)

## Verification
- `npx vitest run metaRegression` — 9 passed
- `npm run lint` — 0 errors (9 pre-existing warnings, none from this change)
- `npm run build` — succeeds
- Pre-push Gemini 3.1 Pro review — "No issues found"

## Screenshots
N/A — meta tags only, no visual UI change.

## Commits
- [`7abdea8`](https://github.com/aschung212/Lift/commit/7abdea8) a11y(LIFT-697): add og:image:alt, twitter:image:alt, and og:locale to social meta (closes #697)

## Test Results
- Before: 1932 passing
- After: 1935 passing (3 delta)

---
_Automated by overnight pipeline — Tue Jun  2 23:05:31 PDT 2026_

## Preview
Test on your phone: https://lift-gxpzwzh1i-aschung212-1101s-projects.vercel.app