### PR TITLE
feat(LIFT-734): label the middle y-axis gridline on time-series charts

### DIFF
--- a/src/components/ExerciseGraph.vue
+++ b/src/components/ExerciseGraph.vue
@@ -46,13 +46,20 @@
         text-anchor="middle"
       >PR</text>
 
-      <!-- Y-axis labels: max at top, min at bottom -->
+      <!-- Y-axis labels: max at top, midpoint, min at bottom -->
       <text
         :x="PAD_L - 5"
         :y="PAD_T + 4"
         class="wtGYLabel"
         text-anchor="end"
       >{{ displayWeight(maxVal) }} {{ weightUnit }}</text>
+      <text
+        v-if="displayWeight(midVal) !== displayWeight(maxVal) && displayWeight(midVal) !== displayWeight(minVal)"
+        :x="PAD_L - 5"
+        :y="PAD_T + chartH / 2 + 4"
+        class="wtGYLabel wtGYLabelMid"
+        text-anchor="end"
+      >{{ displayWeight(midVal) }} {{ weightUnit }}</text>
       <text
         :x="PAD_L - 5"
         :y="PAD_T + chartH + 4"
@@ -131,7 +138,7 @@ const graphData = computed((): TimeSeriesEntry[] => {
 
 const {
   W, H, PAD_L, PAD_R, PAD_T, chartH,
-  minVal, maxVal, points: basePoints,
+  minVal, maxVal, midVal, points: basePoints,
   linePoints, areaPoints, gridYs,
   shouldShowLabel, formatDate,
 } = useSVGTimeSeries(graphData)

--- a/src/components/__tests__/ExerciseGraph.test.ts
+++ b/src/components/__tests__/ExerciseGraph.test.ts
@@ -117,10 +117,39 @@ describe('ExerciseGraph', () => {
         props: { exercise }
       })
       const yLabels = wrapper.findAll('.wtGYLabel')
-      expect(yLabels.length).toBe(2)
-      // Should contain "lbs" from mocked weightUnit
-      expect(yLabels[0].text()).toContain('lbs')
-      expect(yLabels[1].text()).toContain('lbs')
+      // max, midpoint, min — all distinct for this data
+      expect(yLabels.length).toBe(3)
+      for (const label of yLabels) {
+        expect(label.text()).toContain('lbs')
+      }
+    })
+
+    it('renders a midpoint Y-axis label between min and max', () => {
+      const wrapper = mount(ExerciseGraph, {
+        props: { exercise }
+      })
+      const yLabels = wrapper.findAll('.wtGYLabel')
+      const values = yLabels.map(l => parseInt(l.text(), 10))
+      const mid = wrapper.find('.wtGYLabelMid')
+      expect(mid.exists()).toBe(true)
+      const midValue = parseInt(mid.text(), 10)
+      const max = Math.max(...values)
+      const min = Math.min(...values)
+      expect(midValue).toBeLessThan(max)
+      expect(midValue).toBeGreaterThan(min)
+    })
+
+    it('omits the midpoint label when it collides with an endpoint', () => {
+      // Flat progression: min == mid == max, so the mid label is redundant
+      const flat = makeExercise([
+        makeSet(100, 5, '2026-01-01'),
+        makeSet(100, 5, '2026-02-01'),
+      ])
+      const wrapper = mount(ExerciseGraph, {
+        props: { exercise: flat }
+      })
+      expect(wrapper.find('.wtGYLabelMid').exists()).toBe(false)
+      expect(wrapper.findAll('.wtGYLabel').length).toBe(2)
     })
 
     it('has accessible aria-label on SVG', () => {

--- a/src/composables/__tests__/useSVGTimeSeries.test.ts
+++ b/src/composables/__tests__/useSVGTimeSeries.test.ts
@@ -54,6 +54,32 @@ describe('useSVGTimeSeries', () => {
     })
   })
 
