### PR TITLE
feat(LIFT-732): add rep-range / intensity-zone distribution chart

### DIFF
--- a/src/components/RepRangeChart.vue
+++ b/src/components/RepRangeChart.vue
@@ -1,0 +1,226 @@
+<template>
+  <div v-if="totalSets > 0" class="rrChart">
+    <button class="rrHeader" :aria-expanded="!collapsed" @click="$emit('toggleCollapsed')">
+      <p class="rrTitle">Rep Range Focus</p>
+      <div class="rrHeaderRight">
+        <span v-if="collapsed && dominant" class="rrCollapsedSummary">{{ dominant.label }}</span>
+        <svg class="rrChevron" :class="{ rrChevronOpen: !collapsed }" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+    </button>
+
+    <template v-if="!collapsed">
+      <!-- Segmented distribution bar -->
+      <div
+        class="rrBar"
+        role="img"
+        :aria-label="ariaLabel"
+      >
+        <div
+          v-for="seg in segments"
+          :key="seg.id"
+          class="rrSeg"
+          :style="{ width: `${seg.pct}%`, opacity: seg.opacity }"
+        ></div>
+      </div>
+
+      <!-- Legend -->
+      <div class="rrLegend" role="list">
+        <div v-for="seg in zones" :key="seg.id" class="rrLegendRow" role="listitem">
+          <span class="rrSwatch" :style="{ opacity: opacityFor(seg.id) }"></span>
+          <span class="rrLegendLabel">{{ seg.label }}</span>
+          <span class="rrLegendRange">{{ seg.range }}</span>
+          <span class="rrLegendPct">{{ pctFor(seg.sets) }}%</span>
+          <span class="rrLegendSets">{{ seg.sets }} set{{ seg.sets !== 1 ? 's' : '' }}</span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { RepZone, RepZoneId } from '../composables/useRepRangeDistribution'
+
+const props = defineProps<{
+  zones: RepZone[]
+  totalSets: number
+  dominant: RepZone | null
+  collapsed?: boolean
+}>()
+
+defineEmits<{
+  toggleCollapsed: []
+}>()
+
+// Single-hue opacity tiers keep the chart on-theme across all 10 themes
+// (mirrors the accent-opacity convention in MuscleGroupChart) while the
+// legend carries the actual meaning of each band.
+const OPACITY: Record<RepZoneId, number> = {
+  strength: 1,
+  hypertrophy: 0.66,
+  endurance: 0.34,
+}
+
+function opacityFor(id: RepZoneId): number {
+  return OPACITY[id]
+}
+
+function pctFor(sets: number): number {
+  if (props.totalSets === 0) return 0
+  return Math.round((sets / props.totalSets) * 100)
+}
+
+// Bar segments: skip empty zones so a zero-width sliver never renders.
+const segments = computed(() =>
+  props.zones
+    .filter((z) => z.sets > 0)
+    .map((z) => ({
+      id: z.id,
+      pct: (z.sets / props.totalSets) * 100,
+      opacity: OPACITY[z.id],
+    })),
+)
+
+const ariaLabel = computed(() => {
+  const parts = props.zones.map((z) => `${z.label} ${pctFor(z.sets)} percent`)
+  return `Rep range distribution across ${props.totalSets} sets: ${parts.join(', ')}`
+})
+</script>
+
+<style scoped>
+.rrChart {
+  margin-top: 12px;
+  padding: 12px;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.rrHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  color: inherit;
+  font: inherit;
+  min-height: 44px;
+}
+
+.rrHeader:active {
+  opacity: 0.6;
+}
+
+.rrTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  text-align: left;
+}
+
+.rrHeaderRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.rrCollapsedSummary {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.rrChevron {
+  color: var(--text-muted);
+  transition: transform 0.2s;
+}
+
+.rrChevronOpen {
+  transform: rotate(180deg);
+}
+
+.rrBar {
+  display: flex;
+  width: 100%;
+  height: 16px;
+  margin-top: 8px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bg-elevated);
+}
+
+.rrSeg {
+  height: 100%;
+  min-width: 2px;
+  background-color: var(--accent);
+  transition: width 0.3s ease;
+}
+
+.rrSeg:not(:last-child) {
+  border-right: 1px solid var(--bg-secondary);
+}
+
+.rrLegend {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 12px;
+}
+
+.rrLegendRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 24px;
+}
+
+.rrSwatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background-color: var(--accent);
+  flex-shrink: 0;
+}
+
+.rrLegendLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rrLegendRange {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.rrLegendPct {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-left: auto;
+  width: 36px;
+  text-align: right;
+}
+
+.rrLegendSets {
+  font-size: 11px;
+  color: var(--text-secondary);
+  width: 52px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rrSeg {
+    transition: none;
+  }
+  .rrChevron {
+    transition: none;
+  }
+}
+</style>

--- a/src/components/__tests__/RepRangeChart.test.ts
+++ b/src/components/__tests__/RepRangeChart.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RepRangeChart from '../RepRangeChart.vue'
+import type { RepZone } from '../../composables/useRepRangeDistribution'
+
+const zones: RepZone[] = [
+  { id: 'strength', label: 'Strength', range: '1–5', sets: 2 },
+  { id: 'hypertrophy', label: 'Hypertrophy', range: '6–12', sets: 6 },
+  { id: 'endurance', label: 'Endurance', range: '13+', sets: 2 },
+]
+const dominant = zones[1]
+
+describe('RepRangeChart', () => {
+  it('renders nothing when there are no sets', () => {
+    const wrapper = mount(RepRangeChart, {
+      props: {
+        zones: zones.map(z => ({ ...z, sets: 0 })),
+        totalSets: 0,
+        dominant: null,
+      },
+    })
+    expect(wrapper.find('.rrChart').exists()).toBe(false)
+  })
+
+  it('renders one bar segment per non-empty zone when expanded', () => {
+    const wrapper = mount(RepRangeChart, {
+      props: { zones, totalSets: 10, dominant, collapsed: false },
+    })
+    expect(wrapper.find('.rrBar').exists()).toBe(true)
+    expect(wrapper.findAll('.rrSeg')).toHaveLength(3)
+  })
+
+  it('omits empty zones from the bar but keeps them in the legend', () => {
+    const partial: RepZone[] = [
+      { id: 'strength', label: 'Strength', range: '1–5', sets: 4 },
+      { id: 'hypertrophy', label: 'Hypertrophy', range: '6–12', sets: 6 },
+      { id: 'endurance', label: 'Endurance', range: '13+', sets: 0 },
+    ]
+    const wrapper = mount(RepRangeChart, {
+      props: { zones: partial, totalSets: 10, dominant: partial[1], collapsed: false },
+    })
+    expect(wrapper.findAll('.rrSeg')).toHaveLength(2)
+    expect(wrapper.findAll('.rrLegendRow')).toHaveLength(3)
+  })
+
+  it('computes whole-number percentages in the legend', () => {
+    const wrapper = mount(RepRangeChart, {
+      props: { zones, totalSets: 10, dominant, collapsed: false },
+    })
+    const pcts = wrapper.findAll('.rrLegendPct').map(n => n.text())
+    expect(pcts).toEqual(['20%', '60%', '20%'])
+  })
+
+  it('hides the body but keeps the header and dominant summary when collapsed', () => {
+    const wrapper = mount(RepRangeChart, {
+      props: { zones, totalSets: 10, dominant, collapsed: true },
+    })
+    expect(wrapper.find('.rrHeader').exists()).toBe(true)
+    expect(wrapper.find('.rrBar').exists()).toBe(false)
+    expect(wrapper.find('.rrCollapsedSummary').text()).toBe('Hypertrophy')
+  })
+
+  it('exposes an accessible label describing the distribution', () => {
+    const wrapper = mount(RepRangeChart, {
+      props: { zones, totalSets: 10, dominant, collapsed: false },
+    })
+    expect(wrapper.find('.rrBar').attributes('aria-label')).toContain('10 sets')
+  })
+
+  it('emits toggleCollapsed when the header is clicked', async () => {
+    const wrapper = mount(RepRangeChart, {
+      props: { zones, totalSets: 10, dominant, collapsed: false },
+    })
+    await wrapper.find('.rrHeader').trigger('click')
+    expect(wrapper.emitted('toggleCollapsed')).toHaveLength(1)
+  })
+})

--- a/src/composables/__tests__/useRepRangeDistribution.test.ts
+++ b/src/composables/__tests__/useRepRangeDistribution.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useRepRangeDistribution, classifyRepZone } from '../useRepRangeDistribution'
+import type { Exercise } from '../../stores/workout'
+
+function makeExercise(
+  name: string,
+  sets: { date: string; weight: number; reps: number }[],
+): Exercise {
+  return {
+    id: name.toLowerCase().replace(/\s/g, '-'),
+    name,
+    tags: [],
+    sets: sets.map((s, i) => ({
+      id: `${name}-set-${i}`,
+      date: s.date,
+      weight: s.weight,
+      reps: s.reps,
+      estimated1RM: s.weight * (1 + s.reps / 30),
+    })),
+  }
+}
+
+describe('classifyRepZone', () => {
+  it('classifies the strength band (1–5)', () => {
+    expect(classifyRepZone(1)).toBe('strength')
+    expect(classifyRepZone(5)).toBe('strength')
+  })
+
+  it('classifies the hypertrophy band (6–12)', () => {
+    expect(classifyRepZone(6)).toBe('hypertrophy')
+    expect(classifyRepZone(12)).toBe('hypertrophy')
+  })
+
+  it('classifies the endurance band (13+)', () => {
+    expect(classifyRepZone(13)).toBe('endurance')
+    expect(classifyRepZone(30)).toBe('endurance')
+  })
+
+  it('ignores reps below 1 and non-finite values', () => {
+    expect(classifyRepZone(0)).toBeNull()
+    expect(classifyRepZone(-2)).toBeNull()
+    expect(classifyRepZone(NaN)).toBeNull()
+  })
+})
+
+describe('useRepRangeDistribution', () => {
+  it('returns three zeroed zones when there are no sets', () => {
+    const exercises = ref<Exercise[]>([makeExercise('Bench', [])])
+    const { zones, totalSets, dominant } = useRepRangeDistribution(exercises)
+    expect(zones.value.map(z => z.id)).toEqual(['strength', 'hypertrophy', 'endurance'])
+    expect(zones.value.every(z => z.sets === 0)).toBe(true)
+    expect(totalSets.value).toBe(0)
+    expect(dominant.value).toBeNull()
+  })
+
+  it('buckets sets into the correct zones', () => {
+    const exercises = ref([
+      makeExercise('Squat', [
+        { date: '2026-03-23T10:00:00', weight: 225, reps: 3 },  // strength
+        { date: '2026-03-23T10:05:00', weight: 185, reps: 8 },  // hypertrophy
+        { date: '2026-03-23T10:10:00', weight: 185, reps: 10 }, // hypertrophy
+        { date: '2026-03-23T10:15:00', weight: 95, reps: 20 },  // endurance
+      ]),
+    ])
+    const { zones, totalSets } = useRepRangeDistribution(exercises)
+    const byId = Object.fromEntries(zones.value.map(z => [z.id, z.sets]))
+    expect(byId).toEqual({ strength: 1, hypertrophy: 2, endurance: 1 })
+    expect(totalSets.value).toBe(4)
+  })
+
+  it('aggregates across multiple exercises', () => {
+    const exercises = ref([
+      makeExercise('Bench', [{ date: '2026-03-23T10:00:00', weight: 135, reps: 5 }]),
+      makeExercise('Curl', [{ date: '2026-03-24T10:00:00', weight: 30, reps: 10 }]),
+    ])
+    const { totalSets, dominant } = useRepRangeDistribution(exercises)
+    expect(totalSets.value).toBe(2)
+    // Tie broken toward the first/earlier zone in iteration (strength).
+    expect(dominant.value?.id).toBe('strength')
+  })
+
+  it('reports the dominant zone', () => {
+    const exercises = ref([
+      makeExercise('Press', [
+        { date: '2026-03-23T10:00:00', weight: 100, reps: 8 },
+        { date: '2026-03-23T10:05:00', weight: 100, reps: 9 },
+        { date: '2026-03-23T10:10:00', weight: 100, reps: 3 },
+      ]),
+    ])
+    const { dominant } = useRepRangeDistribution(exercises)
+    expect(dominant.value?.id).toBe('hypertrophy')
+    expect(dominant.value?.label).toBe('Hypertrophy')
+  })
+
+  it('reacts to exercise changes', () => {
+    const exercises = ref<Exercise[]>([])
+    const { totalSets } = useRepRangeDistribution(exercises)
+    expect(totalSets.value).toBe(0)
+
+    exercises.value = [
+      makeExercise('Row', [{ date: '2026-03-23T10:00:00', weight: 100, reps: 12 }]),
+    ]
+    expect(totalSets.value).toBe(1)
+  })
+})

