### PR TITLE
feat(LIFT-694): add explicit id field to PWA manifest for stable install identity

### DIFF
--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -15,6 +15,12 @@ const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), '
 const publicDir = resolve(__dirname, '../../../public')
 
 describe('PWA manifest regression tests', () => {
+  describe('manifest includes explicit id for stable install identity', () => {
+    it("has id set to '/' so start_url changes never orphan existing installs", () => {
+      expect(viteConfig).toContain("id: '/'")
+    })
+  })
+
   describe('manifest includes categories for app store classification', () => {
     it('has categories array with health/fitness/sports', () => {
       expect(viteConfig).toContain("categories: ['health', 'fitness', 'sports']")

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,6 +43,11 @@ export default defineConfig({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png'],
       manifest: {
+        // Explicit manifest id pins the PWA's install identity. Without it, Chromium
+        // derives identity from start_url ('/'), so any future start_url change would
+        // orphan existing installs and spawn a duplicate app. Pinning id to the current
+        // derived value ('/') keeps identity stable regardless of start_url changes.
+        id: '/',
         name: 'Lift — Workout Tracker',
         short_name: 'Lift',
         description: 'Track your sets, monitor progress, and hit personal records.',


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-694](https://github.com/aschung212/Lift/issues/694)

LIFT-694 flagged that the PWA manifest in `vite.config.js` has no explicit `id` field, so Chromium derives install identity from `start_url` (`'/'`). Any future `start_url` change would orphan existing installs and create a duplicate app. I pinned `id` to `'/'` (the current derived value) so identity stays stable regardless of `start_url` changes, and added a regression test.

## Changes
- `vite.config.js` — added `id: '/'` to the PWA manifest with an explanatory comment
- `src/lib/__tests__/manifestRegression.test.ts` — added a test asserting the manifest pins `id` to `'/'`

## Verification
- `npx vitest run manifestRegression` — 22 passed
- `npm run lint` — 0 errors (9 pre-existing warnings, none new)
- `npm run build` — succeeded; generated `dist/manifest.webmanifest` contains `"id":"/"`
- Pre-push Gemini 3.1 Pro review — no issues found

## Screenshots
N/A — build-time manifest config change, no UI surface.

## Commits
- [`4cf41f2`](https://github.com/aschung212/Lift/commit/4cf41f2) feat(LIFT-694): add explicit id field to PWA manifest for stable install identity

## Test Results
- Before: 1932 passing
- After: 1933 passing (1 delta)

---
_Automated by overnight pipeline — Tue Jun  2 23:16:28 PDT 2026_

## Preview
Test on your phone: https://lift-5qx9z5moo-aschung212-1101s-projects.vercel.app