### PR TITLE
fix(LIFT-706): address review findings on durable queue replay safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ These patterns were reached through multiple iterations of user testing. Do not 
 - **Theme system.** 10 elemental themes (Eternal, Origin, Fortitude, Intensity, Flow, Stability, Luck, Focus, Energy, Love; internal IDs: `eternal`, `pearl`, `midnight`, `fire`, `water`, `earth`, `luck`, `amethyst`, `air`, `love`) with CSS custom properties, custom SVG icons, and gradient previews. Light/dark/auto modes. Glass morphism is always on. Eternal (black + gold) is the default. Legacy IDs (`void`, `sun`, `moon`, `graphite`, `arctic`, `forge`, `aaron`, `tina`, `bloom`, `metal`, `oak`) are mapped to current IDs by a migration table in `useTheme.ts`.
 - **Hand-rolled SVGs.** No chart libraries. Polyline + polygon with computed point arrays.
 - **Debounced sync.** Rapid store mutations are batched before hitting Supabase.
+- **Durable write queue.** Workout writes enqueued via `syncQueue` can carry a serializable `SyncDescriptor` (upsert/update only — idempotent for safe replay). Descriptors are journaled to IndexedDB so pending offline writes survive a tab close and are replayed on next launch via `syncQueue.rehydrate()` (called from `useAuth.initStores`). The journal is wiped on sign-out so a shared device never replays the previous user's writes. Reconciliation in `_fetchFromSupabase` is the second line of defense: it re-pushes local sets missing from the server even on remote-winning exercises (union-then-push). The Background Sync API is intentionally not used — iOS/WKWebView, the App Store target, lacks it.
 
 ## Documentation Mandate
 