+  describe('midVal', () => {
+    it('returns 0 when data is empty', () => {
+      const data = ref<TimeSeriesEntry[]>([])
+      const { midVal } = useSVGTimeSeries(data)
+      expect(midVal.value).toBe(0)
+    })
+
+    it('is the midpoint between min and max', () => {
+      const data = ref(makeEntries([
+        ['2025-01-01', 100],
+        ['2025-01-02', 200],
+      ]))
+      const { midVal } = useSVGTimeSeries(data)
+      expect(midVal.value).toBe(150)
+    })
+
+    it('aligns with the middle gridline via valueToY', () => {
+      const data = ref(makeEntries([
+        ['2025-01-01', 100],
+        ['2025-01-02', 200],
+      ]))
+      const { midVal, valueToY } = useSVGTimeSeries(data)
+      expect(valueToY(midVal.value)).toBeCloseTo(PAD_T + chartH / 2)
+    })
+  })
+
   describe('points', () => {
     it('returns empty array with fewer than 2 data points', () => {
       const data = ref(makeEntries([['2025-01-01', 100]]))

--- a/src/composables/useSVGTimeSeries.ts
+++ b/src/composables/useSVGTimeSeries.ts
@@ -45,6 +45,7 @@ export interface UseSVGTimeSeriesReturn {
   chartH: number
   minVal: ComputedRef<number>
   maxVal: ComputedRef<number>
+  midVal: ComputedRef<number>
   points: ComputedRef<GraphPoint[]>
   linePoints: ComputedRef<string>
   areaPoints: ComputedRef<string>
@@ -93,6 +94,9 @@ export function useSVGTimeSeries(
     }
     return max
   })
+
+  /** Midpoint value, aligned with the middle horizontal gridline. */
+  const midVal = computed(() => (minVal.value + maxVal.value) / 2)
 
   /** Map data entries to SVG coordinates. Returns [] if fewer than 2 points. */
   const points = computed((): GraphPoint[] => {
@@ -190,6 +194,7 @@ export function useSVGTimeSeries(
     // Computed values
     minVal,
     maxVal,
+    midVal,
     points,
     linePoints,
     areaPoints,

--- a/src/index.css
+++ b/src/index.css
@@ -5793,6 +5793,12 @@ html.theme-fading .settingsSheet {
   font-variant-numeric: tabular-nums;
 }
 
+/* Midpoint label sits on the central gridline — slightly dimmer than the
+   min/max endpoints so the range bounds stay the primary reference. */
+.wtGYLabelMid {
+  opacity: 0.7;
+}
+
 .wtGDateLabel {
   font-size: var(--font-caption2);
   fill: var(--text-muted);

--- a/src/views/BodyweightTracker.vue
+++ b/src/views/BodyweightTracker.vue
@@ -125,8 +125,9 @@
           />
         </template>
 
-        <!-- Y-axis labels -->
+        <!-- Y-axis labels: max at top, midpoint, min at bottom -->
         <text :x="PAD_L - 5" :y="PAD_T + 4" class="wtGYLabel" text-anchor="end">{{ displayWeight(maxVal) }} {{ weightUnit }}</text>
+        <text v-if="displayWeight(midVal) !== displayWeight(maxVal) && displayWeight(midVal) !== displayWeight(minVal)" :x="PAD_L - 5" :y="PAD_T + chartH / 2 + 4" class="wtGYLabel wtGYLabelMid" text-anchor="end">{{ displayWeight(midVal) }} {{ weightUnit }}</text>
         <text :x="PAD_L - 5" :y="PAD_T + chartH + 4" class="wtGYLabel" text-anchor="end">{{ displayWeight(minVal) }} {{ weightUnit }}</text>
 
         <!-- X-axis date labels -->
@@ -543,7 +544,7 @@ const periodTimeRange = computed(() => {
 
 const {
   W, H, PAD_L, PAD_R, PAD_T, chartH,
-  minVal, maxVal,
+  minVal, maxVal, midVal,
   points: basePoints,
   linePoints, gridYs,
   shouldShowLabel, valueToY, formatDate,


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-734](https://github.com/aschung212/Lift/issues/734)

LIFT-734: label the middle y-axis gridline on the app's two time-series charts (`ExerciseGraph`, `BodyweightTracker`), which both drew a center gridline but only labeled min/max.

## Changes
- `src/composables/useSVGTimeSeries.ts` — added `midVal` computed (midpoint of min/max, aligned with the central gridline) to the shared composable + its return type.
- `src/components/ExerciseGraph.vue` — render the midpoint Y-axis label on the middle gridline; destructure `midVal`.
- `src/views/BodyweightTracker.vue` — same midpoint label; destructure `midVal`.
- `src/index.css` — `.wtGYLabelMid` (0.7 opacity) so the min/max bounds stay primary.
- Collision guard: the mid label is omitted when `displayWeight(midVal)` equals either endpoint (flat or rounding-degenerate ranges), preventing stacked duplicate labels.
- Tests: 3 new `useSVGTimeSeries` cases for `midVal`; updated/added 3 `ExerciseGraph` cases (3-label render, midpoint between bounds, omission on flat data).

## Verification
- Affected tests: 44 passed
- Full suite: 2023 passed / 1 skipped (was 2018 — 5 net new tests)
- `npm run lint`: 0 errors (pre-existing warnings only)
- `npm run build`: typecheck + bundle pass
- Pre-push Gemini 3.1 Pro review: **No issues found**
- Pushed `enhance/run4-2026-06-08` to origin

## Screenshots
None (SVG chart change verified via component tests asserting label count/position; no dev server in this environment).

## Commits
- [`99e9117`](https://github.com/aschung212/Lift/commit/99e9117) feat(LIFT-734): label the middle y-axis gridline on time-series charts

## Test Results
- Before: 2018 passing
- After: 2023 passing (5 delta)

---
_Automated by overnight pipeline — Tue Jun  9 23:58:56 PDT 2026_

## Preview
Test on your phone: https://lift-qo7q0jggn-aschung212-1101s-projects.vercel.app