### PR TITLE
feat(LIFT-704): purge Workbox runtime caches on sign-out and account deletion

### DIFF
--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -61,6 +61,12 @@ vi.mock('../../lib/syncQueue', () => ({
   syncQueue: { clear: () => mockSyncQueueClear() }
 }))
 
+// Mock the Supabase runtime cache purge so we can assert it's invoked
+const mockPurgeSupabaseRuntimeCaches = vi.fn().mockResolvedValue(undefined)
+vi.mock('../../lib/swCaches', () => ({
+  purgeSupabaseRuntimeCaches: () => mockPurgeSupabaseRuntimeCaches(),
+}))
+
 // Need to reset modules to get fresh state for useAuth
 // since it runs init() at module level
 let useAuth: typeof import('../useAuth').useAuth
@@ -69,6 +75,7 @@ beforeEach(async () => {
   vi.resetModules()
   // Re-setup mocks that resetModules clears
   mockGetSession.mockResolvedValue({ data: { session: null } })
+  mockPurgeSupabaseRuntimeCaches.mockClear()
   const mod = await import('../useAuth')
   useAuth = mod.useAuth
 })
@@ -184,6 +191,30 @@ describe('useAuth', () => {
       expect(mockProgressionReset).toHaveBeenCalledOnce()
     })
 