--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -57,8 +57,12 @@ vi.mock('../../lib/supabase', () => ({
 
 // Mock syncQueue
 const mockSyncQueueClear = vi.fn()
+const mockSyncQueueRehydrate = vi.fn().mockResolvedValue(undefined)
 vi.mock('../../lib/syncQueue', () => ({
-  syncQueue: { clear: () => mockSyncQueueClear() }
+  syncQueue: {
+    clear: () => mockSyncQueueClear(),
+    rehydrate: () => mockSyncQueueRehydrate(),
+  }
 }))
 
 // Need to reset modules to get fresh state for useAuth

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -69,6 +69,10 @@ async function initStores(userId: string): Promise<void> {
   const preferencesStore = usePreferencesStore()
   const progressionStore = useProgressionStore()
   await migrateLocalStorageToSupabase(userId)
+  // Replay any writes that were journaled to IndexedDB but never reached the
+  // server before the app last closed (LIFT-706). Safe + idempotent; runs
+  // before store fetches so recovered writes are in flight during sync.
+  await syncQueue.rehydrate()
   await Promise.all([
     workoutStore.init(userId),
     bodyweightStore.init(userId),
@@ -152,6 +156,9 @@ async function signOut(): Promise<void> {
   } catch {
     // Network errors during sign-out should not block clearing the user
   } finally {
+    // Cancel pending syncs and wipe the durable journal so the next user on a
+    // shared device never replays this user's writes (LIFT-706).
+    syncQueue.clear()
     resetStores()
     user.value = null
   }

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -9,6 +9,7 @@ import { useTheme } from '../composables/useTheme'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { useRestTimer } from '../composables/useRestTimer'
 import { syncQueue } from '../lib/syncQueue'
+import { closeDB } from '../lib/durableStorage'
 import { logError } from '../lib/logger'
 import type { User, Provider } from '@supabase/supabase-js'
 import type { ColorMode } from '../lib/themes'
@@ -204,7 +205,10 @@ async function deleteAccount(): Promise<void> {
     localStorage.removeItem(key)
   }
 
-  // Delete IndexedDB backup database
+  // Delete IndexedDB backup database. Close the cached connection first —
+  // deleteDatabase() blocks indefinitely while a connection is still open,
+  // which would otherwise leave the durable backup (and sync journal) on disk.
+  closeDB()
   if (typeof indexedDB !== 'undefined') {
     try {
       const dbs = await indexedDB.databases()

--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -179,6 +179,40 @@ describe('SyncQueue durable journal (LIFT-706)', () => {
     await queue.rehydrate()
     expect(queue.pending).toBe(0)
   })
+
+  it('rehydrate() does not clobber a newer in-session write for the same key', async () => {
+    idbStore.set('lift-sync-journal', JSON.stringify([
+      { key: 'set:s1', isDelete: false, descriptor: UPSERT },
+    ]))
+
+    const queue = new SyncQueue(100)
+    // User logs a fresher version of the same set before rehydrate resolves
+    const fresher: SyncDescriptor = { op: 'upsert', table: 'sets', row: { id: 's1', weight: 999 } }
+    queue.enqueue('set:s1', () => executeDescriptor(fresher), fresher)
+
+    await queue.rehydrate()
+    await vi.advanceTimersByTimeAsync(100)
+
+    // The fresher write won — only weight:999 reached the server
+    const upserts = fakeSupabase.calls.filter(c => c.op === 'upsert')
+    expect(upserts).toHaveLength(1)
+    expect(upserts[0].data).toEqual({ id: 's1', weight: 999 })
+  })
+
+  // Regression for the rehydrate + tombstone-resync double-count that would
+  // otherwise falsely trip the SEV1 delete circuit breaker (LIFT-706 review).
+  it('re-enqueuing a delete for an already-pending key does not double-count the breaker', () => {
+    const queue = new SyncQueue(500)
+    const deleteDescriptor: SyncDescriptor = {
+      op: 'update', table: 'sets', values: { deleted_at: 'x' }, match: { id: 's1' },
+    }
+    queue.enqueueDelete('set:s1', () => Promise.resolve(), deleteDescriptor)
+    queue.enqueueDelete('set:s1', () => Promise.resolve(), deleteDescriptor)
+    queue.enqueueDelete('set:s1', () => Promise.resolve(), deleteDescriptor)
+
+    // Same key three times — counts once toward the breaker, not three times.
+    expect(_getCircuitBreakerState().deleteCount).toBe(1)
+  })
 })
 
 describe('executeDescriptor (LIFT-706)', () => {

--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Durable sync-queue journal tests (LIFT-706).
+ *
+ * The in-memory SyncQueue loses pending operations when the tab closes. To
+ * harden offline writes, operations enqueued WITH a serializable descriptor
+ * are journaled to IndexedDB and can be rehydrated + replayed on the next app
+ * load. These tests cover:
+ *   - journaling on enqueue / removal on flush success / removal on drop
+ *   - legacy (descriptor-less) enqueues stay in-memory only
+ *   - rehydrate() replaying persisted writes through executeDescriptor
+ *   - delete routing preserved across rehydrate (circuit breaker still sees it)
+ *   - clear() wiping the durable journal
+ *   - executeDescriptor building correct upsert / update queries
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── In-memory durable storage (stand-in for IndexedDB) ──────────────
+const { idbStore } = vi.hoisted(() => ({ idbStore: new Map<string, string>() }))
+vi.mock('../durableStorage', () => ({
+  backupToIDB: vi.fn((key: string, value: string) => { idbStore.set(key, value) }),
+  restoreFromIDB: vi.fn(async (key: string) => idbStore.get(key) ?? null),
+}))
+
+// ── Fake Supabase that records mutations ────────────────────────────
+const { fakeSupabase } = vi.hoisted(() => {
+  class FakeBuilder {
+    op = 'select'
+    table: string
+    data: unknown = null
+    filters: Record<string, unknown> = {}
+    private parent: { calls: unknown[] }
+    constructor(parent: { calls: unknown[] }, table: string) {
+      this.parent = parent
+      this.table = table
+    }
+    upsert(data: unknown) { this.op = 'upsert'; this.data = data; return this }
+    update(data: unknown) { this.op = 'update'; this.data = data; return this }
+    eq(col: string, val: unknown) { this.filters[col] = val; return this }
+    then<T>(onfulfilled: (v: { data: unknown[]; error: null }) => T): PromiseLike<T> {
+      this.parent.calls.push({ op: this.op, table: this.table, data: this.data, filters: { ...this.filters } })
+      return Promise.resolve({ data: [], error: null }).then(onfulfilled)
+    }
+  }
+  const fake = {
+    calls: [] as Array<{ op: string; table: string; data: unknown; filters: Record<string, unknown> }>,
+    from(table: string) { return new FakeBuilder(this, table) },
+    reset() { this.calls = [] },
+  }
+  return { fakeSupabase: fake }
+})
+vi.mock('../supabase', () => ({ supabase: fakeSupabase, isPreviewMode: { value: false } }))
+vi.mock('../crossTabSync', () => ({ broadcastSyncStatus: vi.fn() }))
+vi.mock('../logger', () => ({ logError: vi.fn(), logWarn: vi.fn(), logInfo: vi.fn() }))
+
+import {
+  SyncQueue,
+  executeDescriptor,
+  syncStatus,
+  _resetRateLimit,
+  _resetCircuitBreaker,
+  _getCircuitBreakerState,
+  type SyncDescriptor,
+} from '../syncQueue'
+
+const UPSERT: SyncDescriptor = { op: 'upsert', table: 'sets', row: { id: 's1', weight: 100 } }
+
+describe('SyncQueue durable journal (LIFT-706)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    syncStatus.value = 'synced'
+    idbStore.clear()
+    fakeSupabase.reset()
+    _resetRateLimit()
+    _resetCircuitBreaker()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('journals an operation enqueued with a descriptor and persists it to IDB', () => {
+    const queue = new SyncQueue(500)
+    queue.enqueue('set:s1', () => Promise.resolve(), UPSERT)
+
+    expect(queue.journalSize).toBe(1)
+    const persisted = JSON.parse(idbStore.get('lift-sync-journal')!)
+    expect(persisted).toHaveLength(1)
+    expect(persisted[0]).toMatchObject({ key: 'set:s1', isDelete: false, descriptor: UPSERT })
+  })
+
+  it('does NOT journal descriptor-less (legacy) operations', () => {
+    const queue = new SyncQueue(500)
+    queue.enqueue('set:s1', () => Promise.resolve())
+
+    expect(queue.journalSize).toBe(0)
+    expect(idbStore.has('lift-sync-journal')).toBe(false)
+  })
+
+  it('removes the journal entry once the operation flushes successfully', async () => {
+    const queue = new SyncQueue(100)
+    queue.enqueue('set:s1', () => Promise.resolve(), UPSERT)
+    expect(queue.journalSize).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(queue.journalSize).toBe(0)
+    expect(JSON.parse(idbStore.get('lift-sync-journal')!)).toHaveLength(0)
+  })
+
+  it('keeps the entry journaled across retries, then drops it after exhausting them', async () => {
+    const queue = new SyncQueue(100)
+    queue.enqueue('set:s1', () => Promise.reject(new Error('offline')), UPSERT)
+
+    // First failed attempt — still journaled (will retry)
+    await vi.advanceTimersByTimeAsync(100)
+    expect(queue.journalSize).toBe(1)
+
+    // Run all retries to exhaustion — op is dropped, journal cleared
+    await vi.runAllTimersAsync()
+    expect(queue.journalSize).toBe(0)
+  })
+
+  it('clear() wipes the in-memory journal and persists the empty journal', () => {
+    const queue = new SyncQueue(500)
+    queue.enqueue('set:s1', () => Promise.resolve(), UPSERT)
+    expect(queue.journalSize).toBe(1)
+
+    queue.clear()
+
+    expect(queue.journalSize).toBe(0)
+    expect(JSON.parse(idbStore.get('lift-sync-journal')!)).toHaveLength(0)
+  })
+
+  // ── Rehydration ──────────────────────────────────────────────────
+
+  it('rehydrate() replays a journaled upsert through executeDescriptor', async () => {
+    // Seed the journal as if a previous session left an unsent write
+    idbStore.set('lift-sync-journal', JSON.stringify([
+      { key: 'set:s1', isDelete: false, descriptor: UPSERT },
+    ]))
+
+    const queue = new SyncQueue(100)
+    await queue.rehydrate()
+    expect(queue.pending).toBe(1)
+    expect(queue.journalSize).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    // The replayed write reached Supabase, then the journal was cleared
+    const upserts = fakeSupabase.calls.filter(c => c.op === 'upsert' && c.table === 'sets')
+    expect(upserts).toHaveLength(1)
+    expect(upserts[0].data).toEqual({ id: 's1', weight: 100 })
+    expect(queue.journalSize).toBe(0)
+  })
+
+  it('rehydrate() routes a journaled delete back through the circuit breaker', async () => {
+    const deleteDescriptor: SyncDescriptor = {
+      op: 'update', table: 'sets', values: { deleted_at: '2026-06-03T00:00:00Z' },
+      match: { id: 's1', user_id: 'u1' },
+    }
+    idbStore.set('lift-sync-journal', JSON.stringify([
+      { key: 'set:s1', isDelete: true, descriptor: deleteDescriptor },
+    ]))
+
+    const queue = new SyncQueue(100)
+    await queue.rehydrate()
+
+    // The delete was counted by the circuit breaker (proves enqueueDelete routing)
+    expect(_getCircuitBreakerState().deleteCount).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+    const updates = fakeSupabase.calls.filter(c => c.op === 'update')
+    expect(updates).toHaveLength(1)
+    expect(updates[0].filters).toMatchObject({ id: 's1', user_id: 'u1' })
+  })
+
+  it('rehydrate() is a no-op when the journal is empty', async () => {
+    const queue = new SyncQueue(100)
+    await queue.rehydrate()
+    expect(queue.pending).toBe(0)
+  })
+})
+
+describe('executeDescriptor (LIFT-706)', () => {
+  beforeEach(() => fakeSupabase.reset())
+
+  it('builds an upsert query from an upsert descriptor', async () => {
+    await executeDescriptor({ op: 'upsert', table: 'exercises', row: { id: 'e1', name: 'Bench' } })
+    expect(fakeSupabase.calls).toEqual([
+      { op: 'upsert', table: 'exercises', data: { id: 'e1', name: 'Bench' }, filters: {} },
+    ])
+  })
+
+  it('builds an update query with eq filters from an update descriptor', async () => {
+    await executeDescriptor({
+      op: 'update', table: 'sets',
+      values: { deleted_at: null },
+      match: { id: 's1', user_id: 'u1' },
+    })
+    expect(fakeSupabase.calls).toEqual([
+      { op: 'update', table: 'sets', data: { deleted_at: null }, filters: { id: 's1', user_id: 'u1' } },
+    ])
+  })
+})

--- a/src/lib/durableStorage.ts
+++ b/src/lib/durableStorage.ts
@@ -42,6 +42,21 @@ export function backupToIDB(key: string, value: string): void {
   })
 }
 
+/**
+ * Close the cached IndexedDB connection.
+ *
+ * `indexedDB.deleteDatabase()` is blocked indefinitely while any connection to
+ * the database is still open. Account deletion must call this first so the
+ * backup (including the sync journal) is actually wiped from disk rather than
+ * deferred until the next tab close.
+ */
+export function closeDB(): void {
+  if (db) {
+    db.close()
+    db = null
+  }
+}
+
 /** Clear all data from IndexedDB backup. */
 export async function clearIDB(): Promise<void> {
   try {

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -193,7 +193,16 @@ export class SyncQueue {
   enqueueDelete(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
 
-    if (CIRCUIT_BREAKER_ENABLED) {
+    // Re-enqueuing a delete for a key that's already pending is the SAME logical
+    // delete being refreshed (e.g. rehydrate() replays a journaled delete and
+    // then _fetchFromSupabase's tombstone pass re-enqueues it before the queue
+    // flushes). Those must NOT each push a fresh timestamp into the breaker, or
+    // a handful of pending offline deletes would falsely trip the SEV1 guard.
+    // The breaker only needs to see genuinely NEW (distinct-key) deletes — a
+    // real delete storm still has distinct keys and still trips.
+    const alreadyPending = this._queue.has(key) || this._retryQueue.has(key)
+
+    if (CIRCUIT_BREAKER_ENABLED && !alreadyPending) {
       const now = Date.now()
 
       // Circuit is currently open (in cool-down): block the delete.
@@ -356,6 +365,10 @@ export class SyncQueue {
     for (const entry of entries) {
       if (!entry || typeof entry.key !== 'string' || !entry.descriptor) continue
       const { key, descriptor, isDelete } = entry
+      // Don't clobber a newer in-session write: if the user acted on this key
+      // while the (async) journal read was in flight, the live queue/retry entry
+      // is fresher than the persisted snapshot and must win.
+      if (this._queue.has(key) || this._retryQueue.has(key)) continue
       if (isDelete) {
         this.enqueueDelete(key, () => executeDescriptor(descriptor), descriptor)
       } else {

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -2,8 +2,57 @@ import { ref } from 'vue'
 import { supabase, isPreviewMode } from './supabase'
 import { logError, logWarn } from './logger'
 import { broadcastSyncStatus } from './crossTabSync'
+import { backupToIDB, restoreFromIDB } from './durableStorage'
 
 type SyncOperation = () => PromiseLike<unknown>
+
+/**
+ * Serializable description of a Supabase mutation (LIFT-706).
+ *
+ * The in-memory queue holds closures, which cannot survive a tab close or
+ * app restart. To harden offline writes — where every logged set is hard-won
+ * data — a closure may be accompanied by a `SyncDescriptor`: a plain,
+ * JSON-serializable record of the same mutation. Descriptors are journaled to
+ * IndexedDB so that pending writes can be rehydrated and replayed after the
+ * app reopens, even if the original closure (and its captured scope) is gone.
+ *
+ * Only idempotent shapes are modeled (upsert / update), matching the
+ * idempotency invariant enforced in architecturalInvariants.test.ts — replay
+ * is safe because re-running an upsert or a targeted update is a no-op once the
+ * server already holds the value.
+ */
+export type SyncDescriptor =
+  | { op: 'upsert'; table: string; row: Record<string, unknown> }
+  | { op: 'update'; table: string; values: Record<string, unknown>; match: Record<string, unknown> }
+
+interface JournalEntry {
+  descriptor: SyncDescriptor
+  isDelete: boolean
+}
+
+/** IndexedDB key (in the shared durable-storage keyval store) for the queue journal. */
+const JOURNAL_KEY = 'lift-sync-journal'
+
+/**
+ * Rebuild a runnable Supabase operation from its serializable descriptor.
+ * Used to replay journaled writes after a reload. Returns a no-op promise when
+ * Supabase is unavailable so replay degrades gracefully offline.
+ */
+export function executeDescriptor(descriptor: SyncDescriptor): PromiseLike<unknown> {
+  if (!supabase) return Promise.resolve()
+  // The table name is dynamic here (driven by the descriptor), so the strongly
+  // typed supabase client surface doesn't apply — cast to a loose client.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const client = supabase as any
+  if (descriptor.op === 'upsert') {
+    return client.from(descriptor.table).upsert(descriptor.row)
+  }
+  let query = client.from(descriptor.table).update(descriptor.values)
+  for (const [col, val] of Object.entries(descriptor.match)) {
+    query = query.eq(col, val)
+  }
+  return query
+}
 
 /** Reactive sync status for UI indicators. */
 export const syncStatus = ref<'synced' | 'syncing' | 'error' | 'offline'>('synced')
@@ -57,17 +106,52 @@ export class SyncQueue {
   private _retryQueue = new Map<string, { op: SyncOperation; attempt: number }>()
   private _maxRetries = 5
   private _attemptMap = new Map<string, number>()
+  // Durable mirror of pending operations keyed identically to _queue. Only
+  // operations enqueued WITH a descriptor are journaled; descriptor-less
+  // callers (e.g. fire-and-forget telemetry) keep the legacy in-memory-only
+  // behavior. The journal becomes "active" the first time a descriptor is
+  // seen, so descriptor-less queues never touch IndexedDB.
+  private _journal = new Map<string, JournalEntry>()
+  private _journalActive = false
 
   constructor(flushDelay = 1000) {
     this._flushDelay = flushDelay
   }
 
+  /** Persist the journal to IndexedDB (fire-and-forget). No-op until active. */
+  private _persistJournal(): void {
+    if (!this._journalActive) return
+    try {
+      const serialized = JSON.stringify(
+        [...this._journal.entries()].map(([key, entry]) => ({ key, ...entry })),
+      )
+      backupToIDB(JOURNAL_KEY, serialized)
+    } catch {
+      // Serialization/IDB failure must never break the in-memory queue.
+    }
+  }
+
+  /** Record (or replace) a journal entry and persist. */
+  private _journalSet(key: string, descriptor: SyncDescriptor, isDelete: boolean): void {
+    this._journalActive = true
+    this._journal.set(key, { descriptor, isDelete })
+    this._persistJournal()
+  }
+
   /**
    * Add an operation to the queue. If `key` matches an existing entry,
    * the previous operation is replaced (last-write-wins).
+   *
+   * Pass a `descriptor` to make the write durable across reloads: it is
+   * journaled to IndexedDB immediately and removed once the op flushes
+   * successfully (or is dropped after exhausting retries). Omit it for
+   * in-memory-only writes (the legacy behavior).
    */
-  enqueue(key: string, op: SyncOperation): void {
+  enqueue(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
+    // Journal first — before rate-limit deferral — so the durable record
+    // exists the instant the user acts, even if execution is deferred.
+    if (descriptor) this._journalSet(key, descriptor, false)
     // Rate limiting
     _rateCount++
     if (!_rateResetTimer) {
@@ -106,7 +190,7 @@ export class SyncQueue {
    * plain `enqueue`, so they are visible to the breaker. See the
    * structural test in syncQueue.test.ts that enforces this.
    */
-  enqueueDelete(key: string, op: SyncOperation): void {
+  enqueueDelete(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
 
     if (CIRCUIT_BREAKER_ENABLED) {
@@ -155,6 +239,10 @@ export class SyncQueue {
       _deleteTimestamps.push(now)
     }
 
+    // Journal the delete (isDelete:true) only after the breaker has cleared it,
+    // so a blocked delete is never replayed. enqueue() is then called WITHOUT a
+    // descriptor so it won't overwrite this entry as a non-delete.
+    if (descriptor) this._journalSet(key, descriptor, true)
     this.enqueue(key, op)
   }
 
@@ -177,13 +265,17 @@ export class SyncQueue {
         entries.map(([, op]) => op()),
       )
       let hasFailure = false
+      let journalChanged = false
       results.forEach((result, i) => {
+        const key = entries[i][0]
         if (result.status === 'fulfilled') {
           // Clear retry counter on success so future failures get full retries
-          this._attemptMap.delete(entries[i][0])
+          this._attemptMap.delete(key)
+          // Write durably landed on the server — drop its journal entry.
+          if (this._journal.delete(key)) journalChanged = true
         } else if (result.status === 'rejected') {
           hasFailure = true
-          const [key, op] = entries[i]
+          const op = entries[i][1]
           const prevAttempt = this._attemptMap.get(key) ?? 0
           const attempt = prevAttempt + 1
           if (attempt <= this._maxRetries) {
@@ -192,9 +284,14 @@ export class SyncQueue {
             logWarn(`Sync failed, will retry (attempt ${attempt}/${this._maxRetries})`, { key })
           } else {
             logError(result.reason, { source: 'SyncQueue', key, attempts: attempt })
+            // Retries exhausted — the op is dropped, so drop its journal entry
+            // too. (Reconciliation in the store's _fetchFromSupabase is the
+            // last line of defense for recovering such writes.)
+            if (this._journal.delete(key)) journalChanged = true
           }
         }
       })
+      if (journalChanged) this._persistJournal()
       if (this._retryQueue.size > 0) this._scheduleRetry()
       const newStatus = hasFailure ? 'error' : 'synced' as const
       syncStatus.value = newStatus
@@ -224,6 +321,52 @@ export class SyncQueue {
     this._retryQueue.clear()
     this._attemptMap.clear()
     _deferredOps.clear()
+    const hadJournal = this._journal.size > 0
+    this._journal.clear()
+    if (hadJournal) this._persistJournal()
+  }
+
+  /**
+   * Replay journaled operations after an app reload (LIFT-706).
+   *
+   * Reads the durable journal from IndexedDB and re-enqueues each entry by
+   * rebuilding its op from the serializable descriptor. Deletes are routed back
+   * through enqueueDelete so the circuit breaker still sees them. Safe to call
+   * once on startup; a no-op when Supabase is unavailable or the journal is
+   * empty. Replay is idempotent (upsert/update only), so re-running a write the
+   * server already has does no harm.
+   */
+  async rehydrate(): Promise<void> {
+    if (!supabase || isPreviewMode.value) return
+    let raw: string | null
+    try {
+      raw = await restoreFromIDB(JOURNAL_KEY)
+    } catch {
+      return
+    }
+    if (!raw) return
+    let entries: Array<{ key: string; descriptor: SyncDescriptor; isDelete: boolean }>
+    try {
+      const parsed = JSON.parse(raw)
+      if (!Array.isArray(parsed)) return
+      entries = parsed
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry || typeof entry.key !== 'string' || !entry.descriptor) continue
+      const { key, descriptor, isDelete } = entry
+      if (isDelete) {
+        this.enqueueDelete(key, () => executeDescriptor(descriptor), descriptor)
+      } else {
+        this.enqueue(key, () => executeDescriptor(descriptor), descriptor)
+      }
+    }
+  }
+
+  /** Number of journaled (durable) pending operations. For tests/telemetry. */
+  get journalSize(): number {
+    return this._journal.size
   }
 
   private _scheduleFlush(): void {

--- a/src/stores/__tests__/syncFuzz.test.ts
+++ b/src/stores/__tests__/syncFuzz.test.ts
@@ -583,4 +583,79 @@ describe('sync fuzz: SEV1 2026-04-12 regression', () => {
       expect(fakeSupabase.tables.exercises[0].archived_at).toBeNull()
     })
   })
+
+  // ── Reconciliation gap (LIFT-706) ──────────────────────────────
+  // A set added offline to an exercise that ANOTHER device later updated:
+  // the remote exercise wins last-write-wins, so it is neither localOnly nor
+  // localWins. Before the fix, its offline-added set rendered locally but was
+  // never pushed — silently diverging from the server. Now it must be pushed.
+  describe('reconciliation pushes offline sets on remote-winning exercises', () => {
+    it('upserts a local-only set even when the remote exercise wins the merge', async () => {
+      const userId = 'test-user'
+      // Local state (loaded from localStorage): older exercise timestamp, but
+      // it holds an extra set ('s-local') that was logged offline.
+      getLocalStorageMock().setItem('workout-exercises', JSON.stringify([
+        {
+          id: 'ex-1', name: 'Bench', tags: [],
+          updated_at: '2026-01-01T00:00:00Z',
+          sets: [
+            { id: 's-local', date: '2026-01-15T12:00:00Z', weight: 200, reps: 5, estimated1RM: 233 },
+          ],
+        },
+      ]))
+      // Remote state: NEWER exercise timestamp (so remote wins the merge) and a
+      // different set the server already knows about.
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-02-01T00:00:00Z' },
+      ])
+      fakeSupabase.seed('sets', [
+        { id: 's-remote', user_id: userId, exercise_id: 'ex-1',
+          date: '2026-01-20T12:00:00Z', weight: 225, reps: 5, estimated_1rm: 253 },
+      ])
+
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      // The offline set was pushed to the server (the gap fix)…
+      const setUpserts = fakeSupabase.upsertsFor('sets')
+      const pushedIds = setUpserts.map(u => (u.data as { id: string }).id)
+      expect(pushedIds).toContain('s-local')
+      // …and the server now holds BOTH sets, no deletes anywhere.
+      expect(fakeSupabase.tables.sets.map(s => s.id).sort()).toEqual(['s-local', 's-remote'])
+      expect(fakeSupabase.deletesFor('sets')).toEqual([])
+      // The already-synced remote set is not redundantly re-pushed.
+      expect(pushedIds).not.toContain('s-remote')
+    })
+
+    it('does not re-push sets that already exist on the remote exercise', async () => {
+      const userId = 'test-user'
+      getLocalStorageMock().setItem('workout-exercises', JSON.stringify([
+        {
+          id: 'ex-1', name: 'Bench', tags: [],
+          updated_at: '2026-01-01T00:00:00Z',
+          sets: [
+            { id: 's-shared', date: '2026-01-20T12:00:00Z', weight: 225, reps: 5, estimated1RM: 253 },
+          ],
+        },
+      ]))
+      fakeSupabase.seed('exercises', [
+        { id: 'ex-1', user_id: userId, name: 'Bench', tags: [],
+          created_at: '2026-01-01T00:00:00Z', updated_at: '2026-02-01T00:00:00Z' },
+      ])
+      fakeSupabase.seed('sets', [
+        { id: 's-shared', user_id: userId, exercise_id: 'ex-1',
+          date: '2026-01-20T12:00:00Z', weight: 225, reps: 5, estimated_1rm: 253 },
+      ])
+
+      const store = useWorkoutStore()
+      await store.init(userId)
+      await tick()
+
+      // Nothing new to push — the set is already on the remote.
+      expect(fakeSupabase.upsertsFor('sets')).toEqual([])
+      expect(fakeSupabase.deletesFor('sets')).toEqual([])
+    })
+  })
 })

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -219,19 +219,74 @@ export const useWorkoutStore = defineStore('workout', () => {
     delete exercise.sample
     if (supabase && !isPreviewMode.value && _userId) {
       const userId = _userId
-      syncQueue.enqueue(`exercise:${exercise.id}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, userId)
       for (const set of exercise.sets) {
-        syncQueue.enqueue(`set:${set.id}`, () =>
-          supabase!.from('sets').upsert({
-            id: set.id, user_id: userId, exercise_id: exercise.id,
-            date: set.date, weight: set.weight, reps: set.reps,
-            estimated_1rm: set.estimated1RM
-          })
-        )
+        _enqueueSetUpsert(set, exercise.id, userId)
       }
     }
+  }
+
+  /**
+   * Durable exercise upsert. Builds the row once and journals a serializable
+   * descriptor alongside the closure so the write survives a reload (LIFT-706).
+   */
+  function _enqueueExerciseUpsert(exercise: Exercise, userId: string) {
+    const row = _buildExerciseUpsert(exercise, userId)
+    syncQueue.enqueue(
+      `exercise:${exercise.id}`,
+      () => supabase!.from('exercises').upsert(row),
+      { op: 'upsert', table: 'exercises', row },
+    )
+  }
+
+  /** Durable set upsert with a journaled descriptor (LIFT-706). */
+  function _enqueueSetUpsert(
+    set: { id: string; date: string; weight: number; reps: number; estimated1RM: number },
+    exerciseId: string,
+    userId: string,
+  ) {
+    const row = {
+      id: set.id, user_id: userId, exercise_id: exerciseId,
+      date: set.date, weight: set.weight, reps: set.reps,
+      estimated_1rm: set.estimated1RM,
+    }
+    syncQueue.enqueue(
+      `set:${set.id}`,
+      () => supabase!.from('sets').upsert(row),
+      { op: 'upsert', table: 'sets', row },
+    )
+  }
+
+  /**
+   * Durable soft-delete (UPDATE { deleted_at }). Routed through enqueueDelete
+   * so the circuit breaker sees it, with a journaled descriptor (LIFT-706).
+   */
+  function _enqueueSoftDelete(key: string, table: 'sets' | 'exercises', match: Record<string, string>) {
+    const deletedAt = new Date().toISOString()
+    const values = { deleted_at: deletedAt }
+    syncQueue.enqueueDelete(
+      key,
+      () => {
+        let q = supabase!.from(table).update(values)
+        for (const [col, val] of Object.entries(match)) q = q.eq(col, val)
+        return q
+      },
+      { op: 'update', table, values, match },
+    )
+  }
+
+  /** Durable soft-delete restore (UPDATE { deleted_at: null }) (LIFT-706). */
+  function _enqueueRestore(key: string, table: 'sets' | 'exercises', match: Record<string, string>) {
+    const values = { deleted_at: null }
+    syncQueue.enqueue(
+      key,
+      () => {
+        let q = supabase!.from(table).update(values)
+        for (const [col, val] of Object.entries(match)) q = q.eq(col, val)
+        return q
+      },
+      { op: 'update', table, values, match },
+    )
   }
 
   // ── Actions ────────────────────────────────────────────────────────
@@ -294,14 +349,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     for (const s of sets) {
       if (isTombstoned('sets', s.id)) {
         // Re-enqueue the soft-delete for tombstoned sets still visible on remote
-        const setId = s.id
-        const userId = _userId
-        const deletedAt = new Date().toISOString()
-        syncQueue.enqueueDelete(`set:${setId}`, () =>
-          supabase!.from('sets')
-            .update({ deleted_at: deletedAt })
-            .eq('id', setId).eq('user_id', userId)
-        )
+        _enqueueSoftDelete(`set:${s.id}`, 'sets', { id: s.id, user_id: _userId })
         continue
       }
       const exerciseId = s.exercise_id
@@ -388,17 +436,9 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (filteredLocalOnly.length > 0) {
       const userId = _userId
       for (const ex of filteredLocalOnly) {
-        syncQueue.enqueue(`exercise:${ex.id}`, () =>
-          supabase!.from('exercises').upsert(_buildExerciseUpsert(ex, userId))
-        )
+        _enqueueExerciseUpsert(ex, userId)
         for (const set of ex.sets) {
-          syncQueue.enqueue(`set:${set.id}`, () =>
-            supabase!.from('sets').upsert({
-              id: set.id, user_id: userId, exercise_id: ex.id,
-              date: set.date, weight: set.weight, reps: set.reps,
-              estimated_1rm: set.estimated1RM
-            })
-          )
+          _enqueueSetUpsert(set, ex.id, userId)
         }
       }
     }
@@ -411,9 +451,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (filteredLocalWins.length > 0) {
       const userId = _userId
       for (const ex of filteredLocalWins) {
-        syncQueue.enqueue(`exercise:${ex.id}`, () =>
-          supabase!.from('exercises').upsert(_buildExerciseUpsert(ex, userId))
-        )
+        _enqueueExerciseUpsert(ex, userId)
         // Only push sets that are new or have changed content (offline edits)
         const remoteSets = new Map(
           (remoteExMap.get(ex.id)?.sets || []).map(s => [s.id, s])
@@ -425,14 +463,38 @@ export const useWorkoutStore = defineStore('workout', () => {
             || remote.reps !== set.reps
             || remote.date !== set.date
           if (needsPush) {
-            syncQueue.enqueue(`set:${set.id}`, () =>
-              supabase!.from('sets').upsert({
-                id: set.id, user_id: userId, exercise_id: ex.id,
-                date: set.date, weight: set.weight, reps: set.reps,
-                estimated_1rm: set.estimated1RM
-              })
-            )
+            _enqueueSetUpsert(set, ex.id, userId)
           }
+        }
+      }
+    }
+
+    // Reconciliation gap (LIFT-706): when a DIFFERENT device updated an
+    // exercise after this device added sets to it offline, the remote copy
+    // WINS the last-write-wins merge — so the exercise is neither localOnly
+    // nor localWins. Its offline-added sets are unioned into local state above
+    // (so they render), but the old push logic only covered localOnly/localWins
+    // exercises, leaving those sets stranded locally and silently diverged from
+    // the server. Push any local set on a both-sides exercise that the remote
+    // doesn't have (and isn't tombstoned). Idempotent upsert + key dedup makes
+    // overlap with the pushes above harmless.
+    {
+      const userId = _userId
+      const alreadyPushedIds = new Set([
+        ...filteredLocalOnly.map(e => e.id),
+        ...filteredLocalWins.map(e => e.id),
+      ])
+      for (const ex of deduped.exercises) {
+        if (ex.sample || alreadyPushedIds.has(ex.id)) continue
+        // Only both-sides exercises reach here; localOnly/localWins are handled
+        // above. Use the pre-merge `remoteSetIds` snapshot — the union step
+        // mutates remote exercises' `.sets` arrays in place, so checking
+        // `remoteEx.sets` here would wrongly treat the just-unioned local set
+        // as already present on the server.
+        if (!remoteExMap.has(ex.id)) continue
+        for (const set of ex.sets) {
+          if (remoteSetIds.has(set.id) || isTombstoned('sets', set.id)) continue
+          _enqueueSetUpsert(set, ex.id, userId)
         }
       }
     }
@@ -442,19 +504,9 @@ export const useWorkoutStore = defineStore('workout', () => {
       .filter(ex => isTombstoned(TOMBSTONE_STORE, ex.id))
     if (tombstoneExercises.length > 0) {
       const userId = _userId
-      const deletedAt = new Date().toISOString()
       for (const ex of tombstoneExercises) {
-        const exId = ex.id
-        syncQueue.enqueueDelete(`exercise-sets:${exId}`, () =>
-          supabase!.from('sets')
-            .update({ deleted_at: deletedAt })
-            .eq('exercise_id', exId).eq('user_id', userId)
-        )
-        syncQueue.enqueueDelete(`exercise:${exId}`, () =>
-          supabase!.from('exercises')
-            .update({ deleted_at: deletedAt })
-            .eq('id', exId).eq('user_id', userId)
-        )
+        _enqueueSoftDelete(`exercise-sets:${ex.id}`, 'sets', { exercise_id: ex.id, user_id: userId })
+        _enqueueSoftDelete(`exercise:${ex.id}`, 'exercises', { id: ex.id, user_id: userId })
       }
     }
   }
@@ -473,10 +525,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (sync && supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${id}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
     return id
   }
@@ -499,10 +548,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (supabase && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
   }
 
@@ -516,10 +562,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (supabase && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
   }
 
@@ -542,13 +585,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (sync && supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`set:${id}`, () =>
-        supabase!.from('sets').upsert({
-          id, user_id: userId, exercise_id: exerciseId,
-          date, weight, reps, estimated_1rm: estimated1RM
-        })
-      )
+      _enqueueSetUpsert({ id, date, weight, reps, estimated1RM }, exerciseId, _userId)
     }
   }
 
@@ -569,14 +606,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (supabase && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`set:${setId}`, () =>
-        supabase!.from('sets').upsert({
-          id: setId, user_id: userId, exercise_id: exerciseId,
-          date: set.date, weight: set.weight, reps: set.reps,
-          estimated_1rm: set.estimated1RM
-        })
-      )
+      _enqueueSetUpsert(set, exerciseId, _userId)
     }
   }
 
@@ -590,13 +620,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (sync && supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      const deletedAt = new Date().toISOString()
-      syncQueue.enqueueDelete(`set:${setId}`, () =>
-        supabase!.from('sets')
-          .update({ deleted_at: deletedAt })
-          .eq('id', setId).eq('user_id', userId)
-      )
+      _enqueueSoftDelete(`set:${setId}`, 'sets', { id: setId, user_id: _userId })
     }
   }
 
@@ -612,12 +636,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     // deleteSet so an in-flight delete is superseded (last-write-wins). If
     // the delete already flushed, this un-soft-deletes the row.
     if (supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`set:${set.id}`, () =>
-        supabase!.from('sets')
-          .update({ deleted_at: null })
-          .eq('id', set.id).eq('user_id', userId)
-      )
+      _enqueueRestore(`set:${set.id}`, 'sets', { id: set.id, user_id: _userId })
     }
   }
 
@@ -633,10 +652,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (supabase && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
   }
 
@@ -650,10 +666,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (supabase && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
   }
 
@@ -666,18 +679,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (sync && supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      const deletedAt = new Date().toISOString()
-      syncQueue.enqueueDelete(`exercise-sets:${exerciseId}`, () =>
-        supabase!.from('sets')
-          .update({ deleted_at: deletedAt })
-          .eq('exercise_id', exerciseId).eq('user_id', userId)
-      )
-      syncQueue.enqueueDelete(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises')
-          .update({ deleted_at: deletedAt })
-          .eq('id', exerciseId).eq('user_id', userId)
-      )
+      _enqueueSoftDelete(`exercise-sets:${exerciseId}`, 'sets', { exercise_id: exerciseId, user_id: _userId })
+      _enqueueSoftDelete(`exercise:${exerciseId}`, 'exercises', { id: exerciseId, user_id: _userId })
     }
   }
 
@@ -700,17 +703,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     // alternative (tracking per-cascade timestamps) is complexity without
     // matching benefit for immediate-undo UX.
     if (supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise-sets:${exercise.id}`, () =>
-        supabase!.from('sets')
-          .update({ deleted_at: null })
-          .eq('exercise_id', exercise.id).eq('user_id', userId)
-      )
-      syncQueue.enqueue(`exercise:${exercise.id}`, () =>
-        supabase!.from('exercises')
-          .update({ deleted_at: null })
-          .eq('id', exercise.id).eq('user_id', userId)
-      )
+      _enqueueRestore(`exercise-sets:${exercise.id}`, 'sets', { exercise_id: exercise.id, user_id: _userId })
+      _enqueueRestore(`exercise:${exercise.id}`, 'exercises', { id: exercise.id, user_id: _userId })
     }
   }
 
@@ -729,10 +723,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     // when the row hasn't yet been created on the server (e.g., an adopted
     // sample exercise whose creating upsert sits in the same queue slot).
     if (supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
   }
 
@@ -746,39 +737,20 @@ export const useWorkoutStore = defineStore('workout', () => {
     _persist()
 
     if (supabase && !isPreviewMode.value && _userId) {
-      const userId = _userId
-      syncQueue.enqueue(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises').upsert(_buildExerciseUpsert(exercise, userId))
-      )
+      _enqueueExerciseUpsert(exercise, _userId)
     }
   }
 
   function syncDeleteSet(setId: string) {
     if (supabase && _userId) {
-      const userId = _userId
-      const deletedAt = new Date().toISOString()
-      syncQueue.enqueueDelete(`set:${setId}`, () =>
-        supabase!.from('sets')
-          .update({ deleted_at: deletedAt })
-          .eq('id', setId).eq('user_id', userId)
-      )
+      _enqueueSoftDelete(`set:${setId}`, 'sets', { id: setId, user_id: _userId })
     }
   }
 
   function syncDeleteExercise(exerciseId: string) {
     if (supabase && _userId) {
-      const userId = _userId
-      const deletedAt = new Date().toISOString()
-      syncQueue.enqueueDelete(`exercise-sets:${exerciseId}`, () =>
-        supabase!.from('sets')
-          .update({ deleted_at: deletedAt })
-          .eq('exercise_id', exerciseId).eq('user_id', userId)
-      )
-      syncQueue.enqueueDelete(`exercise:${exerciseId}`, () =>
-        supabase!.from('exercises')
-          .update({ deleted_at: deletedAt })
-          .eq('id', exerciseId).eq('user_id', userId)
-      )
+      _enqueueSoftDelete(`exercise-sets:${exerciseId}`, 'sets', { exercise_id: exerciseId, user_id: _userId })
+      _enqueueSoftDelete(`exercise:${exerciseId}`, 'exercises', { id: exerciseId, user_id: _userId })
     }
   }
 
@@ -846,9 +818,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (_userId && modified.length > 0) {
       const userId = _userId
       for (const e of modified.filter(e => !e.sample)) {
-        syncQueue.enqueue(`exercise:${e.id}`, () =>
-          supabase!.from('exercises').upsert(_buildExerciseUpsert(e, userId))
-        )
+        _enqueueExerciseUpsert(e, userId)
       }
     }
   }
@@ -877,9 +847,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (_userId && modified.length > 0) {
       const userId = _userId
       for (const e of modified.filter(e => !e.sample)) {
-        syncQueue.enqueue(`exercise:${e.id}`, () =>
-          supabase!.from('exercises').upsert(_buildExerciseUpsert(e, userId))
-        )
+        _enqueueExerciseUpsert(e, userId)
       }
     }
   }

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -478,6 +478,13 @@ export const useWorkoutStore = defineStore('workout', () => {
     // the server. Push any local set on a both-sides exercise that the remote
     // doesn't have (and isn't tombstoned). Idempotent upsert + key dedup makes
     // overlap with the pushes above harmless.
+    //
+    // Known limitation (shared with the localOnly/localWins pushes above): the
+    // fetch filters out rows where deleted_at IS NOT NULL, so a set another
+    // device soft-deleted looks identical to a never-synced local set. Both get
+    // re-pushed. This favors "don't lose hard-won data" over silent removal, but
+    // means cross-device deletes don't propagate through this path — that needs
+    // the server to surface tombstones (a sync-protocol change, see LIFT-705).
     {
       const userId = _userId
       const alreadyPushedIds = new Set([


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-706](https://github.com/aschung212/Lift/issues/706)

LIFT-706: The `syncQueue` held pending ops as in-memory closures that vanished on tab close, and offline sets added to an exercise another device later updated rendered locally but were never re-pushed (silent client/server divergence). I made workout writes durable via a serializable journal replayed on launch, and closed the reconciliation gap.

## Changes
- **`src/lib/syncQueue.ts`** — Added a serializable `SyncDescriptor` (idempotent upsert/update only), an IndexedDB journal that mirrors pending ops (added on enqueue, removed on flush success / drop), `executeDescriptor()` to rebuild ops, and `rehydrate()` to replay journaled writes on startup (deletes routed back through `enqueueDelete`). Guarded `rehydrate()` against a TOCTOU race and stopped re-enqueued deletes for already-pending keys from double-counting the SEV1 circuit breaker.
- **`src/stores/workout.ts`** — Routed all user-mutation writes through four durable helpers (`_enqueueExerciseUpsert`/`_enqueueSetUpsert`/`_enqueueSoftDelete`/`_enqueueRestore`) that carry descriptors. Closed the reconciliation gap in `_fetchFromSupabase` (union-then-push using the pre-merge remote-set snapshot, since the merge mutates remote `.sets` in place).
- **`src/composables/useAuth.ts`** — Call `syncQueue.rehydrate()` in `initStores`; clear the journal on sign-out; close the IDB connection before `deleteAccount()`'s `deleteDatabase()`.
- **`src/lib/durableStorage.ts`** — Added `closeDB()`.
- **Tests** — New `syncQueueJournal.test.ts` (journal persist/replay/clear, TOCTOU, breaker dedup, `executeDescriptor` shapes) + reconciliation-gap tests in `syncFuzz.test.ts`.
- **`CLAUDE.md`** — Documented the durable write queue in Architecture Notes.

## Verification
- `npm test` → 1946 passed, 1 skipped
- `npm run typecheck` → clean
- `npm run lint` → 0 errors (9 pre-existing warnings in unrelated files)
- `npm run build` → success
- Pre-push Gemini review passed; the four P2 findings from the post-commit review were addressed in a follow-up commit.

## Discoveries (for future iterations)
ISSUE_DISCOVER: Durability via the sync journal currently covers only the workout store. `bodyweight.ts`, `preferences.ts`, `progression.ts`, and `xpInstrumentation.ts` still enqueue descriptor-less closures, so their offline writes are not replayed after a tab close. Extend descriptor coverage (or document why telemetry/bodyweight can rely on store reconciliation alone).

ISSUE_DISCOVER: Cross-device soft-deletes don't propagate through `_fetchFromSupabase` because the fetch filters `deleted_at IS NOT NULL`, so a set deleted on device B looks identical to a never-synced local set on device A and gets re-pushed each sync (shared by the existing localOnly/localWins pushes, widened by the LIFT-706 gap fix). A proper fix needs the server to surface tombstones to the read path — overlaps LIFT-705's sync-policy reconsideration.

ISSUE_DISCOVER: When the sync rate limit is exceeded, a deferred op is re-enqueued from `_deferredOps` without its descriptor, so a write deferred at the moment of a tab close keeps only its initial journal entry but won't re-journal on the deferred retry path. Minor (only >200 ops/min), but worth threading the descriptor through `_deferredOps`.

ISSUE_DONE: LIFT-706
  📊 Output tokens: 2021 | Nightly total: 65185/500000 | Run 4/12
✅ Run 4 finished at Thu Jun  4 00:11:16 PDT 2026 — 2 new commit(s)
  ℹ️ Inferred PRIMARY_ISSUE=LIFT-706 from commit message (no ISSUE_DONE marker emitted)
  🟡 Marking LIFT-706 as In Progress (commit detected)
✓ Updated issue LIFT-706
https://github.com/aschung212/Lift/issues/706
  🟡 Marking LIFT-706 as In Progress (commit detected)
✓ Updated issue LIFT-706
https://github.com/aschung212/Lift/issues/706
remote: This repository moved. Please use the new location:        
remote:   https://github.com/aschung212/Lift.git        
remote: 
remote: Create a pull request for 'enhance/LIFT-706-2026-06-03' on GitHub by visiting:        
remote:      https://github.com/aschung212/Lift/pull/new/enhance/LIFT-706-2026-06-03        
remote: 
To https://github.com/aschung212/lift.git
 * [new branch]      enhance/LIFT-706-2026-06-03 -> enhance/LIFT-706-2026-06-03
branch 'enhance/LIFT-706-2026-06-03' set up to track 'origin/enhance/LIFT-706-2026-06-03'.
✅ CI passed (build + tests)

## Commits
- [`e14d439`](https://github.com/aschung212/Lift/commit/e14d439) fix(LIFT-706): address review findings on durable queue replay safety
- [`f3a90d7`](https://github.com/aschung212/Lift/commit/f3a90d7) feat(LIFT-706): persist sync write queue to IndexedDB and harden offline reconciliation

## Test Results
- Before: 1932 passing
- After: 1946 passing (14 delta)

---
_Automated by overnight pipeline — Thu Jun  4 00:12:06 PDT 2026_

## Preview
Test on your phone: https://lift-7ier5qb8i-aschung212-1101s-projects.vercel.app