### PR TITLE
feat(LIFT-712): add share-funnel analytics events

### DIFF
--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -35,7 +35,7 @@
           :class="['spThumb', { spThumbActive: i === activeIndex }]"
           :aria-pressed="i === activeIndex"
           :aria-label="`Select ${card.label} card`"
-          @click="activeIndex = i"
+          @click="selectCard(i)"
         >
           <div class="spThumbCard" :class="{ spThumbCardStory: format === 'story' }">
             <div class="spThumbInner" :class="{ spThumbInnerStory: format === 'story' }">
@@ -79,6 +79,7 @@ import { useWorkoutShare } from '../../composables/useWorkoutShare'
 import { useTheme } from '../../composables/useTheme'
 import { useModal } from '../../composables/useModal'
 import { useSupporter } from '../../composables/useSupporter'
+import { useAnalytics } from '../../composables/useAnalytics'
 
 const props = defineProps<{ summary: SessionSummary }>()
 const emit = defineEmits<{ (e: 'close'): void }>()
@@ -87,6 +88,7 @@ const { open: activateTrap, close: deactivateTrap } = useModal({ selector: '.spO
 const { currentTheme, resolvedMode } = useTheme()
 const { shareCard, downloadCard, isSharing } = useWorkoutShare()
 const { isSupporter } = useSupporter()
+const { logEvent } = useAnalytics()
 
 // Free tier gets the "Made with Lift" watermark; supporters get clean cards.
 const showWatermark = computed(() => !isSupporter.value)
@@ -107,7 +109,15 @@ const activeCard = computed(() => cards.value[activeIndex.value] ?? null)
 const lastResult = ref<string | null>(null)
 
 function setFormat(next: CardFormat) {
+  if (next === format.value) return
   format.value = next
+  logEvent('share_card_selected', { format: next, card: cards.value[0]?.id ?? null })
+}
+
+function selectCard(i: number) {
+  if (i === activeIndex.value) return
+  activeIndex.value = i
+  logEvent('share_card_selected', { format: format.value, card: cards.value[i]?.id ?? null })
 }
 
 // Reset selection when the card list changes (e.g. format toggle).
@@ -155,6 +165,7 @@ async function onSave() {
 // closes even though the parent is still up.
 onMounted(() => {
   activateTrap()
+  logEvent('share_opened', { format: format.value })
 })
 onUnmounted(() => {
   deactivateTrap()

--- a/src/components/share/__tests__/SharePickerSheet.test.ts
+++ b/src/components/share/__tests__/SharePickerSheet.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { ref } from 'vue'
+import SharePickerSheet from '../SharePickerSheet.vue'
+import type { SessionSummary } from '../../../lib/sessionSummary'
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const mockLogEvent = vi.fn()
+vi.mock('../../../composables/useAnalytics', () => ({
+  useAnalytics: () => ({
+    logEvent: mockLogEvent,
+    tabSwitch: vi.fn(),
+    flushEngagement: vi.fn(),
+  }),
+}))
+
+const mockShareCard = vi.fn().mockResolvedValue({ kind: 'shared' })
+const mockDownloadCard = vi.fn().mockResolvedValue({ kind: 'downloaded', filename: 'lift.png' })
+vi.mock('../../../composables/useWorkoutShare', () => ({
+  useWorkoutShare: () => ({
+    shareCard: mockShareCard,
+    downloadCard: mockDownloadCard,
+    isSharing: ref(false),
+    lastError: ref(null),
+  }),
+}))
+
+vi.mock('../../../composables/useTheme', () => ({
+  useTheme: () => ({
+    currentTheme: ref('eternal'),
+    resolvedMode: ref('dark'),
+  }),
+}))
+
+vi.mock('../../../composables/useModal', () => ({
+  useModal: () => ({ open: vi.fn(), close: vi.fn() }),
+}))
+
+vi.mock('../../../composables/useSupporter', () => ({
+  useSupporter: () => ({ isSupporter: ref(false) }),
+}))
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    rawDate: '2026-05-20',
+    date: 'Wed, May 20',
+    duration: '1h 5m',
+    totalVolume: 12000,
+    setsCompleted: 15,
+    exercises: 5,
+    prs: 0,
+    repPRs: 0,
+    bestSet: null,
+    highlights: [],
+    weekVolume: [0, 0, 12000, 0, 0, 0, 0],
+    priorWeekVolume: 10000,
+    streak: 3,
+    unitLabel: 'lbs',
+    ...overrides,
+  }
+}
+
+describe('SharePickerSheet share-funnel analytics (#712)', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    wrapper = mount(SharePickerSheet, { props: { summary: makeSummary() } })
+  })
+
+  it('logs share_opened when the sheet mounts', () => {
+    expect(mockLogEvent).toHaveBeenCalledWith('share_opened', { format: 'square' })
+  })
+
+  it('logs share_card_selected when switching format to story', async () => {
+    const storyBtn = wrapper.findAll('.spFormatBtn').find((b) => b.text() === 'Story')!
+    await storyBtn.trigger('click')
+
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      'share_card_selected',
+      expect.objectContaining({ format: 'story' }),
+    )
+  })
+
+  it('does not re-log share_card_selected when tapping the already-active format', async () => {
+    const postBtn = wrapper.findAll('.spFormatBtn').find((b) => b.text() === 'Post')!
+    await postBtn.trigger('click')
+
+    expect(mockLogEvent).not.toHaveBeenCalledWith('share_card_selected', expect.anything())
+  })
+
+  it('logs share_card_selected when picking a different thumbnail', async () => {
+    const thumbs = wrapper.findAll('.spThumb')
+    expect(thumbs.length).toBeGreaterThan(1)
+    await thumbs[1].trigger('click')
+
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      'share_card_selected',
+      expect.objectContaining({ format: 'square' }),
+    )
+  })
+})

