### PR TITLE
fix(LIFT-707): defer modal-close reload check past Vue render flush

### DIFF
--- a/src/composables/useServiceWorker.ts
+++ b/src/composables/useServiceWorker.ts
@@ -1,5 +1,6 @@
 import { registerSW } from 'virtual:pwa-register'
 import { isNative } from '../lib/platform'
+import { reloadWhenSafe } from '../lib/safeReload'
 
 /**
  * Service worker lifecycle management for the web (PWA) build.
@@ -57,10 +58,12 @@ export function useServiceWorker(): { checkForSWUpdate: () => void } {
   // On first visit currentController is null; skip reload to avoid a surprise refresh.
   // On subsequent changes a new SW took over — reload to pick up fresh chunk hashes
   // (without this, lazy-loaded tabs request old hashed filenames that no longer exist).
+  // Reload is deferred until the user is in a safe state (no modal open, no input
+  // focused) so it never discards an in-progress set entry — see reloadWhenSafe (LIFT-707).
   let currentController = navigator.serviceWorker?.controller
   navigator.serviceWorker?.addEventListener('controllerchange', () => {
     if (currentController) {
-      window.location.reload()
+      reloadWhenSafe()
     }
     currentController = navigator.serviceWorker?.controller ?? null
   })

--- a/src/lib/__tests__/safeReload.test.ts
+++ b/src/lib/__tests__/safeReload.test.ts
@@ -12,9 +12,13 @@ async function freshImport() {
   reloadWhenSafe = mod.reloadWhenSafe
 }
 
-/** Wait a macrotask so the MutationObserver microtask has flushed. */
-function flush() {
-  return new Promise((resolve) => setTimeout(resolve, 0))
+/**
+ * Wait two macrotasks so the MutationObserver microtask and the deferred
+ * macrotask safety re-check both flush.
+ */
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 /** Force document.visibilityState and fire the matching visibilitychange. */
@@ -115,6 +119,27 @@ describe('safeReload', () => {
 
       // User backgrounds the app — the safest possible moment to reload.
       setVisibility('hidden')
+      expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('reloads after a modal closes even if its input is still focused when the class flips', async () => {
+      // Simulates the Vue timing race: the modal-open class is removed before
+      // the framework unmounts the focused input. The deferred macrotask check
+      // must still fire once activeElement settles, not skip the reload.
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      document.documentElement.classList.add('modal-open')
+      input.focus()
+      const reload = vi.fn()
+
+      reloadWhenSafe(reload)
+      expect(reload).not.toHaveBeenCalled()
+
+      // Class flips synchronously; the input is still focused at this instant.
+      document.documentElement.classList.remove('modal-open')
+      // The macrotask re-check runs after activeElement settles (input blurred).
+      input.blur()
+      await flush()
       expect(reload).toHaveBeenCalledTimes(1)
     })
 

--- a/src/lib/__tests__/safeReload.test.ts
+++ b/src/lib/__tests__/safeReload.test.ts
@@ -12,9 +12,13 @@ async function freshImport() {
   reloadWhenSafe = mod.reloadWhenSafe
 }
 
-/** Wait a macrotask so MutationObserver microtasks have flushed. */
-function flush() {
-  return new Promise((resolve) => setTimeout(resolve, 0))
+/**
+ * Wait two macrotasks so the MutationObserver microtask and the deferred
+ * (setTimeout-scheduled) safety re-check both flush.
+ */
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 describe('safeReload', () => {
@@ -86,6 +90,10 @@ describe('safeReload', () => {
 
       input.blur()
       input.dispatchEvent(new Event('focusout', { bubbles: true }))
+      // Must NOT reload synchronously — focusout fires during the mousedown
+      // that moves focus off the input (e.g. tapping Save); a sync reload would
+      // unload the page before the click handler runs and lose the action.
+      expect(reload).not.toHaveBeenCalled()
       await flush()
       expect(reload).toHaveBeenCalledTimes(1)
     })

--- a/src/lib/__tests__/safeReload.test.ts
+++ b/src/lib/__tests__/safeReload.test.ts
@@ -12,25 +12,32 @@ async function freshImport() {
   reloadWhenSafe = mod.reloadWhenSafe
 }
 
-/**
- * Wait two macrotasks so the MutationObserver microtask and the deferred
- * (setTimeout-scheduled) safety re-check both flush.
- */
-async function flush() {
-  await new Promise((resolve) => setTimeout(resolve, 0))
-  await new Promise((resolve) => setTimeout(resolve, 0))
+/** Wait a macrotask so the MutationObserver microtask has flushed. */
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+/** Force document.visibilityState and fire the matching visibilitychange. */
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  })
+  document.dispatchEvent(new Event('visibilitychange'))
 }
 
 describe('safeReload', () => {
   beforeEach(async () => {
     document.documentElement.className = ''
     document.body.innerHTML = ''
+    setVisibility('visible')
     await freshImport()
   })
 
   afterEach(() => {
     document.documentElement.className = ''
     document.body.innerHTML = ''
+    setVisibility('visible')
   })
 
   describe('isSafeToReload', () => {
@@ -79,7 +86,7 @@ describe('safeReload', () => {
       expect(reload).toHaveBeenCalledTimes(1)
     })
 
-    it('does NOT reload while an input is focused, then reloads on focusout', async () => {
+    it('defers while an input is focused and does not reload on its blur', async () => {
       const input = document.createElement('input')
       document.body.appendChild(input)
       input.focus()
@@ -88,13 +95,26 @@ describe('safeReload', () => {
       reloadWhenSafe(reload)
       expect(reload).not.toHaveBeenCalled()
 
+      // Blurring/focusout must NOT trigger a reload — it fires synchronously
+      // during the mousedown that moves focus (e.g. tapping Save) and would
+      // unload the page before the click handler runs, losing the action.
       input.blur()
       input.dispatchEvent(new Event('focusout', { bubbles: true }))
-      // Must NOT reload synchronously — focusout fires during the mousedown
-      // that moves focus off the input (e.g. tapping Save); a sync reload would
-      // unload the page before the click handler runs and lose the action.
-      expect(reload).not.toHaveBeenCalled()
       await flush()
+      expect(reload).not.toHaveBeenCalled()
+    })
+
+    it('reloads when the page becomes hidden (backgrounded / navigated away)', () => {
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+      const reload = vi.fn()
+
+      reloadWhenSafe(reload)
+      expect(reload).not.toHaveBeenCalled()
+
+      // User backgrounds the app — the safest possible moment to reload.
+      setVisibility('hidden')
       expect(reload).toHaveBeenCalledTimes(1)
     })
 

--- a/src/lib/__tests__/safeReload.test.ts
+++ b/src/lib/__tests__/safeReload.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// reloadWhenSafe holds a module-scoped `reloadScheduled` guard, so each test
+// re-imports the module fresh to start from a clean slate.
+let isSafeToReload: typeof import('../safeReload').isSafeToReload
+let reloadWhenSafe: typeof import('../safeReload').reloadWhenSafe
+
+async function freshImport() {
+  vi.resetModules()
+  const mod = await import('../safeReload')
+  isSafeToReload = mod.isSafeToReload
+  reloadWhenSafe = mod.reloadWhenSafe
+}
+
+/** Wait a macrotask so MutationObserver microtasks have flushed. */
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('safeReload', () => {
+  beforeEach(async () => {
+    document.documentElement.className = ''
+    document.body.innerHTML = ''
+    await freshImport()
+  })
+
+  afterEach(() => {
+    document.documentElement.className = ''
+    document.body.innerHTML = ''
+  })
+
+  describe('isSafeToReload', () => {
+    it('is true with no modal open and no input focused', () => {
+      expect(isSafeToReload()).toBe(true)
+    })
+
+    it('is false while a modal is open (modal-open class on <html>)', () => {
+      document.documentElement.classList.add('modal-open')
+      expect(isSafeToReload()).toBe(false)
+    })
+
+    it('is false while an input is focused', () => {
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+      expect(document.activeElement).toBe(input)
+      expect(isSafeToReload()).toBe(false)
+    })
+
+    it('is false while a textarea is focused', () => {
+      const ta = document.createElement('textarea')
+      document.body.appendChild(ta)
+      ta.focus()
+      expect(isSafeToReload()).toBe(false)
+    })
+  })
+
+  describe('reloadWhenSafe', () => {
+    it('reloads immediately when it is safe', () => {
+      const reload = vi.fn()
+      reloadWhenSafe(reload)
+      expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT reload while a modal is open, then reloads once it closes', async () => {
+      document.documentElement.classList.add('modal-open')
+      const reload = vi.fn()
+
+      reloadWhenSafe(reload)
+      expect(reload).not.toHaveBeenCalled()
+
+      // User closes the modal — class removed triggers the deferred reload.
+      document.documentElement.classList.remove('modal-open')
+      await flush()
+      expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT reload while an input is focused, then reloads on focusout', async () => {
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+      const reload = vi.fn()
+
+      reloadWhenSafe(reload)
+      expect(reload).not.toHaveBeenCalled()
+
+      input.blur()
+      input.dispatchEvent(new Event('focusout', { bubbles: true }))
+      await flush()
+      expect(reload).toHaveBeenCalledTimes(1)
+    })
+
+    it('schedules only one reload when called repeatedly while unsafe', async () => {
+      document.documentElement.classList.add('modal-open')
+      const reload = vi.fn()
+
+      reloadWhenSafe(reload)
+      reloadWhenSafe(reload)
+      reloadWhenSafe(reload)
+      expect(reload).not.toHaveBeenCalled()
+
+      document.documentElement.classList.remove('modal-open')
+      await flush()
+      expect(reload).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/src/lib/safeReload.ts
+++ b/src/lib/safeReload.ts
@@ -1,0 +1,73 @@
+/**
+ * Guards an auto-update `window.location.reload()` so it never fires
+ * mid-interaction (LIFT-707).
+ *
+ * When a new service worker activates (`controllerchange`), the page must
+ * reload to pick up fresh hashed-chunk filenames — without it, lazy-loaded tabs
+ * request old chunk names that no longer exist on the server. But that reload is
+ * triggered by an uncontrolled signal (a deploy activating) and can land while
+ * the user is mid-set-entry: the settled set-logging modal keeps unsaved
+ * weight/reps fields open, and a silent refresh would discard them. That
+ * contradicts the app's local-first, never-interrupt-the-UI ethos.
+ *
+ * This module defers the reload until the user is back in a safe state — no
+ * modal open, no input focused — instead of reloading immediately.
+ */
+
+/** True when reloading now would not interrupt the user. */
+export function isSafeToReload(): boolean {
+  if (typeof document === 'undefined') return true
+  // A modal is open (it toggles the scroll-lock `modal-open` class on <html>)
+  // and may be holding unsaved fields, e.g. the set-logging weight/reps inputs.
+  if (document.documentElement.classList.contains('modal-open')) return false
+  // The user is actively typing into a field outside a modal (e.g. bodyweight).
+  const el = document.activeElement as HTMLElement | null
+  if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
+    return false
+  }
+  return true
+}
+
+// Module-scoped guard so overlapping controllerchange events (e.g. two deploys
+// landing close together) only ever schedule a single deferred reload.
+let reloadScheduled = false
+
+/**
+ * Reload immediately if it's safe, otherwise defer until the user returns to a
+ * safe state — a modal closes or focus leaves an input. Idempotent: a second
+ * call while a reload is already pending is a no-op.
+ *
+ * @param reload Injectable reload action (defaults to `window.location.reload`);
+ *               parameterised so tests don't have to navigate the document.
+ */
+export function reloadWhenSafe(reload: () => void = () => window.location.reload()): void {
+  if (isSafeToReload()) {
+    reload()
+    return
+  }
+  if (reloadScheduled) return
+  reloadScheduled = true
+
+  const tryReload = () => {
+    if (!isSafeToReload()) return
+    cleanup()
+    reloadScheduled = false
+    reload()
+  }
+
+  // Modal close toggles the `modal-open` class on <html>; an attribute observer
+  // re-checks the moment that class changes.
+  const observer = typeof MutationObserver !== 'undefined'
+    ? new MutationObserver(tryReload)
+    : null
+
+  function cleanup() {
+    observer?.disconnect()
+    document.removeEventListener('focusout', tryReload)
+  }
+
+  observer?.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+  // Blurring out of an input fires a bubbling focusout — re-check then too,
+  // since losing focus isn't a class mutation.
+  document.addEventListener('focusout', tryReload)
+}

--- a/src/lib/safeReload.ts
+++ b/src/lib/safeReload.ts
@@ -73,9 +73,18 @@ export function reloadWhenSafe(reload: () => void = () => window.location.reload
 
   // (2) A class changed on <html> — if that cleared the modal-open block and we
   //     are now safe, reload. The class only flips on a deliberate open/close,
-  //     so this never preempts an in-flight click.
+  //     so this never preempts an in-flight click. The re-check is deferred to a
+  //     macrotask: the MutationObserver microtask fires before Vue flushes its
+  //     render, so a just-closed modal's focused input is still mounted and
+  //     document.activeElement would read as "still typing" — wrongly skipping
+  //     the reload. setTimeout(0) runs after Vue's microtasks settle the DOM.
+  let pending: ReturnType<typeof setTimeout> | null = null
   const onMutation = () => {
-    if (isSafeToReload()) finish()
+    if (pending !== null) return
+    pending = setTimeout(() => {
+      pending = null
+      if (isSafeToReload()) finish()
+    }, 0)
   }
   const observer = typeof MutationObserver !== 'undefined'
     ? new MutationObserver(onMutation)
@@ -84,6 +93,10 @@ export function reloadWhenSafe(reload: () => void = () => window.location.reload
   function cleanup() {
     observer?.disconnect()
     document.removeEventListener('visibilitychange', onVisibility)
+    if (pending !== null) {
+      clearTimeout(pending)
+      pending = null
+    }
   }
 
   observer?.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })

--- a/src/lib/safeReload.ts
+++ b/src/lib/safeReload.ts
@@ -10,8 +10,19 @@
  * weight/reps fields open, and a silent refresh would discard them. That
  * contradicts the app's local-first, never-interrupt-the-UI ethos.
  *
- * This module defers the reload until the user is back in a safe state — no
- * modal open, no input focused — instead of reloading immediately.
+ * This module defers the reload until a genuinely safe moment instead of
+ * reloading immediately. The two trigger moments are deliberately chosen to
+ * avoid racing with user input:
+ *   1. The page becomes hidden (backgrounded or navigated away) — the safest
+ *      possible moment: nothing on screen to interrupt, and the user gets the
+ *      fresh version when they return.
+ *   2. An open modal closes (its scroll-lock class is removed) and nothing else
+ *      blocks — re-checked via a class MutationObserver.
+ *
+ * We deliberately do NOT trigger off `focusout`: it fires synchronously during
+ * the `mousedown`/`touchstart` that moves focus off an input (e.g. tapping a
+ * Save button), so reloading then would unload the page before the ensuing
+ * `click` handler runs and silently swallow the user's action.
  */
 
 /** True when reloading now would not interrupt the user. */
@@ -33,9 +44,9 @@ export function isSafeToReload(): boolean {
 let reloadScheduled = false
 
 /**
- * Reload immediately if it's safe, otherwise defer until the user returns to a
- * safe state — a modal closes or focus leaves an input. Idempotent: a second
- * call while a reload is already pending is a no-op.
+ * Reload immediately if it's safe, otherwise defer until the next safe moment —
+ * the page is hidden, or an open modal closes. Idempotent: a second call while a
+ * reload is already pending is a no-op.
  *
  * @param reload Injectable reload action (defaults to `window.location.reload`);
  *               parameterised so tests don't have to navigate the document.
@@ -48,45 +59,33 @@ export function reloadWhenSafe(reload: () => void = () => window.location.reload
   if (reloadScheduled) return
   reloadScheduled = true
 
-  let pending: ReturnType<typeof setTimeout> | null = null
-
-  const tryReload = () => {
-    if (!isSafeToReload()) return
+  const finish = () => {
     cleanup()
     reloadScheduled = false
     reload()
   }
 
-  // Re-check on the next macrotask rather than synchronously. `focusout` fires
-  // during the `mousedown`/`touchstart` that moves focus off an input — e.g.
-  // tapping a Save button — so a synchronous reload would unload the page before
-  // the ensuing `click` handler runs, swallowing that action and losing the
-  // user's data. Deferring lets the queued pointer/click events flush first.
-  const scheduleCheck = () => {
-    if (pending !== null) return
-    pending = setTimeout(() => {
-      pending = null
-      tryReload()
-    }, 0)
+  // (1) Page hidden: the user left/backgrounded the app — reload unconditionally,
+  //     it's the safest possible moment and there is nothing to interrupt.
+  const onVisibility = () => {
+    if (document.visibilityState === 'hidden') finish()
   }
 
-  // Modal close toggles the `modal-open` class on <html>; an attribute observer
-  // re-checks the moment that class changes.
+  // (2) A class changed on <html> — if that cleared the modal-open block and we
+  //     are now safe, reload. The class only flips on a deliberate open/close,
+  //     so this never preempts an in-flight click.
+  const onMutation = () => {
+    if (isSafeToReload()) finish()
+  }
   const observer = typeof MutationObserver !== 'undefined'
-    ? new MutationObserver(scheduleCheck)
+    ? new MutationObserver(onMutation)
     : null
 
   function cleanup() {
     observer?.disconnect()
-    document.removeEventListener('focusout', scheduleCheck)
-    if (pending !== null) {
-      clearTimeout(pending)
-      pending = null
-    }
+    document.removeEventListener('visibilitychange', onVisibility)
   }
 
   observer?.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-  // Blurring out of an input fires a bubbling focusout — re-check then too,
-  // since losing focus isn't a class mutation.
-  document.addEventListener('focusout', scheduleCheck)
+  document.addEventListener('visibilitychange', onVisibility)
 }

--- a/src/lib/safeReload.ts
+++ b/src/lib/safeReload.ts
@@ -48,6 +48,8 @@ export function reloadWhenSafe(reload: () => void = () => window.location.reload
   if (reloadScheduled) return
   reloadScheduled = true
 
+  let pending: ReturnType<typeof setTimeout> | null = null
+
   const tryReload = () => {
     if (!isSafeToReload()) return
     cleanup()
@@ -55,19 +57,36 @@ export function reloadWhenSafe(reload: () => void = () => window.location.reload
     reload()
   }
 
+  // Re-check on the next macrotask rather than synchronously. `focusout` fires
+  // during the `mousedown`/`touchstart` that moves focus off an input — e.g.
+  // tapping a Save button — so a synchronous reload would unload the page before
+  // the ensuing `click` handler runs, swallowing that action and losing the
+  // user's data. Deferring lets the queued pointer/click events flush first.
+  const scheduleCheck = () => {
+    if (pending !== null) return
+    pending = setTimeout(() => {
+      pending = null
+      tryReload()
+    }, 0)
+  }
+
   // Modal close toggles the `modal-open` class on <html>; an attribute observer
   // re-checks the moment that class changes.
   const observer = typeof MutationObserver !== 'undefined'
-    ? new MutationObserver(tryReload)
+    ? new MutationObserver(scheduleCheck)
     : null
 
   function cleanup() {
     observer?.disconnect()
-    document.removeEventListener('focusout', tryReload)
+    document.removeEventListener('focusout', scheduleCheck)
+    if (pending !== null) {
+      clearTimeout(pending)
+      pending = null
+    }
   }
 
   observer?.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
   // Blurring out of an input fires a bubbling focusout — re-check then too,
   // since losing focus isn't a class mutation.
-  document.addEventListener('focusout', tryReload)
+  document.addEventListener('focusout', scheduleCheck)
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-707](https://github.com/aschung212/Lift/issues/707)

LIFT-707 flagged that the SW `controllerchange` handler called `window.location.reload()` immediately when a new deploy activated, which could discard an in-progress set entry — the settled set-logging modal keeps unsaved weight/reps fields open, and a silent refresh mid-interaction contradicts the local-first, never-block-the-UI ethos. The reload itself is still needed (stale hashed-chunk filenames after a deploy), so the fix is to defer it to a genuinely safe moment rather than remove it.

## Changes
- **`src/lib/safeReload.ts`** (new) — `isSafeToReload()` predicate (no `modal-open` class, no focused input/textarea) and `reloadWhenSafe()`, which reloads immediately when safe, otherwise defers until the next non-racy moment: the page becomes hidden (backgrounded/navigated away — safest moment for a PWA reload) or an open modal closes (class `MutationObserver`). The modal-close re-check is deferred a macrotask so Vue's render flush settles `activeElement` first.
- **`src/composables/useServiceWorker.ts`** — `controllerchange` handler now calls `reloadWhenSafe()` instead of `window.location.reload()`; comment documents why.
- **`src/lib/__tests__/safeReload.test.ts`** (new) — 10 tests covering the safety predicate, immediate-when-safe reload, deferral while a modal is open / input focused, page-hidden trigger, the Vue-timing modal-close race, and idempotency.

Three rounds of Gemini review findings addressed: (P1) `focusout` could swallow a Save tap → dropped that trigger; (P1) `setTimeout(0)` still preempts the physical click → reload only on page-hidden/modal-close; (P2) modal-close microtask read stale `activeElement` → deferred past Vue's render flush. Final pre-commit review came back clean.

## Verification
- `npm test` — 1942 passed, 1 skipped
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (9 pre-existing warnings, none in changed files)
- `npm run build` — succeeds

## Issue updates
ISSUE_DONE:LIFT-707

## Discoveries
ISSUE_DISCOVER:`useServiceWorker.ts` registers a `setInterval` 10-minute update poll and a `visibilitychange` listener that are never torn down — harmless as a document-lifetime singleton, but the interval handle isn't stored so it can't be cleared, and there's no test asserting the controllerchange→reloadWhenSafe wiring (the new safeReload unit tests cover the helper but not its integration in the composable, since `navigator.serviceWorker` is absent in happy-dom).

## Commits
- [`8143d42`](https://github.com/aschung212/Lift/commit/8143d42) fix(LIFT-707): defer modal-close reload check past Vue render flush
- [`6f54f65`](https://github.com/aschung212/Lift/commit/6f54f65) fix(LIFT-707): trigger deferred reload on page-hidden, not focusout
- [`d8502f7`](https://github.com/aschung212/Lift/commit/d8502f7) fix(LIFT-707): defer focusout safety re-check to avoid preempting clicks
- [`fa8c194`](https://github.com/aschung212/Lift/commit/fa8c194) fix(LIFT-707): defer SW auto-update reload until no modal open or input focused

## Test Results
- Before: 1932 passing
- After: 1942 passing (10 delta)

---
_Automated by overnight pipeline — Wed Jun  3 23:18:29 PDT 2026_

## Preview
Test on your phone: https://lift-mb3092ke6-aschung212-1101s-projects.vercel.app