### PR TITLE
feat(LIFT-693): add SoftwareApplication JSON-LD structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,31 @@
   <meta name="description" content="A free, open-source PWA workout tracker. Log sets, track estimated 1RM progress, visualize training history, and hit new PRs — all offline-capable." />
   <link rel="canonical" href="https://spa-rho-sandy.vercel.app" />
 
+  <!--
+    Structured data (schema.org SoftwareApplication) so Google can render a
+    rich app result for "Lift workout tracker" searches. price:0 marks it free;
+    no aggregateRating is included because we have no authentic review data and
+    fabricating one violates Google's policy (and the SEV1 no-fabrication rule).
+    URL/name are pinned to the real deployment domain via metaRegression test.
+  -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Lift",
+    "description": "A free, open-source PWA workout tracker. Log sets, track estimated 1RM progress, visualize training history, and hit new PRs — all offline-capable.",
+    "url": "https://spa-rho-sandy.vercel.app",
+    "applicationCategory": "HealthApplication",
+    "operatingSystem": "iOS, Android, Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "isAccessibleForFree": true
+  }
+  </script>
+
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Lift — Workout Tracker" />

--- a/src/lib/__tests__/metaRegression.test.ts
+++ b/src/lib/__tests__/metaRegression.test.ts
@@ -44,6 +44,43 @@ describe('index.html meta tag regression tests', () => {
     })
   })
 
+  describe('SoftwareApplication JSON-LD structured data', () => {
+    const match = html.match(
+      /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/
+    )
+
+    it('includes a JSON-LD structured-data block', () => {
+      expect(match).not.toBeNull()
+    })
+
+    it('is valid, parseable JSON', () => {
+      expect(() => JSON.parse(match![1])).not.toThrow()
+    })
+
+    it('declares the schema.org SoftwareApplication type', () => {
+      const data = JSON.parse(match![1])
+      expect(data['@context']).toBe('https://schema.org')
+      expect(data['@type']).toBe('SoftwareApplication')
+    })
+
+    it('pins name and url to the real deployment domain', () => {
+      const data = JSON.parse(match![1])
+      expect(data.name).toBe('Lift')
+      expect(data.url).toContain(DEPLOYMENT_DOMAIN)
+    })
+
+    it('marks the app as free via a price:0 offer', () => {
+      const data = JSON.parse(match![1])
+      expect(data.offers.price).toBe('0')
+      expect(data.offers.priceCurrency).toBe('USD')
+    })
+
+    it('does not fabricate an aggregateRating', () => {
+      const data = JSON.parse(match![1])
+      expect(data.aggregateRating).toBeUndefined()
+    })
+  })
+
   describe('no references to domains we do not own', () => {
     it('does not reference liftracker.app (competitor domain)', () => {
       expect(html).not.toContain('liftracker.app')


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-693](https://github.com/aschung212/Lift/issues/693)

LIFT-693 flagged that Lift ships zero structured data — a grep for `application/ld+json` / `schema.org` returned no matches. Adding a schema.org `SoftwareApplication` block lets Google render a rich app result for "Lift workout tracker" searches, the highest-leverage SEO win for a free fitness PWA. I added the JSON-LD to `index.html` alongside the existing SEO meta and pinned its name/url to the real deployment domain with regression tests.

## Changes
- `index.html` — Added a `<script type="application/ld+json">` `SoftwareApplication` block (name, description matching the meta description, `applicationCategory: HealthApplication`, `operatingSystem`, free `price:0` offer, `isAccessibleForFree`). Deliberately omitted `aggregateRating` since we have no authentic review data — fabricating one would violate Google policy and the SEV1 no-fabrication rule.
- `src/lib/__tests__/metaRegression.test.ts` — Added 6 tests: block exists, is parseable JSON, declares the correct schema.org type, pins name/url to the real deployment domain, marks the app free via `price:0`, and asserts no fabricated `aggregateRating`.

## Verification
- `npx vitest run metaRegression` — 12 passed
- `npm run lint` — 0 errors (only pre-existing warnings)
- `npm run build` — built successfully; confirmed JSON-LD survives into `dist/index.html`
- Pre-push Gemini 3.1 Pro review — "No issues found"

## Screenshots
None — change is non-visual (HTML `<head>` metadata only).

## Commits
- [`d0e64ed`](https://github.com/aschung212/Lift/commit/d0e64ed) feat(LIFT-693): add SoftwareApplication JSON-LD structured data

## Test Results
- Before: 1932 passing
- After: 1938 passing (6 delta)

---
_Automated by overnight pipeline — Tue Jun  2 23:21:54 PDT 2026_

## Preview
Test on your phone: https://lift-rgl8f2nl3-aschung212-1101s-projects.vercel.app