--- a/src/composables/__tests__/useWorkoutShare.test.ts
+++ b/src/composables/__tests__/useWorkoutShare.test.ts
@@ -19,6 +19,16 @@ vi.mock('../../lib/shareImage', async (importOriginal) => {
   }
 })
 
+// Capture analytics so the share-funnel events (#712) can be asserted.
+const mockLogEvent = vi.fn()
+vi.mock('../useAnalytics', () => ({
+  useAnalytics: () => ({
+    logEvent: mockLogEvent,
+    tabSwitch: vi.fn(),
+    flushEngagement: vi.fn(),
+  }),
+}))
+
 // ── Helpers ────────────────────────────────────────────────────────────
 
 const DummyCard = defineComponent({ name: 'DummyCard', template: '<div>card</div>' })
@@ -64,6 +74,7 @@ describe('useWorkoutShare', () => {
 
   beforeEach(() => {
     vi.useFakeTimers()
+    mockLogEvent.mockClear()
     mockRenderNodeToBlob.mockResolvedValue(fakeBlob)
 
     createObjectURLSpy = vi.fn().mockReturnValue('blob:mock-url')
@@ -424,6 +435,76 @@ describe('useWorkoutShare', () => {
 
       const hostNode = mockRenderNodeToBlob.mock.calls[0][0]
       expect(hostNode.querySelector('[data-share-watermark]')).not.toBeNull()
+    })
+  })
+
+  // ── Share-funnel analytics (#712) ──────────────────────────────────
+  describe('share-funnel analytics', () => {
+    it('logs share_completed with outcome "shared" when Web Share succeeds', async () => {
+      const shareFn = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'share', { value: shareFn, writable: true, configurable: true })
+      Object.defineProperty(navigator, 'canShare', { value: vi.fn().mockReturnValue(true), writable: true, configurable: true })
+
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest({ format: 'story' }))
+
+      expect(mockLogEvent).toHaveBeenCalledWith('share_completed', {
+        format: 'story',
+        method: 'share',
+        outcome: 'shared',
+      })
+    })
+
+    it('logs share_completed with outcome "downloaded" when sharing falls back to download', async () => {
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest())
+
+      expect(mockLogEvent).toHaveBeenCalledWith('share_completed', {
+        format: 'square',
+        method: 'share',
+        outcome: 'downloaded',
+      })
+    })
+
+    it('does NOT log a completed/failed event when the user cancels the share sheet', async () => {
+      const abortError = new DOMException('User cancelled', 'AbortError')
+      Object.defineProperty(navigator, 'share', { value: vi.fn().mockRejectedValue(abortError), writable: true, configurable: true })
+      Object.defineProperty(navigator, 'canShare', { value: vi.fn().mockReturnValue(true), writable: true, configurable: true })
+
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest())
+
+      expect(mockLogEvent).not.toHaveBeenCalledWith('share_completed', expect.anything())
+      expect(mockLogEvent).not.toHaveBeenCalledWith('share_failed', expect.anything())
+    })
+
+    it('logs share_failed with method "share" when rendering fails', async () => {
+      mockRenderNodeToBlob.mockRejectedValueOnce(new Error('boom'))
+
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest({ format: 'story' }))
+
+      expect(mockLogEvent).toHaveBeenCalledWith('share_failed', { format: 'story', method: 'share' })
+    })
+
+    it('logs share_completed with method "save" on the download path', async () => {
+      const { downloadCard } = await getComposable()
+      await downloadCard(makeRequest())
+
+      expect(mockLogEvent).toHaveBeenCalledWith('share_completed', {
+        format: 'square',
+        method: 'save',
+        outcome: 'downloaded',
+      })
+    })
+
+    it('logs share_failed with method "save" when download rendering fails', async () => {
+      mockRenderNodeToBlob.mockRejectedValueOnce(new Error('download fail'))
+
+      const { downloadCard } = await getComposable()
+      await downloadCard(makeRequest())
+
+      expect(mockLogEvent).toHaveBeenCalledWith('share_failed', { format: 'square', method: 'save' })
     })
   })
 })

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -21,6 +21,7 @@ import {
   type CardFormat,
 } from '../lib/shareImage'
 import type { SessionSummary } from '../lib/sessionSummary'
