### PR TITLE
feat(LIFT-730): surface a week-over-week volume trend chart in the calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Lift lets you track any strength exercise over time. Log a set (weight + reps + 
 - Set count badge on each exercise tag
 - Log sets directly from the calendar
 - Tag filtering shared with workouts tab
+- Weekly view surfaces a muscle-group volume snapshot and a week-over-week training-volume trend line (hand-rolled SVG)
 
 ### Body Weight Tracking
 - Log daily weigh-ins with date
@@ -181,7 +182,7 @@ All interactive elements meet Apple's 44pt minimum touch target. Font sizes are 
 | **Stores** | Exercise/set CRUD, Epley 1RM, PR detection, bodyweight stats, preference toggles, progression XP and theme unlocks, sync fuzzing |
 | **Composables** | Theme switching, color modes, auth flows (OAuth, email, sign-up with duplicate detection), keyboard shortcuts, undo toast, swipe-to-dismiss, focus trap, haptics, PR burst, tag recovery/volume |
 | **Library** | Sync queue debouncing/coalescing, conflict resolver (last-write-wins, merge strategies), CSS/meta/manifest/SEO/theme-contrast/vercel-headers regression suites, CSV import, data export, plate calculator, XP migration |
-| **Components** | WorkoutTracker, BodyweightTracker, AuthScreen, ExerciseGraph, OnboardingScreen, CalendarView, ErrorBoundary, StarterPickerFlow, SkeletonLoader, MuscleGroupChart/Recovery, PR target, accessibility attributes |
+| **Components** | WorkoutTracker, BodyweightTracker, AuthScreen, ExerciseGraph, OnboardingScreen, CalendarView, ErrorBoundary, StarterPickerFlow, SkeletonLoader, MuscleGroupChart/Recovery, VolumeTrendChart, PR target, accessibility attributes |
 
 ```bash
 npm test           # run all tests

--- a/src/components/VolumeTrendChart.vue
+++ b/src/components/VolumeTrendChart.vue
@@ -1,0 +1,161 @@
+<template>
+  <div v-if="points.length >= 2" class="vtChart">
+    <button class="vtHeader" :aria-expanded="!collapsed" @click="$emit('toggleCollapsed')">
+      <p class="vtTitle">Volume Trend</p>
+      <div class="vtHeaderRight">
+        <span v-if="collapsed" class="vtCollapsedSummary">{{ formatVolume(totalVolume) }} {{ weightUnit }} total</span>
+        <svg class="vtChevron" :class="{ vtChevronOpen: !collapsed }" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+    </button>
+
+    <div v-if="!collapsed" class="wtGraphWrap vtGraphWrap">
+      <p class="wtGraphTitle">Weekly Training Volume</p>
+      <svg
+        :viewBox="`0 0 ${W} ${H}`"
+        class="wtGraphSvg"
+        role="img"
+        :aria-label="`Weekly training volume chart with ${points.length} weeks, from ${formatVolume(minVal)} to ${formatVolume(maxVal)} ${weightUnit}`"
+      >
+        <desc>{{ `Weekly training volume from ${formatDate(points[0]?.date)} to ${formatDate(points[points.length - 1]?.date)}, ranging from ${formatVolume(minVal)} to ${formatVolume(maxVal)} ${weightUnit} across ${points.length} weeks.` }}</desc>
+        <!-- Horizontal grid lines -->
+        <line
+          v-for="gy in gridYs"
+          :key="gy"
+          :x1="PAD_L"
+          :y1="gy"
+          :x2="W - PAD_R"
+          :y2="gy"
+          class="wtGGrid"
+        />
+
+        <!-- Area fill under line -->
+        <polygon :points="areaPoints" class="wtGArea" />
+
+        <!-- Line -->
+        <polyline :points="linePoints" class="wtGLine" />
+
+        <!-- Endpoint dots -->
+        <circle :cx="points[0].x" :cy="points[0].y" r="3" class="wtGDot" />
+        <circle :cx="points[points.length - 1].x" :cy="points[points.length - 1].y" r="3" class="wtGDot" />
+
+        <!-- Y-axis labels: max at top, min at bottom -->
+        <text :x="PAD_L - 5" :y="PAD_T + 4" class="wtGYLabel" text-anchor="end">{{ formatVolume(maxVal) }}</text>
+        <text :x="PAD_L - 5" :y="PAD_T + chartH + 4" class="wtGYLabel" text-anchor="end">{{ formatVolume(minVal) }}</text>
+
+        <!-- X-axis date labels -->
+        <text
+          v-for="(p, i) in points"
+          v-show="shouldShowLabel(i)"
+          :key="'lbl-' + p.date"
+          :x="p.x"
+          :y="H - 3"
+          class="wtGDateLabel"
+          text-anchor="middle"
+        >{{ formatDate(p.date) }}</text>
+      </svg>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRef } from 'vue'
+import { useWeightUnit } from '../composables/useWeightUnit'
+import { useSVGTimeSeries, type TimeSeriesEntry } from '../composables/useSVGTimeSeries'
+
+const props = defineProps<{
+  weeklyVolume: TimeSeriesEntry[]
+  totalVolume: number
+  collapsed?: boolean
+}>()
+
+defineEmits<{
+  toggleCollapsed: []
+}>()
+
+const { weightUnit, displayWeight } = useWeightUnit()
+
+const graphData = toRef(props, 'weeklyVolume')
+
+const {
+  W, H, PAD_L, PAD_R, PAD_T, chartH,
+  minVal, maxVal, points,
+  linePoints, areaPoints, gridYs,
+  shouldShowLabel, formatDate,
+} = useSVGTimeSeries(graphData)
+
+/** Format a stored-lbs volume value into display units with k-abbreviation. */
+function formatVolume(lbs: number): string {
+  const v = displayWeight(lbs)
+  if (v >= 1000) return `${(v / 1000).toFixed(1)}k`
+  return String(v)
+}
+</script>
+
+<style scoped>
+.vtChart {
+  margin-top: 12px;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.vtHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  color: inherit;
+  font: inherit;
+  min-height: 44px;
+}
+
+.vtHeader:active {
+  opacity: 0.6;
+}
+
+.vtTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  text-align: left;
+}
+
+.vtHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.vtCollapsedSummary {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.vtChevron {
+  color: var(--text-muted);
+  transition: transform 0.2s;
+}
+
+.vtChevronOpen {
+  transform: rotate(180deg);
+}
+
+/* Override the global wtGraphWrap margin so the chart sits flush inside the card. */
+.vtGraphWrap {
+  margin: 8px 0 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vtChevron {
+    transition: none;
+  }
+}
+</style>

--- a/src/components/VolumeTrendChart.vue
+++ b/src/components/VolumeTrendChart.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { toRef } from 'vue'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { useSVGTimeSeries, type TimeSeriesEntry } from '../composables/useSVGTimeSeries'
 

--- a/src/components/__tests__/VolumeTrendChart.test.ts
+++ b/src/components/__tests__/VolumeTrendChart.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import VolumeTrendChart from '../VolumeTrendChart.vue'
+import type { TimeSeriesEntry } from '../../composables/useSVGTimeSeries'
+
+vi.mock('../../composables/useWeightUnit', () => ({
+  useWeightUnit: () => ({
+    weightUnit: { value: 'lbs' },
+    displayWeight: (w: number) => Math.round(w),
+    toLbs: (w: number) => w,
+  }),
+}))
+
+const weeks: TimeSeriesEntry[] = [
+  { date: '2026-03-23', value: 12000 },
+  { date: '2026-03-30', value: 0 },
+  { date: '2026-04-06', value: 18500 },
+]
+
+describe('VolumeTrendChart', () => {
+  it('renders nothing with fewer than 2 weeks', () => {
+    const wrapper = mount(VolumeTrendChart, {
+      props: { weeklyVolume: [{ date: '2026-03-23', value: 100 }], totalVolume: 100 },
+    })
+    expect(wrapper.find('.vtChart').exists()).toBe(false)
+  })
+
+  it('renders the SVG chart when expanded', () => {
+    const wrapper = mount(VolumeTrendChart, {
+      props: { weeklyVolume: weeks, totalVolume: 30500, collapsed: false },
+    })
+    expect(wrapper.find('.wtGraphSvg').exists()).toBe(true)
+    expect(wrapper.find('.wtGLine').exists()).toBe(true)
+    expect(wrapper.find('.wtGArea').exists()).toBe(true)
+  })
+
+  it('hides the chart body but keeps the header when collapsed', () => {
+    const wrapper = mount(VolumeTrendChart, {
+      props: { weeklyVolume: weeks, totalVolume: 30500, collapsed: true },
+    })
+    expect(wrapper.find('.vtHeader').exists()).toBe(true)
+    expect(wrapper.find('.wtGraphSvg').exists()).toBe(false)
+    // Collapsed summary shows abbreviated total volume.
+    expect(wrapper.find('.vtCollapsedSummary').text()).toContain('30.5k')
+  })
+
+  it('abbreviates large y-axis values with k', () => {
+    const wrapper = mount(VolumeTrendChart, {
+      props: { weeklyVolume: weeks, totalVolume: 30500, collapsed: false },
+    })
+    const labels = wrapper.findAll('.wtGYLabel').map(n => n.text())
+    expect(labels.some(t => t.includes('18.5k'))).toBe(true)
+  })
+
+  it('emits toggleCollapsed when the header is clicked', async () => {
+    const wrapper = mount(VolumeTrendChart, {
+      props: { weeklyVolume: weeks, totalVolume: 30500, collapsed: false },
+    })
+    await wrapper.find('.vtHeader').trigger('click')
+    expect(wrapper.emitted('toggleCollapsed')).toHaveLength(1)
+  })
+})

--- a/src/composables/__tests__/useVolumeTrend.test.ts
+++ b/src/composables/__tests__/useVolumeTrend.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useVolumeTrend } from '../useVolumeTrend'
+import type { Exercise } from '../../stores/workout'
+
+function makeExercise(
+  name: string,
+  sets: { date: string; weight: number; reps: number }[],
+): Exercise {
+  return {
+    id: name.toLowerCase().replace(/\s/g, '-'),
+    name,
+    tags: [],
+    sets: sets.map((s, i) => ({
+      id: `${name}-set-${i}`,
+      date: s.date,
+      weight: s.weight,
+      reps: s.reps,
+      estimated1RM: s.weight * (1 + s.reps / 30),
+    })),
+  }
+}
+
+describe('useVolumeTrend', () => {
+  it('returns empty when there are no sets', () => {
+    const exercises = ref<Exercise[]>([makeExercise('Bench', [])])
+    const { weeklyVolume, totalVolume, weekCount } = useVolumeTrend(exercises)
+    expect(weeklyVolume.value).toEqual([])
+    expect(totalVolume.value).toBe(0)
+    expect(weekCount.value).toBe(0)
+  })
+
+  it('sums weight × reps per ISO week, bucketed to Monday', () => {
+    // 2026-03-23 is a Monday; 2026-03-25 is a Wednesday (same week).
+    const exercises = ref([
+      makeExercise('Squat', [
+        { date: '2026-03-23T10:00:00', weight: 100, reps: 5 }, // 500
+        { date: '2026-03-25T10:00:00', weight: 100, reps: 5 }, // 500
+      ]),
+    ])
+    const { weeklyVolume, totalVolume } = useVolumeTrend(exercises)
+    expect(weeklyVolume.value).toEqual([{ date: '2026-03-23', value: 1000 }])
+    expect(totalVolume.value).toBe(1000)
+  })
+
+  it('buckets a Sunday into the prior Monday week', () => {
+    // 2026-03-29 is a Sunday — belongs to the week starting Monday 2026-03-23.
+    const exercises = ref([
+      makeExercise('Row', [
+        { date: '2026-03-29T10:00:00', weight: 50, reps: 10 }, // 500
+      ]),
+    ])
+    const { weeklyVolume } = useVolumeTrend(exercises)
+    expect(weeklyVolume.value).toEqual([{ date: '2026-03-23', value: 500 }])
+  })
+
+  it('fills empty weeks between first and last with 0 volume', () => {
+    const exercises = ref([
+      makeExercise('Deadlift', [
+        { date: '2026-03-23T10:00:00', weight: 100, reps: 5 }, // week 1: 500
+        { date: '2026-04-06T10:00:00', weight: 100, reps: 5 }, // week 3: 500
+      ]),
+    ])
+    const { weeklyVolume, weekCount } = useVolumeTrend(exercises)
+    expect(weeklyVolume.value).toEqual([
+      { date: '2026-03-23', value: 500 },
+      { date: '2026-03-30', value: 0 },
+      { date: '2026-04-06', value: 500 },
+    ])
+    expect(weekCount.value).toBe(3)
+  })
+
+  it('aggregates across multiple exercises into the same week', () => {
+    const exercises = ref([
+      makeExercise('Bench', [{ date: '2026-03-24T10:00:00', weight: 80, reps: 10 }]), // 800
+      makeExercise('Curl', [{ date: '2026-03-26T10:00:00', weight: 30, reps: 12 }]), // 360
+    ])
+    const { weeklyVolume, totalVolume } = useVolumeTrend(exercises)
+    expect(weeklyVolume.value).toEqual([{ date: '2026-03-23', value: 1160 }])
+    expect(totalVolume.value).toBe(1160)
+  })
+
+  it('reacts to exercise changes', () => {
+    const exercises = ref<Exercise[]>([])
+    const { weeklyVolume } = useVolumeTrend(exercises)
+    expect(weeklyVolume.value).toEqual([])
+
+    exercises.value = [
+      makeExercise('Bench', [{ date: '2026-03-23T10:00:00', weight: 100, reps: 5 }]),
+    ]
+    expect(weeklyVolume.value).toEqual([{ date: '2026-03-23', value: 500 }])
+  })
+})

--- a/src/composables/useVolumeTrend.ts
+++ b/src/composables/useVolumeTrend.ts
@@ -1,0 +1,76 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { Exercise } from '../stores/workout'
+import type { TimeSeriesEntry } from './useSVGTimeSeries'
+
+export interface UseVolumeTrendReturn {
+  /**
+   * Total training volume (weight × reps, in stored lbs) bucketed by ISO week.
+   * `date` is the Monday of each week (YYYY-MM-DD); empty weeks between the
+   * first and last trained week are filled with 0 so rest weeks show as dips.
+   */
+  weeklyVolume: ComputedRef<TimeSeriesEntry[]>
+  /** Sum of all weekly volume, in stored lbs. */
+  totalVolume: ComputedRef<number>
+  /** Number of weeks in the trend (including filled empty weeks). */
+  weekCount: ComputedRef<number>
+}
+
+/** Monday (ISO week start) of a YYYY-MM-DD local date key. */
+function mondayOfWeek(dateKey: string): string {
+  const [y, m, d] = dateKey.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  const dow = date.getDay()
+  const daysSinceMonday = dow === 0 ? 6 : dow - 1
+  date.setDate(date.getDate() - daysSinceMonday)
+  return toKey(date)
+}
+
+/** Advance a YYYY-MM-DD week-start key by 7 days. */
+function nextWeek(weekStart: string): string {
+  const [y, m, d] = weekStart.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  date.setDate(date.getDate() + 7)
+  return toKey(date)
+}
+
+function toKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+/**
+ * Aggregates total training volume per ISO week across the full set history.
+ * Used to surface a week-over-week volume trend line in the calendar/stats area.
+ */
+export function useVolumeTrend(exercises: Ref<Exercise[]>): UseVolumeTrendReturn {
+  const weeklyVolume = computed((): TimeSeriesEntry[] => {
+    const byWeek = new Map<string, number>()
+    for (const exercise of exercises.value) {
+      for (const set of exercise.sets) {
+        const wk = mondayOfWeek(set.date.slice(0, 10))
+        byWeek.set(wk, (byWeek.get(wk) ?? 0) + set.weight * set.reps)
+      }
+    }
+    if (byWeek.size === 0) return []
+
+    const weeks = [...byWeek.keys()].sort()
+    const last = weeks[weeks.length - 1]
+    const result: TimeSeriesEntry[] = []
+    let cursor = weeks[0]
+    while (cursor <= last) {
+      result.push({ date: cursor, value: Math.round(byWeek.get(cursor) ?? 0) })
+      cursor = nextWeek(cursor)
+    }
+    return result
+  })
+
+  const totalVolume = computed(() =>
+    weeklyVolume.value.reduce((sum, w) => sum + w.value, 0),
+  )
+
+  const weekCount = computed(() => weeklyVolume.value.length)
+
+  return { weeklyVolume, totalVolume, weekCount }
+}

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -219,6 +219,15 @@
         :collapsed="volumeCollapsed"
         @toggle-collapsed="volumeCollapsed = !volumeCollapsed"
       />
+
+      <!-- Week-over-week training volume trend (collapsible) -->
+      <VolumeTrendChart
+        v-if="volumeTrend.length >= 2"
+        :weekly-volume="volumeTrend"
+        :total-volume="volumeTrendTotal"
+        :collapsed="trendCollapsed"
+        @toggle-collapsed="trendCollapsed = !trendCollapsed"
+      />
     </div>
   </div>
 
@@ -306,9 +315,11 @@ import { usePRBaseline } from '../composables/usePRBaseline'
 import { useModal } from '../composables/useModal'
 import { useTagVolume } from '../composables/useTagVolume'
 import { useTagRecovery } from '../composables/useTagRecovery'
+import { useVolumeTrend } from '../composables/useVolumeTrend'
 
 const MuscleGroupChart = defineAsyncComponent(() => import('../components/MuscleGroupChart.vue'))
 const MuscleGroupRecovery = defineAsyncComponent(() => import('../components/MuscleGroupRecovery.vue'))
+const VolumeTrendChart = defineAsyncComponent(() => import('../components/VolumeTrendChart.vue'))
 
 const store = useWorkoutStore()
 const { weightUnit, displayWeight, toLbs } = useWeightUnit()
@@ -601,6 +612,9 @@ const weekDateStrings = computed(() => weekDays.value.map(d => d.dateStr))
 const exercisesRef = computed(() => filteredExercises.value)
 const { weeklyVolume, maxSets, totalSets } = useTagVolume(exercisesRef, weekDateStrings)
 
+// ── Week-over-week volume trend (full history, respects tag filter) ──
+const { weeklyVolume: volumeTrend, totalVolume: volumeTrendTotal } = useVolumeTrend(exercisesRef)
+
 // ── Tag recovery ─────────────────────────────────────────────────
 const allExercisesRef = computed(() => store.exercises)
 const tagRecoveryDaysRef = computed(() => store.tagRecoveryDays)
@@ -635,6 +649,7 @@ function onRecoveryDaysChange(tag: string, days: number | null) {
 }
 
 const volumeCollapsed = ref(false)
+const trendCollapsed = ref(true)
 
 function formatSelectedDay(dateStr: string) {
   return new Date(dateStr + 'T12:00:00').toLocaleDateString(undefined, {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-730](https://github.com/aschung212/Lift/issues/730)



## Changes




## Commits
- [`28740a0`](https://github.com/aschung212/Lift/commit/28740a0) feat(LIFT-730): surface a week-over-week volume trend chart in the calendar

## Test Results
- Before: 2018 passing
- After: 2029 passing (11 delta)

---
_Automated by overnight pipeline — Tue Jun  9 23:36:13 PDT 2026_

## Preview
Test on your phone: https://lift-1zgmjrlrm-aschung212-1101s-projects.vercel.app