### PR TITLE
feat(LIFT-714): add discoverable app handle to all share cards

### DIFF
--- a/src/components/share/__tests__/cardHandle.test.ts
+++ b/src/components/share/__tests__/cardHandle.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { SQUARE_CARDS, STORY_CARDS } from '../cardRegistry'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
+import type { SessionSummary } from '../../../lib/sessionSummary'
+
+/**
+ * Regression guard for the share-card acquisition loop (issue #714).
+ *
+ * Every share card must stamp the app's public handle so a viewer who sees a
+ * card on social has a path to find and install the app — the link is the
+ * conversion mechanism that closes the loop. Before #714 the cards rendered a
+ * "LIFT" wordmark but zero links, so the funnel leaked at the final step.
+ *
+ * Mounting every registered card (rather than asserting on source text) means
+ * a card added later that forgets the handle fails here, and a card whose
+ * `v-if`'d brand block stops rendering is also caught.
+ */
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    rawDate: '2026-04-21',
+    date: 'Tue, Apr 21',
+    duration: '1h 14m',
+    totalVolume: 24850,
+    setsCompleted: 18,
+    exercises: 5,
+    prs: 1,
+    repPRs: 1,
+    bestSet: { exerciseId: 'ex1', name: 'Bench', weight: 225, reps: 5, e1RM: 263, isPR: true },
+    highlights: [
+      { exerciseId: 'ex1', name: 'Bench', weight: 225, reps: 5, e1RM: 263, badge: 'PR', volume: 1125 },
+    ],
+    weekVolume: [0, 24850, 0, 0, 0, 0, 0],
+    priorWeekVolume: 18200,
+    streak: 4,
+    unitLabel: 'lbs',
+    ...overrides,
+  }
+}
+
+const ALL_CARDS = [...SQUARE_CARDS, ...STORY_CARDS]
+
+describe('share-card handle (issue #714)', () => {
+  it('pins the handle to the real deployment domain, never a fabricated one', () => {
+    // Mirrors the metaRegression contract: the only valid domain is the real
+    // Vercel deployment. A hallucinated competitor domain shipping on a share
+    // card would be the SEV1 failure mode from 2026-04-02.
+    expect(SHARE_CARD_HANDLE).toBe('spa-rho-sandy.vercel.app')
+    expect(SHARE_CARD_HANDLE).not.toContain('liftracker')
+    expect(SHARE_CARD_HANDLE).not.toMatch(/^https?:\/\//)
+  })
+
+  it.each(ALL_CARDS.map((c) => [c.id, c.component] as const))(
+    'renders the app handle on the %s card',
+    (_id, component) => {
+      const wrapper = mount(component, { props: { summary: makeSummary() } })
+      expect(wrapper.text()).toContain(SHARE_CARD_HANDLE)
+    },
+  )
+
+  it('still renders the handle when there is no best set (defensive empty-day render)', () => {
+    // PR Focus / Best Set bodies are v-if'd on bestSet; the handle lives
+    // outside those guards so it must survive a null bestSet.
+    for (const { id, component } of ALL_CARDS) {
+      if (id === 'pr-focus') continue // hidden entirely when prs === 0 / no bestSet
+      const wrapper = mount(component, {
+        props: { summary: makeSummary({ bestSet: null, prs: 0, repPRs: 0, highlights: [] }) },
+      })
+      expect(wrapper.text()).toContain(SHARE_CARD_HANDLE)
+    }
+  })
+})

--- a/src/components/share/cards/BestSetCard.vue
+++ b/src/components/share/cards/BestSetCard.vue
@@ -21,7 +21,10 @@
 
     <div class="bsFoot">
       <div class="bsE1RM" v-if="summary.bestSet">~{{ summary.bestSet.e1RM }} {{ summary.unitLabel }} e1RM</div>
-      <div class="bsBrand">LIFT</div>
+      <div class="bsBrand">
+        <span class="bsMark">LIFT</span>
+        <span class="bsHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
     </div>
   </div>
 </template>
@@ -29,6 +32,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -158,11 +162,27 @@ const prLabel = computed(() => (props.summary.bestSet?.isPR ? 'New personal reco
 }
 
 .bsBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.bsMark {
   font-family: var(--ff-mono);
   font-weight: 700;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.22em;
   color: var(--accent);
+}
+
+.bsHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 </style>

--- a/src/components/share/cards/BestSetStory.vue
+++ b/src/components/share/cards/BestSetStory.vue
@@ -12,12 +12,16 @@
       <div class="bsE1RM">~{{ summary.bestSet.e1RM }} {{ summary.unitLabel }} e1RM</div>
     </div>
 
-    <div class="bsBrand">LIFT</div>
+    <div class="bsBrand">
+      <span class="bsMark">LIFT</span>
+      <span class="bsHandle">{{ SHARE_CARD_HANDLE }}</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 defineProps<{ summary: SessionSummary }>()
 </script>
@@ -113,11 +117,27 @@ defineProps<{ summary: SessionSummary }>()
 }
 
 .bsBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.bsMark {
   font-family: var(--ff-mono);
   font-weight: 700;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.26em;
   color: var(--accent);
+}
+
+.bsHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 </style>

--- a/src/components/share/cards/BoldFloodCard.vue
+++ b/src/components/share/cards/BoldFloodCard.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="bfRoot">
     <div class="bfHead">
-      <div class="bfBrand">Lift</div>
+      <div class="bfBrand">
+        <span class="bfMark">Lift</span>
+        <span class="bfHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
       <div class="bfDate">{{ summary.date }}</div>
     </div>
 
@@ -30,6 +33,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -56,12 +60,27 @@ const formattedVolume = computed(() => props.summary.totalVolume.toLocaleString(
 }
 
 .bfBrand {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.bfMark {
   font-family: var(--ff-mono);
   font-weight: 700;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.22em;
   text-transform: uppercase;
+}
+
+.bfHandle {
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  opacity: 0.65;
 }
 
 .bfDate {

--- a/src/components/share/cards/BoldFloodStory.vue
+++ b/src/components/share/cards/BoldFloodStory.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="bsRoot">
     <div class="bsHead">
-      <div class="bsBrand">Lift</div>
+      <div class="bsBrand">
+        <span class="bsMark">Lift</span>
+        <span class="bsHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
       <div class="bsDate">{{ summary.date }}</div>
     </div>
 
@@ -25,6 +28,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -57,12 +61,27 @@ const stats = computed(() => [
 }
 
 .bsBrand {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.bsMark {
   font-family: var(--ff-mono);
   font-weight: 700;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.24em;
   text-transform: uppercase;
+}
+
+.bsHandle {
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
 }
 
 .bsDate {

--- a/src/components/share/cards/DailyRingCard.vue
+++ b/src/components/share/cards/DailyRingCard.vue
@@ -35,13 +35,17 @@
       </div>
     </div>
 
-    <div class="drBrand">LIFT</div>
+    <div class="drBrand">
+      <span class="drMark">LIFT</span>
+      <span class="drHandle">{{ SHARE_CARD_HANDLE }}</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -163,11 +167,27 @@ const formattedGoal = computed(() => GOAL.value.toLocaleString('en-US'))
 }
 
 .drBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.drMark {
   font-family: var(--ff-mono);
   font-weight: 700;
   font-size: 10px;
   line-height: 1;
   letter-spacing: 0.22em;
   color: var(--accent);
+}
+
+.drHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 </style>

--- a/src/components/share/cards/PrFocusCard.vue
+++ b/src/components/share/cards/PrFocusCard.vue
@@ -15,12 +15,16 @@
       </div>
     </div>
 
-    <div class="prBrand">LIFT</div>
+    <div class="prBrand">
+      <span class="prMark">LIFT</span>
+      <span class="prHandle">{{ SHARE_CARD_HANDLE }}</span>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 defineProps<{ summary: SessionSummary }>()
 </script>
@@ -136,11 +140,27 @@ defineProps<{ summary: SessionSummary }>()
 }
 
 .prBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.prMark {
   font-family: var(--ff-mono);
   font-weight: 700;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.26em;
+  color: var(--text-muted);
+}
+
+.prHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
   color: var(--text-muted);
 }
 </style>

--- a/src/components/share/cards/ReceiptCard.vue
+++ b/src/components/share/cards/ReceiptCard.vue
@@ -28,12 +28,14 @@
     </div>
 
     <div class="rcThanks">— THANK YOU —</div>
+    <div class="rcHandle">{{ SHARE_CARD_HANDLE }}</div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -134,5 +136,13 @@ const formattedVolume = computed(() => props.summary.totalVolume.toLocaleString(
   font-size: 10px;
   letter-spacing: 0.3em;
   opacity: 0.6;
+}
+
+.rcHandle {
+  text-align: center;
+  margin-top: 8px;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  opacity: 0.55;
 }
 </style>

--- a/src/components/share/cards/StatGridCard.vue
+++ b/src/components/share/cards/StatGridCard.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="sgRoot">
     <div class="sgHead">
-      <div class="sgEyebrow">Lift · {{ weekdayLabel }}</div>
+      <div class="sgBrand">
+        <span class="sgEyebrow">Lift · {{ weekdayLabel }}</span>
+        <span class="sgHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
       <div class="sgDate">{{ summary.date }}</div>
     </div>
     <div
@@ -20,6 +23,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -89,6 +93,12 @@ const cells = computed<Cell[]>(() => {
   border-bottom: 1px solid var(--border-strong);
 }
 
+.sgBrand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
 .sgEyebrow {
   font-family: var(--ff-mono);
   font-weight: 700;
@@ -97,6 +107,15 @@ const cells = computed<Cell[]>(() => {
   letter-spacing: 0.22em;
   text-transform: uppercase;
   color: var(--accent);
+}
+
+.sgHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 
 .sgDate {

--- a/src/components/share/cards/TicketStubCard.vue
+++ b/src/components/share/cards/TicketStubCard.vue
@@ -4,6 +4,7 @@
       <div class="tsLeft">
         <div>
           <div class="tsEyebrow">Lift · Session</div>
+          <div class="tsHandle">{{ SHARE_CARD_HANDLE }}</div>
           <div class="tsTitle">Workout</div>
           <div class="tsMeta">{{ summary.date.toUpperCase() }} · {{ summary.duration }}</div>
         </div>
@@ -33,6 +34,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -79,6 +81,16 @@ const formattedVolume = computed(() => Math.round(props.summary.totalVolume).toL
   letter-spacing: 0.24em;
   text-transform: uppercase;
   color: var(--accent);
+}
+
+.tsHandle {
+  margin-top: 6px;
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
 }
 
 .tsTitle {

--- a/src/components/share/cards/WeekChartCard.vue
+++ b/src/components/share/cards/WeekChartCard.vue
@@ -2,7 +2,10 @@
   <div class="wcRoot">
     <div class="wcHead">
       <div class="wcEyebrow">Week {{ weekdayLabel }}</div>
-      <div class="wcBrand">LIFT</div>
+      <div class="wcBrand">
+        <span class="wcMark">LIFT</span>
+        <span class="wcHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
     </div>
 
     <div class="wcDelta">{{ deltaLabel }}</div>
@@ -43,6 +46,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -105,11 +109,27 @@ function barPercent(v: number): number {
 }
 
 .wcBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.wcMark {
   font-family: var(--ff-mono);
   font-weight: 500;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.wcHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
   color: var(--text-muted);
 }
 

--- a/src/components/share/cards/WeekChartStory.vue
+++ b/src/components/share/cards/WeekChartStory.vue
@@ -2,7 +2,10 @@
   <div class="wsRoot">
     <div class="wsHead">
       <div class="wsEyebrow">Week {{ weekdayLabel }}</div>
-      <div class="wsBrand">LIFT</div>
+      <div class="wsBrand">
+        <span class="wsMark">LIFT</span>
+        <span class="wsHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
     </div>
 
     <div class="wsHero">
@@ -41,6 +44,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 
 const props = defineProps<{ summary: SessionSummary }>()
 
@@ -100,11 +104,27 @@ function barPercent(v: number): number {
 }
 
 .wsBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.wsMark {
   font-family: var(--ff-mono);
   font-weight: 500;
   font-size: 11px;
   line-height: 1;
   letter-spacing: 0.14em;
+  color: var(--text-muted);
+}
+
+.wsHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
   color: var(--text-muted);
 }
 

--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -71,6 +71,18 @@ export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): 
 export const WATERMARK_TEXT = 'Made with Lift'
 
 /**
+ * The app's public URL, stamped onto every share card so a viewer who sees a
+ * card on social has a path to find and install the app (issue #714). This
+ * closes the organic-acquisition loop: the supporter-gated watermark (#601)
+ * establishes attribution, this handle is the actual conversion mechanism, so
+ * unlike the watermark it appears on every card regardless of entitlement.
+ *
+ * Single source of truth — the real deployment domain per CLAUDE.md. Never
+ * fabricate or guess this value; the metaRegression suite pins it.
+ */
+export const SHARE_CARD_HANDLE = 'spa-rho-sandy.vercel.app'
+
+/**
  * Build the watermark element used by the offscreen export pipeline.
  *
  * Styles are inlined (not class-based) so they survive `html-to-image`'s


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-714](https://github.com/aschung212/Lift/issues/714)

LIFT-714: the workout share cards rendered a "LIFT" wordmark but **zero links**, so when a card landed on Instagram/Twitter a viewer had no path to find the app — the organic-acquisition loop leaked at its highest-intent final step. I added the real deployment domain as a subtle, discoverable handle on all 11 card designs, sourced from a single constant so the URL is never fabricated (SEV1 rule).

## Changes
- `src/lib/shareImage.ts` — added `SHARE_CARD_HANDLE = 'spa-rho-sandy.vercel.app'` as the single source of truth, documented as the conversion mechanism complementing the supporter-gated `WATERMARK_TEXT` (#601).
- All 11 cards now render the handle as a subtle brand lockup, styled to each card's existing treatment (theme `--text-muted` for theme cards, `opacity` for the inverted Bold/Flood and cream Receipt cards):
  - Bottom-centered wordmarks: `PrFocusCard`, `DailyRingCard`, `BestSetStory`
  - Footer/header wordmark lockups: `BestSetCard`, `WeekChartCard`, `WeekChartStory`, `BoldFloodCard`, `BoldFloodStory`, `StatGridCard`, `TicketStubCard`
  - `ReceiptCard` — added a footer handle line under "— THANK YOU —"
- `src/components/share/__tests__/cardHandle.test.ts` (new) — mounts every registered card and asserts the handle renders (including a null-`bestSet` empty-day render), and pins the handle to the real domain (rejects `liftracker`, rejects `http(s)://` prefixes) so a hallucinated competitor URL can never ship on a card.

## Verification
- `npm test` → 1975 passed | 1 skipped (added 12 new assertions across 11 cards + domain pin)
- `npm run lint` → 0 errors (pre-existing warnings only, all in unrelated files)
- `npm run typecheck` → clean
- `npm run build` → succeeds
- No new modal/nav paradigms; handles use the type scale, theme tokens, and existing 4/6px spacing; no layout shift (handle is appended at the natural end of each brand element).

## Screenshots
Not captured — change is purely additive text in offscreen-rasterized share cards (no interactive app surface). Visual verification is best done against the SharePickerSheet previews; flagged as a candidate for the LIFT-664 visual-regression suite below.

ISSUE_DISCOVER: The share cards have no visual-regression coverage (LIFT-664 is unstarted). This PR touches all 11 card layouts with no automated visual guard — content is tested but a layout break (e.g. handle overflow on a narrow theme font, or header-row collision) would only be caught manually. The card surface is now marketing-critical (it's the acquisition loop), making it a strong candidate to be the first target when LIFT-664 lands.

ISSUE_DISCOVER: `StatGridCard.vue` and `TicketStubCard.vue` place the handle in the header eyebrow rather than a true footer because their layouts (a full-bleed 2×2 grid and a centered ticket) have no footer region. This is a minor inconsistency with the issue's "card footers" framing; acceptable, but worth noting if a future redesign wants uniform footer placement across all cards.

ISSUE_DONE:LIFT-714:Added the real deployment domain as a discoverable handle to all 11 share cards via a single SHARE_CARD_HANDLE constant, closing the acquisition loop's final conversion step; added a regression test that mounts every card to assert the handle renders and pins it to the real domain. Tests/lint/typecheck/build all green.
  📊 Output tokens: 34383 | Nightly total: 72746/500000 | Run 4/12
✅ Run 4 finished at Thu Jun  4 23:41:38 PDT 2026 — 1 new commit(s)
remote: This repository moved. Please use the new location:        
remote:   https://github.com/aschung212/Lift.git        
remote: 
remote: Create a pull request for 'enhance/LIFT-714-2026-06-04' on GitHub by visiting:        
remote:      https://github.com/aschung212/Lift/pull/new/enhance/LIFT-714-2026-06-04        
remote: 
To https://github.com/aschung212/lift.git
 * [new branch]      enhance/LIFT-714-2026-06-04 -> enhance/LIFT-714-2026-06-04
branch 'enhance/LIFT-714-2026-06-04' set up to track 'origin/enhance/LIFT-714-2026-06-04'.
✅ CI passed (build + tests)

## Commits
- [`34c38c2`](https://github.com/aschung212/Lift/commit/34c38c2) feat(LIFT-714): add discoverable app handle to all share cards

## Test Results
- Before: 1962 passing
- After: 1975 passing (13 delta)

---
_Automated by overnight pipeline — Thu Jun  4 23:42:20 PDT 2026_

## Preview
Test on your phone: https://lift-j1ph6fgux-aschung212-1101s-projects.vercel.app