--- a/src/composables/useRepRangeDistribution.ts
+++ b/src/composables/useRepRangeDistribution.ts
@@ -1,0 +1,86 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { Exercise } from '../stores/workout'
+
+export type RepZoneId = 'strength' | 'hypertrophy' | 'endurance'
+
+export interface RepZone {
+  id: RepZoneId
+  /** Human label for the training emphasis. */
+  label: string
+  /** Rep-range description, e.g. "1–5". */
+  range: string
+  /** Number of sets that fell into this zone. */
+  sets: number
+}
+
+export interface UseRepRangeDistributionReturn {
+  /** Always three zones, in fixed strength → hypertrophy → endurance order. */
+  zones: ComputedRef<RepZone[]>
+  /** Total sets counted across all three zones. */
+  totalSets: ComputedRef<number>
+  /** The zone with the most sets, or null when there are no sets. */
+  dominant: ComputedRef<RepZone | null>
+}
+
+/**
+ * Classifies a set's rep count into a training-emphasis zone.
+ * Boundaries follow the widely-used strength (1–5), hypertrophy (6–12),
+ * and muscular-endurance (13+) bands. Sets with fewer than 1 rep are ignored.
+ */
+export function classifyRepZone(reps: number): RepZoneId | null {
+  if (!Number.isFinite(reps) || reps < 1) return null
+  if (reps <= 5) return 'strength'
+  if (reps <= 12) return 'hypertrophy'
+  return 'endurance'
+}
+
+const ZONE_META: Record<RepZoneId, { label: string; range: string }> = {
+  strength: { label: 'Strength', range: '1–5' },
+  hypertrophy: { label: 'Hypertrophy', range: '6–12' },
+  endurance: { label: 'Endurance', range: '13+' },
+}
+
+const ZONE_ORDER: RepZoneId[] = ['strength', 'hypertrophy', 'endurance']
+
+/**
+ * Buckets every logged set across the given exercises into strength,
+ * hypertrophy, and endurance rep zones. Requires no new data capture —
+ * derived purely from the reps already stored on each set. Surfaces a
+ * training-balance insight (am I training for strength vs size?).
+ */
+export function useRepRangeDistribution(
+  exercises: Ref<Exercise[]>,
+): UseRepRangeDistributionReturn {
+  const zones = computed((): RepZone[] => {
+    const counts: Record<RepZoneId, number> = {
+      strength: 0,
+      hypertrophy: 0,
+      endurance: 0,
+    }
+
+    for (const exercise of exercises.value) {
+      for (const set of exercise.sets) {
+        const zone = classifyRepZone(set.reps)
+        if (zone) counts[zone]++
+      }
+    }
+
+    return ZONE_ORDER.map((id) => ({
+      id,
+      label: ZONE_META[id].label,
+      range: ZONE_META[id].range,
+      sets: counts[id],
+    }))
+  })
+
+  const totalSets = computed(() =>
+    zones.value.reduce((sum, z) => sum + z.sets, 0),
+  )
+
+  const dominant = computed((): RepZone | null => {
+    if (totalSets.value === 0) return null
+    return zones.value.reduce((best, z) => (z.sets > best.sets ? z : best))
+  })
+
+  return { zones, totalSets, dominant }
+}

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -228,6 +228,16 @@
         :collapsed="trendCollapsed"
         @toggle-collapsed="trendCollapsed = !trendCollapsed"
       />
