### PR TITLE
feat(LIFT-695): unify manifest description with meta and add discoverability keywords

### DIFF
--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -21,6 +21,43 @@ describe('PWA manifest regression tests', () => {
     })
   })
 
+  describe('manifest description aligns with meta description and leads with differentiators', () => {
+    const indexHtml = readFileSync(resolve(__dirname, '../../../index.html'), 'utf-8')
+
+    it('uses the unified discoverability-focused description', () => {
+      expect(viteConfig).toContain(
+        "description: 'Free, offline-capable PWA workout tracker. Log sets, track estimated 1RM progress, visualize training history, and hit new PRs.'"
+      )
+    })
+
+    it('no longer uses the generic keyword-poor description', () => {
+      expect(viteConfig).not.toContain(
+        'Track your sets, monitor progress, and hit personal records.'
+      )
+    })
+
+    it('includes the high-value discoverability keywords surfaced in install UI', () => {
+      const manifestDescMatch = viteConfig.match(/description: '([^']+)'/)
+      expect(manifestDescMatch).not.toBeNull()
+      const manifestDesc = (manifestDescMatch as RegExpMatchArray)[1]
+      expect(manifestDesc).toContain('Free')
+      expect(manifestDesc).toContain('offline')
+      expect(manifestDesc).toContain('1RM')
+      expect(manifestDesc).toContain('PWA')
+    })
+
+    it('shares the same value props as the index.html meta description', () => {
+      // Both descriptions must lead with the free/offline/PWA/1RM differentiators
+      // so the install prompt and search snippet tell a consistent story.
+      const metaMatch = indexHtml.match(/<meta name="description" content="([^"]+)"/)
+      expect(metaMatch).not.toBeNull()
+      const metaDesc = (metaMatch as RegExpMatchArray)[1]
+      for (const keyword of ['free', 'PWA', '1RM', 'offline']) {
+        expect(metaDesc.toLowerCase()).toContain(keyword.toLowerCase())
+      }
+    })
+  })
+
   describe('manifest includes display_override for fallback chain', () => {
     it('has display_override array with standalone and minimal-ui', () => {
       expect(viteConfig).toContain("display_override: ['standalone', 'minimal-ui']")

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,7 +45,7 @@ export default defineConfig({
       manifest: {
         name: 'Lift — Workout Tracker',
         short_name: 'Lift',
-        description: 'Track your sets, monitor progress, and hit personal records.',
+        description: 'Free, offline-capable PWA workout tracker. Log sets, track estimated 1RM progress, visualize training history, and hit new PRs.',
         theme_color: '#0f0f0f',
         background_color: '#0f0f0f',
         display: 'standalone',


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-695](https://github.com/aschung212/Lift/issues/695)

LIFT-695 flagged that the PWA manifest description (`vite.config.js`) diverged from the `index.html` meta description and omitted the high-value keywords "free", "offline", "1RM", and "PWA". Since the manifest description surfaces in Chrome's install prompt, the Android app drawer, and richer-install UI, this is a discoverability/ASO miss. I aligned the two and led with the differentiators, then locked it in with regression tests.

## Changes
- `vite.config.js`: replaced the generic manifest description `"Track your sets, monitor progress, and hit personal records."` with `"Free, offline-capable PWA workout tracker. Log sets, track estimated 1RM progress, visualize training history, and hit new PRs."` — leading with free/offline/PWA/1RM.
- `src/lib/__tests__/manifestRegression.test.ts`: added a test block pinning the new description, asserting the old keyword-poor copy is gone, verifying the manifest contains all four discoverability keywords, and cross-checking that the `index.html` meta description shares the same value props (guards against future drift between the two files).

## Verification
- `npx vitest run src/lib/__tests__/manifestRegression.test.ts` → 25 passed
- `npm run lint` → 0 errors (pre-existing warnings only)
- `npm run build` → success; verified `dist/manifest.webmanifest` emits the new description
- Pre-commit + pre-push Gemini 3.1 Pro review → "No issues found"

## Screenshots
N/A — no visual UI change; this is a manifest metadata string surfaced only in browser/OS install UI.

## Commits
- [`ac34f06`](https://github.com/aschung212/Lift/commit/ac34f06) feat(LIFT-695): unify manifest description with meta and add discoverability keywords

## Test Results
- Before: 1932 passing
- After: 1936 passing (4 delta)

---
_Automated by overnight pipeline — Tue Jun  2 23:11:27 PDT 2026_

## Preview
Test on your phone: https://lift-b2a8dhz88-aschung212-1101s-projects.vercel.app