### PR TITLE
feat: top-bar "+" adds a new exercise on the Workouts page

### DIFF
--- a/e2e/workout-flow.spec.ts
+++ b/e2e/workout-flow.spec.ts
@@ -67,7 +67,7 @@ test.describe('Exercise CRUD', () => {
     await expect(page.locator('.wtSetRow')).toHaveCount(2)
   })
 
-  test('creates a second exercise via top-bar picker', async ({ page }) => {
+  test('creates a second exercise via the top-bar "+"', async ({ page }) => {
     // Create first exercise to clear fresh-start state. Save requires a set
     // (weight + reps) — without it the modal transitions to a different
     // state whose close button isn't .repMaxBtnClose, so mirror the
@@ -80,12 +80,9 @@ test.describe('Exercise CRUD', () => {
     await page.locator('.repMaxBtnClose').click()
     await expect(page.locator('.wtExerciseName', { hasText: 'OHP' })).toBeVisible()
 
-    // Use top-bar "+" button to open exercise picker
+    // The top-bar "+" now opens the New Exercise modal directly (no picker hop).
     await page.locator('.topBarPlusBtn').click()
-    await expect(page.locator('#timeline-picker-title')).toBeVisible()
-
-    // Click "+ New exercise" in the picker
-    await page.locator('.wtExPickerName', { hasText: '+ New exercise' }).click()
+    await expect(page.locator('#log-modal-title')).toHaveText('New Exercise')
 
     // Fill in second exercise
     await page.fill('input[placeholder="e.g. Bench Press"]', 'Bench Press')

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,9 +71,9 @@
             <button
               v-if="activeTab === 'workouts'"
               class="topBarPlusBtn"
-              @click="triggerQuickLog"
-              title="Log a set"
-              aria-label="Log a set"
+              @click="triggerAddExercise"
+              title="Add exercise"
+              aria-label="Add exercise"
             >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             </button>
@@ -452,14 +452,15 @@ function switchTab(tabId: string) {
   })
 }
 
-// Exposed from WorkoutTracker via defineExpose so the top-bar "+" can trigger
-// the same quick-log exercise-picker flow the in-content "+ Log Set" uses.
+// Exposed from WorkoutTracker via defineExpose so the top-bar "+" can open the
+// new-exercise modal directly. Logging a set is a per-exercise action (the "+"
+// on each exercise row); the top-bar "+" is reserved for adding an exercise.
 const workoutTrackerRef = ref<InstanceType<typeof WorkoutTracker> | null>(null)
 
-function triggerQuickLog() {
+function triggerAddExercise() {
   const wt = workoutTrackerRef.value
-  if (wt && typeof wt.openTimelineLogModal === 'function') {
-    wt.openTimelineLogModal()
+  if (wt && typeof wt.openNewExerciseModal === 'function') {
+    wt.openNewExerciseModal()
   }
 }
 

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -90,7 +90,7 @@
       </button>
     </div>
     <p v-else-if="store.exercises.length === 0" class="wtEmpty">
-      No exercises yet. Hit "+ New Exercise" to add your first one.
+      No exercises yet. Tap the "+" in the top right to add your first one.
     </p>
 
     <template v-else-if="listView === 'exercises'">
@@ -207,7 +207,17 @@
 
     <!-- Timeline view -->
     <template v-else-if="listView === 'timeline'">
-      <div class="wtTimelineControls">
+      <div class="wtTimelineControls wtTimelineControlsRow">
+        <!-- Timeline rows have no per-exercise "+", so this is the log entry
+             point for the timeline view (the top-bar "+" adds an exercise). -->
+        <button
+          class="wtTimelineLogBtn"
+          @click="openTimelineLogModal"
+          aria-label="Log a set"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          <span>Log a set</span>
+        </button>
         <button
           :class="['wtWarmupToggle', { wtWarmupToggleActive: hideWarmups }]"
           @click="hideWarmups = !hideWarmups"
@@ -2682,10 +2692,9 @@ onUnmounted(() => {
   document.documentElement.classList.remove('modal-open')
 })
 
-// Exposed so the app's top-bar "+" button can trigger quick-log without
-// duplicating the exercise-picker state in App.vue. openNewExerciseModal is
-// also exposed for unit tests that previously opened the new-exercise
-// dialog via the in-card "+ New Exercise" button (retired after the
-// 03-workouts.png restyle).
+// openNewExerciseModal is exposed so App.vue's top-bar "+" can open the
+// new-exercise modal directly (the primary "add exercise" entry point).
+// openTimelineLogModal is exposed for the timeline view's "Log a set" button
+// and for unit tests; it opens the exercise picker used to quick-log a set.
 defineExpose({ openTimelineLogModal, openNewExerciseModal, timerCtrl })
 </script>

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -638,9 +638,9 @@ describe('WorkoutTracker', () => {
   })
 
   describe('new exercise modal', () => {
-    // The top-bar "+" button in App.vue calls the exposed openTimelineLogModal,
-    // which opens the exercise picker. Clicking "+ New exercise" in the picker
-    // opens the new exercise modal. Tests use the exposed API directly.
+    // App.vue's top-bar "+" calls the exposed openNewExerciseModal directly to
+    // open this modal (the picker's "+ New exercise" row is now only reached
+    // via the timeline "Log a set" button). Tests use the exposed API directly.
     async function openNewExerciseModal(wrapper: VueWrapper) {
       exposed(wrapper).openNewExerciseModal()
       await wrapper.vm.$nextTick()
@@ -1329,10 +1329,10 @@ describe('WorkoutTracker', () => {
       expect(wrapper.find('.wtViewToggleBtn.active').text()).toBe('Timeline')
     })
 
-    it('quick-log button is driven by the app-level "+" and works from both views', async () => {
-      // The old `wtLogBtn` in the card header is gone (03-workouts.png). Both
-      // views now rely on the App.vue top-bar "+" which calls the exposed
-      // openTimelineLogModal helper to open the exercise picker.
+    it('exposes openTimelineLogModal to open the exercise picker from both views', async () => {
+      // The top-bar "+" now adds an exercise; logging a set goes through the
+      // exercise picker, exposed via openTimelineLogModal (used by the timeline
+      // view's "Log a set" button). The picker works from both views.
       const wrapper = mountTracker()
       expect(typeof exposed(wrapper).openTimelineLogModal).toBe('function')
 
@@ -1346,6 +1346,22 @@ describe('WorkoutTracker', () => {
       await wrapper.vm.$nextTick()
       exposed(wrapper).openTimelineLogModal()
       await wrapper.vm.$nextTick()
+      expect(wrapper.find('.wtExPickerNew').exists()).toBe(true)
+    })
+
+    it('timeline view shows a "Log a set" button that opens the exercise picker', async () => {
+      const wrapper = mountTracker()
+      // Switch to timeline view (timeline rows have no per-exercise "+").
+      await wrapper.findAll('.wtViewToggleBtn')[1].trigger('click')
+      await wrapper.vm.$nextTick()
+
+      const logBtn = wrapper.find('.wtTimelineLogBtn')
+      expect(logBtn.exists()).toBe(true)
+      expect(logBtn.attributes('aria-label')).toBe('Log a set')
+
+      await logBtn.trigger('click')
+      await wrapper.vm.$nextTick()
+      // Picker opens with the "+ New exercise" row available.
       expect(wrapper.find('.wtExPickerNew').exists()).toBe(true)
     })
 

--- a/src/index.css
+++ b/src/index.css
@@ -2358,6 +2358,35 @@ html.theme-fading .settingsSheet {
   padding: 4px 16px 0;
 }
 
+/* Timeline view: "Log a set" on the left, warmup toggle on the right. */
+.wtTimelineControlsRow {
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.wtTimelineLogBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  min-height: 32px;
+  font-size: var(--font-caption1);
+  font-weight: 600;
+  color: var(--text-on-accent, var(--bg-primary));
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.wtTimelineLogBtn:active {
+  opacity: 0.8;
+  background: var(--accent-hover, var(--accent));
+}
+
 .wtWarmupToggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

On the Workouts page, the top-bar **"+"** opened a "Choose Exercise" picker — and adding a *new* exercise meant scrolling to the bottom of that list to find the "+ New exercise" row. This repurposes the top-bar "+" to open the **New Exercise** modal directly.

The mental model is now clean and consistent:
- **Top-right "+"** → add a new exercise (a global action)
- **Each exercise row's "+"** → log a set for that exercise (a local action, unchanged)

### Preserving timeline logging
The **Timeline** sub-view has no per-row "+", and the top-bar "+" used to be its only way to log a set. So this adds a **"Log a set"** button to the timeline controls (wired to the existing exercise picker) — otherwise repurposing the "+" would have silently removed logging from the timeline view.

## Changes
- **`src/App.vue`** — top-bar "+" now calls `triggerAddExercise` → `openNewExerciseModal`; label `"Log a set"` → `"Add exercise"`.
- **`src/components/WorkoutTracker.vue`** — new timeline "Log a set" button; refreshed empty-state hint and the `defineExpose` comment.
- **`src/index.css`** — styles for the timeline log button (on the existing 4/8/12/16 spacing scale).
- **Tests** — new unit test for the timeline "Log a set" button + refreshed stale comments; updated the e2e "second exercise" test to the direct top-bar → New Exercise flow (it previously asserted the picker hop).

## Test plan
- ✅ `npm test` — 2019/2019 unit tests pass
- ✅ `npm run typecheck` (vue-tsc) — clean
- ✅ `npm run lint` — 0 errors
- ✅ `npm run test:e2e -- e2e/workout-flow.spec.ts` — 6/6 pass (incl. the rewritten top-bar test)
- ✅ Manual walkthrough: top-bar "+" → New Exercise modal; row "+" → log set; timeline "Log a set" → picker — 0 console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)