### PR TITLE
feat(LIFT-715): capture acquisition source via ref/utm query params

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -224,6 +224,7 @@ import { isMigrated, markMigrated, computeRetroactiveXP } from './lib/xpMigratio
 import { requestPersistentStorage, ensureLocalStorage } from './lib/durableStorage'
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
+import { captureAcquisitionSource } from './composables/useAcquisitionSource'
 import { usePreferencesStore } from './stores/preferences'
 import { useWorkoutStore } from './stores/workout'
 import { syncStatus } from './lib/syncQueue'
@@ -342,6 +343,13 @@ function handleSignOut() {
   onboardingComplete.value = false
   signOut()
 }
+
+// ── Acquisition attribution ─────────────────────────────────────
+// Capture the inbound ?ref= / ?utm_*= source once, before the ?tab= cleanup
+// below strips the query string. Logs a single acquisition_source event and
+// remembers it so launch channels (Product Hunt, Reddit, link-in-bio) are
+// measurable without a backend.
+captureAcquisitionSource()
 
 // ── Tab initialization (supports PWA manifest shortcuts via ?tab= param) ──
 const VALID_TABS = ['workouts', 'calendar', 'weight'] as const

--- a/src/composables/__tests__/useAcquisitionSource.test.ts
+++ b/src/composables/__tests__/useAcquisitionSource.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock @vercel/analytics so we can assert on the emitted event without a network.
+vi.mock('@vercel/analytics', () => ({
+  track: vi.fn(),
+}))
+
+import { track } from '@vercel/analytics'
+const mockTrack = vi.mocked(track)
+
+import { captureAcquisitionSource } from '../useAcquisitionSource'
+
+const STORAGE_KEY = 'acquisition-source-v1'
+
+function setLocation(search: string): void {
+  window.history.replaceState({}, '', '/' + search)
+}
+
+describe('captureAcquisitionSource', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockTrack.mockClear()
+    setLocation('')
+  })
+
+  afterEach(() => {
+    setLocation('')
+  })
+
+  it('logs acquisition_source with utm params on first load', () => {
+    captureAcquisitionSource('?utm_source=producthunt&utm_medium=referral')
+    expect(mockTrack).toHaveBeenCalledWith('acquisition_source', {
+      utm_source: 'producthunt',
+      utm_medium: 'referral',
+    })
+  })
+
+  it('captures the short ?ref= alias', () => {
+    captureAcquisitionSource('?ref=reddit')
+    expect(mockTrack).toHaveBeenCalledWith('acquisition_source', { ref: 'reddit' })
+  })
+
+  it('persists the captured source under the versioned key', () => {
+    captureAcquisitionSource('?ref=tiktok')
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ ref: 'tiktok' })
+  })
+
+  it('does not re-log on subsequent loads once captured', () => {
+    captureAcquisitionSource('?ref=tiktok')
+    mockTrack.mockClear()
+    captureAcquisitionSource('?ref=reddit')
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('records a paramless first visit as direct without logging an event', () => {
+    captureAcquisitionSource('')
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ ref: 'direct' })
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('a recorded direct visit blocks a later inbound link from logging', () => {
+    captureAcquisitionSource('')
+    mockTrack.mockClear()
+    captureAcquisitionSource('?utm_source=producthunt')
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('ignores unrelated query params like ?tab=', () => {
+    captureAcquisitionSource('?tab=calendar')
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ ref: 'direct' })
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('captures the full utm set', () => {
+    captureAcquisitionSource('?utm_source=ph&utm_medium=post&utm_campaign=launch&utm_term=t&utm_content=c')
+    expect(mockTrack).toHaveBeenCalledWith('acquisition_source', {
+      utm_source: 'ph',
+      utm_medium: 'post',
+      utm_campaign: 'launch',
+      utm_term: 't',
+      utm_content: 'c',
+    })
+  })
+
+  it('trims and caps oversized values to 64 chars', () => {
+    const long = 'x'.repeat(200)
+    captureAcquisitionSource(`?ref=${long}`)
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+    expect(stored.ref).toHaveLength(64)
+  })
+
+  it('strips acquisition params from the URL but keeps other params', () => {
+    setLocation('?utm_source=producthunt&tab=calendar')
+    captureAcquisitionSource(window.location.search)
+    expect(window.location.search).toBe('?tab=calendar')
+  })
+
+  it('clears the query string entirely when only acquisition params are present', () => {
+    setLocation('?ref=reddit')
+    captureAcquisitionSource(window.location.search)
+    expect(window.location.search).toBe('')
+  })
+
+  it('treats an empty param value as no source', () => {
+    captureAcquisitionSource('?ref=')
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual({ ref: 'direct' })
+    expect(mockTrack).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when analytics tracking fails', () => {
+    mockTrack.mockImplementationOnce(() => { throw new Error('offline') })
+    expect(() => captureAcquisitionSource('?ref=reddit')).not.toThrow()
+  })
+})

--- a/src/composables/useAcquisitionSource.ts
+++ b/src/composables/useAcquisitionSource.ts
@@ -1,0 +1,91 @@
+import { useAnalytics } from './useAnalytics'
+
+// One-time persisted flag. Presence of this key means the inbound source has
+// already been captured for this install, so we never re-log on reload.
+const STORAGE_KEY = 'acquisition-source-v1'
+
+// Cap each captured value so a malformed or oversized inbound param can't bloat
+// the analytics payload. Marketing source tokens are short by convention.
+const MAX_LEN = 64
+
+// The short ?ref= alias (used by Product Hunt, link-in-bio tools) plus the
+// standard UTM set. Only these keys are read — arbitrary query params are
+// ignored so we never capture unrelated state (e.g. ?tab=).
+const PARAM_KEYS = [
+  'ref',
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+] as const
+
+export type AcquisitionSource = Partial<Record<(typeof PARAM_KEYS)[number], string>>
+
+function sanitize(value: string): string {
+  // Bound the token and strip surrounding whitespace. Values are sent as-is to
+  // analytics, so keeping them short and trimmed avoids noisy dimensions.
+  return value.trim().slice(0, MAX_LEN)
+}
+
+/**
+ * One-time capture of the inbound acquisition source (`?ref=` / `?utm_*=`).
+ *
+ * On the first load that carries attribution params, this logs a single
+ * `acquisition_source` analytics event, persists a flag so it never re-logs,
+ * and strips the params from the URL so they don't persist on reload, get
+ * bookmarked, or leak into shared links. Paramless first visits are recorded
+ * as `direct` (persisted but not logged) so organic opens aren't re-evaluated.
+ *
+ * Local-first: nothing is sent to a backend beyond the existing analytics pipe.
+ *
+ * @param search query string to parse (defaults to the live `location.search`)
+ */
+export function captureAcquisitionSource(search: string = window.location.search): void {
+  let alreadyCaptured = false
+  try {
+    alreadyCaptured = localStorage.getItem(STORAGE_KEY) !== null
+  } catch { /* storage blocked — fall through and attempt a best-effort capture */ }
+  if (alreadyCaptured) return
+
+  const params = new URLSearchParams(search)
+  const captured: AcquisitionSource = {}
+  for (const key of PARAM_KEYS) {
+    const raw = params.get(key)
+    if (raw) {
+      const clean = sanitize(raw)
+      if (clean) captured[key] = clean
+    }
+  }
+
+  const hasSource = Object.keys(captured).length > 0
+
+  // Mark captured even on a paramless first visit so a direct/organic open is
+  // recorded once and never re-evaluated against a later inbound link.
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(hasSource ? captured : { ref: 'direct' }))
+  } catch { /* storage blocked — the worst case is a duplicate log on next load */ }
+
+  if (!hasSource) return
+
+  // Only attributable (non-direct) first visits emit an event — 'direct' is the
+  // absence of a campaign and would just add noise to the analytics dimension.
+  useAnalytics().logEvent('acquisition_source', captured)
+
+  // Strip the acquisition params from the URL, preserving any other params
+  // (e.g. ?tab=) so they don't persist on reload or leak into shared links.
+  if (typeof window !== 'undefined' && window.history?.replaceState) {
+    const url = new URL(window.location.href)
+    let mutated = false
+    for (const key of PARAM_KEYS) {
+      if (url.searchParams.has(key)) {
+        url.searchParams.delete(key)
+        mutated = true
+      }
+    }
+    if (mutated) {
+      const next = url.searchParams.toString()
+      window.history.replaceState({}, '', url.pathname + (next ? `?${next}` : '') + url.hash)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-715](https://github.com/aschung212/Lift/issues/715)



## Changes




## Commits
- [`5cd5ee4`](https://github.com/aschung212/Lift/commit/5cd5ee4) feat(LIFT-715): capture acquisition source via ref/utm query params

## Test Results
- Before: 1962 passing
- After: 1975 passing (13 delta)

---
_Automated by overnight pipeline — Fri Jun  5 00:07:49 PDT 2026_

## Preview
Test on your phone: https://lift-jsymmfzav-aschung212-1101s-projects.vercel.app