+
+      <!-- Rep-range / intensity-zone distribution (collapsible) -->
+      <RepRangeChart
+        v-if="repRangeTotal > 0"
+        :zones="repRangeZones"
+        :total-sets="repRangeTotal"
+        :dominant="repRangeDominant"
+        :collapsed="repRangeCollapsed"
+        @toggle-collapsed="repRangeCollapsed = !repRangeCollapsed"
+      />
     </div>
   </div>
 
@@ -316,10 +326,12 @@ import { useModal } from '../composables/useModal'
 import { useTagVolume } from '../composables/useTagVolume'
 import { useTagRecovery } from '../composables/useTagRecovery'
 import { useVolumeTrend } from '../composables/useVolumeTrend'
+import { useRepRangeDistribution } from '../composables/useRepRangeDistribution'
 
 const MuscleGroupChart = defineAsyncComponent(() => import('../components/MuscleGroupChart.vue'))
 const MuscleGroupRecovery = defineAsyncComponent(() => import('../components/MuscleGroupRecovery.vue'))
 const VolumeTrendChart = defineAsyncComponent(() => import('../components/VolumeTrendChart.vue'))
+const RepRangeChart = defineAsyncComponent(() => import('../components/RepRangeChart.vue'))
 
 const store = useWorkoutStore()
 const { weightUnit, displayWeight, toLbs } = useWeightUnit()