+    // Regression LIFT-704: signOut must purge cached Supabase REST responses so
+    // personal data isn't left at rest in Cache Storage on a shared device
+    it('purges Supabase runtime caches on sign out', async () => {
+      const { signOut, devSignIn } = useAuth()
+      await devSignIn()
+
+      mockPurgeSupabaseRuntimeCaches.mockClear()
+      await signOut()
+
+      expect(mockPurgeSupabaseRuntimeCaches).toHaveBeenCalledOnce()
+    })
+
+    // Regression LIFT-704: cache purge must still run when supabase throws
+    it('purges Supabase runtime caches even when supabase signOut throws', async () => {
+      mockSignOut.mockRejectedValueOnce(new Error('Network error'))
+      const { signOut, devSignIn } = useAuth()
+      await devSignIn()
+
+      mockPurgeSupabaseRuntimeCaches.mockClear()
+      await signOut()
+
+      expect(mockPurgeSupabaseRuntimeCaches).toHaveBeenCalledOnce()
+    })
+
     // Regression LIFT-497: stores must reset even when supabase throws
     it('resets stores even when supabase signOut throws', async () => {
       mockSignOut.mockRejectedValueOnce(new Error('Network error'))
@@ -260,6 +291,18 @@ describe('useAuth', () => {
 
       await deleteAccount()
       expect(user.value).toBeNull()
+    })
+
+    // Regression LIFT-704: account deletion must purge cached Supabase REST
+    // responses, mirroring the localStorage/IndexedDB cleanup
+    it('purges Supabase runtime caches on account deletion', async () => {
+      const { deleteAccount, devSignIn } = useAuth()
+      await devSignIn()
+
+      mockPurgeSupabaseRuntimeCaches.mockClear()
+      await deleteAccount()
+
+      expect(mockPurgeSupabaseRuntimeCaches).toHaveBeenCalledOnce()
     })
 
     it('cancels pending sync operations before deleting', async () => {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -9,6 +9,7 @@ import { useTheme } from '../composables/useTheme'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { useRestTimer } from '../composables/useRestTimer'
 import { syncQueue } from '../lib/syncQueue'
+import { purgeSupabaseRuntimeCaches } from '../lib/swCaches'
 import { logError } from '../lib/logger'
 import type { User, Provider } from '@supabase/supabase-js'
 import type { ColorMode } from '../lib/themes'
@@ -153,6 +154,9 @@ async function signOut(): Promise<void> {
     // Network errors during sign-out should not block clearing the user
   } finally {
     resetStores()
+    // Purge cached Supabase REST responses so personal data isn't left at rest
+    // in Cache Storage on a shared device (localStorage/IDB are cleared elsewhere).
+    await purgeSupabaseRuntimeCaches()
     user.value = null
   }
 }

--- a/src/lib/__tests__/swCachesRegression.test.ts
+++ b/src/lib/__tests__/swCachesRegression.test.ts
@@ -1,0 +1,80 @@
+/// <reference types="node" />
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { SUPABASE_RUNTIME_CACHES, purgeSupabaseRuntimeCaches } from '../swCaches'
+
+/**
+ * Regression tests for the Supabase runtime cache cleanup (LIFT-704).
+ *
+ * The list of cache names lives in `swCaches.ts` but must stay in lockstep with
+ * the `cacheName` values declared in `vite.config.js` runtimeCaching. If the two
+ * drift, sign-out/account-deletion would leave personal data at rest in Cache
+ * Storage. These tests pin the single source of truth and the purge behavior.
+ */
+
+const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), 'utf-8')
+
+describe('Supabase runtime cache name sync', () => {
+  it('every purged cache name is actually defined in vite.config.js', () => {
+    for (const name of SUPABASE_RUNTIME_CACHES) {
+      expect(viteConfig).toContain(`cacheName: '${name}'`)
+    }
+  })
+
+  it('does not include supabase-auth (NetworkOnly, never stores a response)', () => {
+    expect(SUPABASE_RUNTIME_CACHES as readonly string[]).not.toContain('supabase-auth')
+  })
+
+  it('covers every personal-data supabase cache declared in the config', () => {
+    // Find each `cacheName: 'supabase-*'` in the config and ensure the purge
+    // list accounts for it (except the auth cache, which holds nothing).
+    const declared = [...viteConfig.matchAll(/cacheName: '(supabase-[\w-]+)'/g)].map((m) => m[1])
+    const expected = declared.filter((name) => name !== 'supabase-auth')
+    expect([...SUPABASE_RUNTIME_CACHES].sort()).toEqual([...new Set(expected)].sort())
+  })
+})
+
+describe('purgeSupabaseRuntimeCaches', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('deletes only the supabase runtime caches, leaving unrelated caches intact', async () => {
+    const deleted: string[] = []
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue([
+        'supabase-sets',
+        'supabase-exercises',
+        'supabase-bodyweight',
+        'supabase-progression',
+        'supabase-api',
+        'workbox-precache-v2-https://example.com/',
+        'unrelated-cache',
+      ]),
+      delete: vi.fn((name: string) => {
+        deleted.push(name)
+        return Promise.resolve(true)
+      }),
+    })
+
+    await purgeSupabaseRuntimeCaches()
+
+    expect(deleted.sort()).toEqual([...SUPABASE_RUNTIME_CACHES].sort())
+    expect(deleted).not.toContain('workbox-precache-v2-https://example.com/')
+    expect(deleted).not.toContain('unrelated-cache')
+  })
+
+  it('is a no-op when the Cache Storage API is unavailable (WKWebView/SSR/test)', async () => {
+    vi.stubGlobal('caches', undefined)
+    await expect(purgeSupabaseRuntimeCaches()).resolves.toBeUndefined()
+  })
+
+  it('swallows errors so it never blocks sign-out', async () => {
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockRejectedValue(new Error('SecurityError: storage disabled')),
+      delete: vi.fn(),
+    })
+    await expect(purgeSupabaseRuntimeCaches()).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/swCaches.ts
+++ b/src/lib/swCaches.ts
@@ -1,0 +1,41 @@
+/**
+ * Names of the Workbox runtime caches that hold authenticated Supabase REST
+ * responses — the user's workouts, bodyweight, and progression. These mirror
+ * the `cacheName` values in the `runtimeCaching` config in `vite.config.js`;
+ * `swCachesRegression.test.ts` pins them in sync so the two never drift.
+ *
+ * `supabase-auth` is intentionally excluded: that route is NetworkOnly and
+ * never stores a response, so there is nothing to purge (and no token at rest).
+ */
+export const SUPABASE_RUNTIME_CACHES = [
+  'supabase-sets',
+  'supabase-exercises',
+  'supabase-bodyweight',
+  'supabase-progression',
+  'supabase-api',
+] as const
+
+/**
+ * Delete the Workbox runtime caches that contain the signed-in user's personal
+ * Supabase data. Called on sign-out and account deletion so no workout,
+ * bodyweight, or progression data is left at rest in Cache Storage on a shared
+ * device — mirroring the existing localStorage and IndexedDB cleanup.
+ *
+ * Degrades gracefully where the Cache Storage API is unavailable (Capacitor
+ * WKWebView, SSR, test environments) or throws (private browsing, restricted
+ * contexts): the failure is swallowed so it never blocks sign-out.
+ */
+export async function purgeSupabaseRuntimeCaches(): Promise<void> {
+  if (typeof caches === 'undefined') return
+  try {
+    const names = await caches.keys()
+    await Promise.all(
+      names
+        .filter((name) => (SUPABASE_RUNTIME_CACHES as readonly string[]).includes(name))
+        .map((name) => caches.delete(name)),
+    )
+  } catch {
+    // Cache Storage can be unavailable or throw in restricted environments —
+    // cleanup is best-effort and must never block the sign-out flow.
+  }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-704](https://github.com/aschung212/Lift/issues/704)

LIFT-704: `signOut()` and `deleteAccount()` in `useAuth.ts` cleared localStorage, IndexedDB, and Pinia stores but never deleted the Workbox Cache Storage buckets holding cached Supabase REST responses — leaving personal workout/bodyweight/progression data at rest after logout (a privacy gap on shared devices). Fix by purging the `supabase-*` runtime caches on the sign-out path, with a centralized cache-name list kept in sync with `vite.config.js`.

## Changes
- **`src/lib/swCaches.ts`** (new): `SUPABASE_RUNTIME_CACHES` single-source-of-truth list + `purgeSupabaseRuntimeCaches()`. Guards for missing Cache Storage API (Capacitor WKWebView/SSR/tests) and swallows errors so it never blocks sign-out. Excludes `supabase-auth` (NetworkOnly, stores nothing).
- **`src/composables/useAuth.ts`**: call `purgeSupabaseRuntimeCaches()` in `signOut()`'s `finally` block; `deleteAccount()` is covered transitively since it ends by calling `signOut()`.
- **`src/lib/__tests__/swCachesRegression.test.ts`** (new): pins the purge list in sync with `vite.config.js` cacheNames, asserts selective deletion (leaves `workbox-precache`/unrelated caches intact), no-op when `caches` undefined, and error-swallowing.
- **`src/composables/__tests__/useAuth.test.ts`**: assert purge runs on sign-out, on sign-out when supabase throws, and on account deletion.

## Verification
- `npx vitest run`: 1941 passed, 1 skipped (98 files) — +9 new tests
- `npm run lint`: 0 errors (pre-existing warnings only, none in new files)
- `npm run build`: success, SW generated cleanly

## Screenshots
N/A — no UI changes (cleanup logic only).

## Commits
- [`9ccc70f`](https://github.com/aschung212/Lift/commit/9ccc70f) feat(LIFT-704): purge Workbox runtime caches on sign-out and account deletion

## Test Results
- Before: 1932 passing
- After: 1941 passing (9 delta)

---
_Automated by overnight pipeline — Wed Jun  3 23:35:25 PDT 2026_

## Preview
Test on your phone: https://lift-oc3zuarhr-aschung212-1101s-projects.vercel.app