+import { useAnalytics } from './useAnalytics'
 
 export interface ShareCardRequest {
   /** The Vue component that renders the card. */
@@ -170,6 +171,7 @@ export interface UseWorkoutShareReturn {
 export function useWorkoutShare(): UseWorkoutShareReturn {
   const isSharing = ref(false)
   const lastError = ref<Error | null>(null)
+  const { logEvent } = useAnalytics()
 
   /**
    * Render → share. Resolves with the outcome; never throws on user-cancel.
@@ -197,6 +199,7 @@ export function useWorkoutShare(): UseWorkoutShareReturn {
       if (canWebShareFiles([file])) {
         try {
           await navigator.share({ files: [file], title: 'Lift workout' })
+          logEvent('share_completed', { format: req.format, method: 'share', outcome: 'shared' })
           return { kind: 'shared' }
         } catch (err) {
           // AbortError = user dismissed sheet. Anything else falls to download.
@@ -205,9 +208,11 @@ export function useWorkoutShare(): UseWorkoutShareReturn {
       }
 
       downloadBlob(blob, filename)
+      logEvent('share_completed', { format: req.format, method: 'share', outcome: 'downloaded' })
       return { kind: 'downloaded', filename }
     } catch (err) {
       lastError.value = err as Error
+      logEvent('share_failed', { format: req.format, method: 'share' })
       return { kind: 'error', error: err as Error }
     } finally {
       isSharing.value = false
@@ -223,9 +228,11 @@ export function useWorkoutShare(): UseWorkoutShareReturn {
       const blob = await renderCardOffscreen(req)
       const filename = defaultShareFilename(req.summary.rawDate, req.format)
       downloadBlob(blob, filename)
+      logEvent('share_completed', { format: req.format, method: 'save', outcome: 'downloaded' })
       return { kind: 'downloaded', filename }
     } catch (err) {
       lastError.value = err as Error
+      logEvent('share_failed', { format: req.format, method: 'save' })
       return { kind: 'error', error: err as Error }
     } finally {
       isSharing.value = false


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-712](https://github.com/aschung212/Lift/issues/712)

LIFT-712 (priority:2-high): the workout share flow — the #1 organic-acquisition loop in fitness-app growth models — fired zero analytics, so no marketing channel was measurable. I added share-funnel events using the existing `useAnalytics` infrastructure, split across the two layers that actually know each fact: outcome events in the share composable, UI-interaction events in the picker sheet.

## Changes
- **`src/composables/useWorkoutShare.ts`** — logs `share_completed` (`{ format, method, outcome }`) when a Web Share succeeds (`outcome: 'shared'`) or falls back to download (`outcome: 'downloaded'`), on both the share (`method: 'share'`) and save (`method: 'save'`) paths; logs `share_failed` (`{ format, method }`) on render/share errors. User-cancel (AbortError) and the reentrance guard intentionally emit nothing — they aren't funnel completions or failures.
- **`src/components/share/SharePickerSheet.vue`** — logs `share_opened` (`{ format }`) on mount and `share_card_selected` (`{ format, card }`) on format-toggle and thumbnail selection, de-duped so tapping the already-active option emits nothing.
- **Tests** — extended `useWorkoutShare.test.ts` (+6) for the completion/failure matrix and cancel-emits-nothing; new `SharePickerSheet.test.ts` (+4) for open/select events and no-op de-dup.

## Verification
- `npx vitest run` — 100 files / 1972 passed, 1 skipped (was 99/1962; +1 file, +10 tests)
- `npm run build` — vue-tsc typecheck clean, built in 3.46s
- `npm run lint` — 0 errors (9 pre-existing warnings, none in touched files)
- Post-commit Gemini 3.1 Pro review: **No issues found**

## Screenshots
N/A — analytics-only change, no visual surface.

## Commits
- [`c0d99a5`](https://github.com/aschung212/Lift/commit/c0d99a5) feat(LIFT-712): add share-funnel analytics events

## Test Results
- Before: 1962 passing
- After: 1972 passing (10 delta)

---
_Automated by overnight pipeline — Thu Jun  4 23:17:09 PDT 2026_

## Preview
Test on your phone: https://lift-i4i45ywuq-aschung212-1101s-projects.vercel.app