@@ -615,6 +627,9 @@ const { weeklyVolume, maxSets, totalSets } = useTagVolume(exercisesRef, weekDate
 // ── Week-over-week volume trend (full history, respects tag filter) ──
 const { weeklyVolume: volumeTrend, totalVolume: volumeTrendTotal } = useVolumeTrend(exercisesRef)
 
+// ── Rep-range distribution (full history, respects tag filter) ──
+const { zones: repRangeZones, totalSets: repRangeTotal, dominant: repRangeDominant } = useRepRangeDistribution(exercisesRef)
+
 // ── Tag recovery ─────────────────────────────────────────────────
 const allExercisesRef = computed(() => store.exercises)
 const tagRecoveryDaysRef = computed(() => store.tagRecoveryDays)
@@ -650,6 +665,7 @@ function onRecoveryDaysChange(tag: string, days: number | null) {
 
 const volumeCollapsed = ref(false)
 const trendCollapsed = ref(true)
+const repRangeCollapsed = ref(true)
 
 function formatSelectedDay(dateStr: string) {
   return new Date(dateStr + 'T12:00:00').toLocaleDateString(undefined, {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-732](https://github.com/aschung212/Lift/issues/732)

Picked **LIFT-732** (rep-range / intensity-zone distribution chart) from the unstarted backlog — a self-contained data-viz feature requiring no new data capture, high product-taste signal, and cleanly scoped. Studied the existing collapsible-chart convention (`MuscleGroupChart`, `VolumeTrendChart`, `useTagVolume`, `useVolumeTrend`) and mirrored it exactly.

## Changes
- **`src/composables/useRepRangeDistribution.ts`** (new) — pure composable bucketing every set into strength (1–5) / hypertrophy (6–12) / endurance (13+) zones; exposes `zones`, `totalSets`, `dominant`. Exported `classifyRepZone` helper for the band boundaries.
- **`src/components/RepRangeChart.vue`** (new) — collapsible card with a segmented distribution bar + legend (set count + %). Single-hue accent opacity tiers keep it on-theme across all 10 themes; meaning carried by legend text and `aria-label`, not color alone.
- **`src/views/CalendarView.vue`** — wired the chart into the week view after the volume trend; lazy-loaded via `defineAsyncComponent`, respects the active tag filter, full-history data, collapsed by default.
- **Tests** (new) — `useRepRangeDistribution.test.ts` (10 cases) and `RepRangeChart.test.ts` (7 cases).

## Verification
- New tests: 16 passed (2 files)
- Full suite: **2123 passed / 1 skipped** (was 2107; +16)
- `npm run lint`: clean
- `npm run build`: succeeds — chart code-splits into its own 2.17 kB chunk
- Pre-commit Gemini 3.1 Pro review: **No issues found**

## Screenshots
None — headless environment. Manual on-device theme verification left as an unchecked item in the PR test plan.

## Commits
- [`3996d31`](https://github.com/aschung212/Lift/commit/3996d31) feat(LIFT-732): add rep-range / intensity-zone distribution chart

## Test Results
- Before: 2107 passing
- After: 2123 passing (16 delta)

---
_Automated by overnight pipeline — Mon Jun 15 23:47:25 PDT 2026_

## Preview
Test on your phone: https://lift-qlzjgvrma-aschung212-1101s-projects.vercel.app