### PR TITLE
feat(LIFT-731): add per-muscle-group volume trend drill-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Lift lets you track any strength exercise over time. Log a set (weight + reps + 
 - Set count badge on each exercise tag
 - Log sets directly from the calendar
 - Tag filtering shared with workouts tab
-- Weekly view surfaces a muscle-group volume snapshot and a week-over-week training-volume trend line (hand-rolled SVG)
+- Weekly view surfaces a muscle-group volume snapshot (tap any tag to drill into its week-over-week volume trend) plus an overall training-volume trend line (hand-rolled SVG)
 
 ### Body Weight Tracking
 - Log daily weigh-ins with date

--- a/src/components/MuscleGroupChart.vue
+++ b/src/components/MuscleGroupChart.vue
@@ -17,17 +17,40 @@
           role="listitem"
           :aria-label="`${item.tag}: ${item.sets} sets`"
         >
-          <span class="mgLabel">{{ item.tag }}</span>
-          <div class="mgBarTrack">
-            <div
-              class="mgBarFill"
-              :style="{
-                width: `${(item.sets / maxSets) * 100}%`,
-                opacity: 1 - (index * 0.06),
-              }"
-            ></div>
-          </div>
-          <span class="mgCount">{{ item.sets }}</span>
+          <component
+            :is="isExpandable(item.tag) ? 'button' : 'div'"
+            class="mgRowMain"
+            :class="{ mgRowMainTappable: isExpandable(item.tag) }"
+            :type="isExpandable(item.tag) ? 'button' : undefined"
+            :aria-expanded="isExpandable(item.tag) ? (expandedTag === item.tag) : undefined"
+            :aria-label="isExpandable(item.tag) ? `${item.tag}: ${item.sets} sets. ${expandedTag === item.tag ? 'Hide' : 'Show'} weekly volume trend` : undefined"
+            @click="isExpandable(item.tag) && toggleTag(item.tag)"
+          >
+            <span class="mgLabel">{{ item.tag }}</span>
+            <div class="mgBarTrack">
+              <div
+                class="mgBarFill"
+                :style="{
+                  width: `${(item.sets / maxSets) * 100}%`,
+                  opacity: 1 - (index * 0.06),
+                }"
+              ></div>
+            </div>
+            <span class="mgCount">{{ item.sets }}</span>
+            <svg
+              v-if="isExpandable(item.tag)"
+              class="mgRowChevron"
+              :class="{ mgRowChevronOpen: expandedTag === item.tag }"
+              viewBox="0 0 24 24" width="14" height="14" fill="none"
+              stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+              aria-hidden="true"
+            ><polyline points="6 9 12 15 18 9"/></svg>
+          </component>
+          <TagVolumeSparkline
+            v-if="expandedTag === item.tag && tagTrends"
+            :series="tagTrends[item.tag]"
+            :tag="item.tag"
+          />
         </div>
       </div>
 
@@ -37,18 +60,35 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue'
+import TagVolumeSparkline from './TagVolumeSparkline.vue'
 import type { TagVolume } from '../composables/useTagVolume'
+import type { TimeSeriesEntry } from '../composables/useSVGTimeSeries'
 
-defineProps<{
+const props = defineProps<{
   weeklyVolume: TagVolume[]
   maxSets: number
   totalSets: number
   collapsed?: boolean
+  /** Per-tag weekly volume history. When a tag has ≥2 weeks, its row becomes
+   *  tappable to reveal an inline trend sparkline. */
+  tagTrends?: Record<string, TimeSeriesEntry[]>
 }>()
 
 defineEmits<{
   toggleCollapsed: []
 }>()
+
+// Only one tag's trend is open at a time (progressive disclosure).
+const expandedTag = ref<string | null>(null)
+
+function isExpandable(tag: string): boolean {
+  return (props.tagTrends?.[tag]?.length ?? 0) >= 2
+}
+
+function toggleTag(tag: string) {
+  expandedTag.value = expandedTag.value === tag ? null : tag
+}
 </script>
 
 <style scoped>
@@ -116,9 +156,42 @@ defineEmits<{
 
 .mgRow {
   display: flex;
+  flex-direction: column;
+  min-height: 44px;
+}
+
+.mgRowMain {
+  display: flex;
   align-items: center;
   gap: 8px;
+  width: 100%;
   min-height: 44px;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.mgRowMainTappable {
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mgRowMainTappable:active {
+  opacity: 0.6;
+}
+
+.mgRowChevron {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  transition: transform 0.2s;
+}
+
+.mgRowChevronOpen {
+  transform: rotate(180deg);
 }
 
 .mgLabel {
@@ -165,7 +238,8 @@ defineEmits<{
   .mgBarFill {
     transition: none;
   }
-  .mgChevron {
+  .mgChevron,
+  .mgRowChevron {
     transition: none;
   }
 }

--- a/src/components/TagVolumeSparkline.vue
+++ b/src/components/TagVolumeSparkline.vue
@@ -1,0 +1,86 @@
+<template>
+  <div v-if="points.length >= 2" class="mgSparkline wtGraphWrap">
+    <p class="wtGraphTitle">{{ tag }} weekly volume</p>
+    <svg
+      :viewBox="`0 0 ${W} ${H}`"
+      class="wtGraphSvg"
+      role="img"
+      :aria-label="`${tag} weekly volume trend across ${points.length} weeks, from ${formatVolume(minVal)} to ${formatVolume(maxVal)} ${weightUnit}`"
+    >
+      <desc>{{ `${tag} weekly training volume from ${formatDate(points[0]?.date)} to ${formatDate(points[points.length - 1]?.date)}, ranging from ${formatVolume(minVal)} to ${formatVolume(maxVal)} ${weightUnit}.` }}</desc>
+      <!-- Horizontal grid lines -->
+      <line
+        v-for="gy in gridYs"
+        :key="gy"
+        :x1="PAD_L"
+        :y1="gy"
+        :x2="W - PAD_R"
+        :y2="gy"
+        class="wtGGrid"
+      />
+
+      <!-- Area fill under line -->
+      <polygon :points="areaPoints" class="wtGArea" />
+
+      <!-- Line -->
+      <polyline :points="linePoints" class="wtGLine" />
+
+      <!-- Endpoint dots -->
+      <circle :cx="points[0].x" :cy="points[0].y" r="3" class="wtGDot" />
+      <circle :cx="points[points.length - 1].x" :cy="points[points.length - 1].y" r="3" class="wtGDot" />
+
+      <!-- Y-axis labels: max at top, min at bottom -->
+      <text :x="PAD_L - 5" :y="PAD_T + 4" class="wtGYLabel" text-anchor="end">{{ formatVolume(maxVal) }}</text>
+      <text :x="PAD_L - 5" :y="PAD_T + chartH + 4" class="wtGYLabel" text-anchor="end">{{ formatVolume(minVal) }}</text>
+
+      <!-- X-axis date labels -->
+      <text
+        v-for="(p, i) in points"
+        v-show="shouldShowLabel(i)"
+        :key="'lbl-' + p.date"
+        :x="p.x"
+        :y="H - 3"
+        class="wtGDateLabel"
+        text-anchor="middle"
+      >{{ formatDate(p.date) }}</text>
+    </svg>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue'
+import { useWeightUnit } from '../composables/useWeightUnit'
+import { useSVGTimeSeries, type TimeSeriesEntry } from '../composables/useSVGTimeSeries'
+
+const props = defineProps<{
+  /** Weekly volume series (stored lbs) for a single tag. */
+  series: TimeSeriesEntry[]
+  /** Tag name, used for titles and the accessible label. */
+  tag: string
+}>()
+
+const { weightUnit, displayWeight } = useWeightUnit()
+
+const graphData = toRef(props, 'series')
+
+const {
+  W, H, PAD_L, PAD_R, PAD_T, chartH,
+  minVal, maxVal, points,
+  linePoints, areaPoints, gridYs,
+  shouldShowLabel, formatDate,
+} = useSVGTimeSeries(graphData)
+
+/** Format a stored-lbs volume value into display units with k-abbreviation. */
+function formatVolume(lbs: number): string {
+  const v = displayWeight(lbs)
+  if (v >= 1000) return `${(v / 1000).toFixed(1)}k`
+  return String(v)
+}
+</script>
+
+<style scoped>
+/* Override the global wtGraphWrap margin so the sparkline sits flush under the row. */
+.mgSparkline {
+  margin: 4px 0 8px;
+}
+</style>

--- a/src/components/__tests__/MuscleGroupChart.test.ts
+++ b/src/components/__tests__/MuscleGroupChart.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import MuscleGroupChart from '../MuscleGroupChart.vue'
 import type { TagVolume } from '../../composables/useTagVolume'
+import type { TimeSeriesEntry } from '../../composables/useSVGTimeSeries'
 
 const sampleVolume: TagVolume[] = [
   { tag: 'Chest', sets: 12 },
@@ -9,13 +10,28 @@ const sampleVolume: TagVolume[] = [
   { tag: 'Legs', sets: 10 },
 ]
 
-function mountChart(props?: Partial<{ weeklyVolume: TagVolume[]; maxSets: number; totalSets: number; collapsed: boolean }>) {
+const sampleTrends: Record<string, TimeSeriesEntry[]> = {
+  Chest: [
+    { date: '2026-03-02', value: 1000 },
+    { date: '2026-03-09', value: 1400 },
+    { date: '2026-03-16', value: 1200 },
+  ],
+  Back: [
+    { date: '2026-03-09', value: 800 },
+    { date: '2026-03-16', value: 900 },
+  ],
+  // Legs has only one week → not expandable.
+  Legs: [{ date: '2026-03-16', value: 600 }],
+}
+
+function mountChart(props?: Partial<{ weeklyVolume: TagVolume[]; maxSets: number; totalSets: number; collapsed: boolean; tagTrends: Record<string, TimeSeriesEntry[]> }>) {
   return mount(MuscleGroupChart, {
     props: {
       weeklyVolume: props?.weeklyVolume ?? sampleVolume,
       maxSets: props?.maxSets ?? 12,
       totalSets: props?.totalSets ?? 30,
       collapsed: props?.collapsed ?? false,
+      ...(props?.tagTrends !== undefined ? { tagTrends: props.tagTrends } : {}),
     },
   })
 }
@@ -133,6 +149,69 @@ describe('MuscleGroupChart', () => {
       const wrapper = mountChart()
       const header = wrapper.find('.mgHeader')
       expect(header.exists()).toBe(true)
+    })
+  })
+
+  describe('tag trend expansion', () => {
+    it('renders rows as non-interactive divs when no tagTrends provided', () => {
+      const wrapper = mountChart()
+      const mains = wrapper.findAll('.mgRowMain')
+      expect(mains).toHaveLength(3)
+      mains.forEach(m => expect(m.element.tagName).toBe('DIV'))
+      expect(wrapper.find('.mgRowChevron').exists()).toBe(false)
+    })
+
+    it('makes a tag with ≥2 weeks of history tappable', () => {
+      const wrapper = mountChart({ tagTrends: sampleTrends })
+      const chestMain = wrapper.findAll('.mgRowMain')[0]
+      expect(chestMain.element.tagName).toBe('BUTTON')
+      expect(chestMain.attributes('aria-expanded')).toBe('false')
+    })
+
+    it('leaves a tag with <2 weeks of history non-interactive', () => {
+      const wrapper = mountChart({ tagTrends: sampleTrends })
+      // Legs (index 2) has a single-week series.
+      const legsMain = wrapper.findAll('.mgRowMain')[2]
+      expect(legsMain.element.tagName).toBe('DIV')
+      expect(legsMain.attributes('aria-expanded')).toBeUndefined()
+    })
+
+    it('reveals the sparkline when an expandable row is tapped', async () => {
+      const wrapper = mountChart({ tagTrends: sampleTrends })
+      expect(wrapper.findComponent({ name: 'TagVolumeSparkline' }).exists()).toBe(false)
+
+      await wrapper.findAll('.mgRowMain')[0].trigger('click')
+
+      const sparkline = wrapper.findComponent({ name: 'TagVolumeSparkline' })
+      expect(sparkline.exists()).toBe(true)
+      expect(sparkline.props('tag')).toBe('Chest')
+      expect(wrapper.findAll('.mgRowMain')[0].attributes('aria-expanded')).toBe('true')
+    })
+
+    it('collapses the sparkline when the open row is tapped again', async () => {
+      const wrapper = mountChart({ tagTrends: sampleTrends })
+      await wrapper.findAll('.mgRowMain')[0].trigger('click')
+      expect(wrapper.findComponent({ name: 'TagVolumeSparkline' }).exists()).toBe(true)
+
+      await wrapper.findAll('.mgRowMain')[0].trigger('click')
+      expect(wrapper.findComponent({ name: 'TagVolumeSparkline' }).exists()).toBe(false)
+    })
+
+    it('only keeps one tag expanded at a time', async () => {
+      const wrapper = mountChart({ tagTrends: sampleTrends })
+      await wrapper.findAll('.mgRowMain')[0].trigger('click') // Chest
+      await wrapper.findAll('.mgRowMain')[1].trigger('click') // Back
+
+      const sparklines = wrapper.findAllComponents({ name: 'TagVolumeSparkline' })
+      expect(sparklines).toHaveLength(1)
+      expect(sparklines[0].props('tag')).toBe('Back')
+    })
+
+    it('exposes a descriptive aria-label on the toggle', () => {
+      const wrapper = mountChart({ tagTrends: sampleTrends })
+      const chestMain = wrapper.findAll('.mgRowMain')[0]
+      expect(chestMain.attributes('aria-label')).toContain('Chest: 12 sets')
+      expect(chestMain.attributes('aria-label')).toContain('Show weekly volume trend')
     })
   })
 })

--- a/src/components/__tests__/TagVolumeSparkline.test.ts
+++ b/src/components/__tests__/TagVolumeSparkline.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TagVolumeSparkline from '../TagVolumeSparkline.vue'
+import type { TimeSeriesEntry } from '../../composables/useSVGTimeSeries'
+
+vi.mock('../../composables/useWeightUnit', () => ({
+  useWeightUnit: () => ({
+    weightUnit: { value: 'lbs' },
+    displayWeight: (w: number) => Math.round(w),
+    toLbs: (w: number) => w,
+  }),
+}))
+
+const series: TimeSeriesEntry[] = [
+  { date: '2026-03-02', value: 1000 },
+  { date: '2026-03-09', value: 0 },
+  { date: '2026-03-16', value: 1800 },
+]
+
+function mountSparkline(props?: Partial<{ series: TimeSeriesEntry[]; tag: string }>) {
+  return mount(TagVolumeSparkline, {
+    props: {
+      series: props?.series ?? series,
+      tag: props?.tag ?? 'Chest',
+    },
+  })
+}
+
+describe('TagVolumeSparkline', () => {
+  it('renders nothing with fewer than 2 points', () => {
+    const wrapper = mountSparkline({ series: [{ date: '2026-03-02', value: 1000 }] })
+    expect(wrapper.find('.mgSparkline').exists()).toBe(false)
+  })
+
+  it('renders the SVG line and area when it has data', () => {
+    const wrapper = mountSparkline()
+    expect(wrapper.find('.wtGraphSvg').exists()).toBe(true)
+    expect(wrapper.find('.wtGLine').exists()).toBe(true)
+    expect(wrapper.find('.wtGArea').exists()).toBe(true)
+  })
+
+  it('titles the chart with the tag name', () => {
+    const wrapper = mountSparkline({ tag: 'Legs' })
+    expect(wrapper.find('.wtGraphTitle').text()).toBe('Legs weekly volume')
+  })
+
+  it('exposes an accessible aria-label naming the tag and value range', () => {
+    const wrapper = mountSparkline({ tag: 'Back' })
+    const label = wrapper.find('.wtGraphSvg').attributes('aria-label') || ''
+    expect(label).toContain('Back weekly volume trend')
+    expect(label).toContain('3 weeks')
+  })
+
+  it('shows the max and min volume on the y-axis', () => {
+    const wrapper = mountSparkline()
+    const yLabels = wrapper.findAll('.wtGYLabel').map(t => t.text())
+    expect(yLabels).toContain('1.8k')
+    expect(yLabels).toContain('0')
+  })
+
+  it('abbreviates volumes at or above 1000 with a k suffix', () => {
+    const wrapper = mountSparkline({ series: [
+      { date: '2026-03-02', value: 12000 },
+      { date: '2026-03-09', value: 24500 },
+    ] })
+    const yLabels = wrapper.findAll('.wtGYLabel').map(t => t.text())
+    expect(yLabels).toContain('24.5k')
+    expect(yLabels).toContain('12.0k')
+  })
+})

--- a/src/composables/__tests__/useTagVolumeTrend.test.ts
+++ b/src/composables/__tests__/useTagVolumeTrend.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useTagVolumeTrend } from '../useTagVolumeTrend'
+import type { Exercise } from '../../stores/workout'
+
+function makeExercise(
+  name: string,
+  tags: string[],
+  sets: { date: string; weight?: number; reps?: number }[],
+): Exercise {
+  return {
+    id: name.toLowerCase().replace(/\s/g, '-'),
+    name,
+    tags,
+    sets: sets.map((s, i) => ({
+      id: `${name}-set-${i}`,
+      date: s.date,
+      weight: s.weight ?? 100,
+      reps: s.reps ?? 10,
+      estimated1RM: 133,
+    })),
+  }
+}
+
+describe('useTagVolumeTrend', () => {
+  it('buckets per-tag volume by ISO week', () => {
+    // Two distinct weeks for Chest.
+    const exercises = ref([
+      makeExercise('Bench', ['Chest'], [
+        { date: '2026-03-02T18:00:00.000Z', weight: 100, reps: 10 }, // week of Mar 2
+        { date: '2026-03-09T18:00:00.000Z', weight: 100, reps: 10 }, // week of Mar 9
+      ]),
+    ])
+
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    const chest = tagTrends.value['Chest']
+    expect(chest).toHaveLength(2)
+    expect(chest[0]).toEqual({ date: '2026-03-02', value: 1000 })
+    expect(chest[1]).toEqual({ date: '2026-03-09', value: 1000 })
+  })
+
+  it('sums volume across exercises sharing a tag in the same week', () => {
+    const exercises = ref([
+      makeExercise('Bench', ['Push'], [{ date: '2026-03-02T18:00:00.000Z', weight: 100, reps: 5 }]),
+      makeExercise('Overhead Press', ['Push'], [{ date: '2026-03-03T18:00:00.000Z', weight: 50, reps: 8 }]),
+    ])
+
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    // 100*5 + 50*8 = 500 + 400 = 900
+    expect(tagTrends.value['Push']).toEqual([{ date: '2026-03-02', value: 900 }])
+  })
+
+  it('fills intervening empty weeks with zero volume', () => {
+    const exercises = ref([
+      makeExercise('Squat', ['Legs'], [
+        { date: '2026-03-02T18:00:00.000Z' }, // week of Mar 2
+        { date: '2026-03-16T18:00:00.000Z' }, // week of Mar 16 (skips Mar 9)
+      ]),
+    ])
+
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    const legs = tagTrends.value['Legs']
+    expect(legs.map(e => e.date)).toEqual(['2026-03-02', '2026-03-09', '2026-03-16'])
+    expect(legs[1].value).toBe(0)
+  })
+
+  it('extends a neglected tag with a zero tail up to the most recent trained week', () => {
+    // Legs last trained Mar 2, but Chest keeps training through Mar 16.
+    const exercises = ref([
+      makeExercise('Squat', ['Legs'], [{ date: '2026-03-02T18:00:00.000Z' }]),
+      makeExercise('Bench', ['Chest'], [
+        { date: '2026-03-09T18:00:00.000Z' },
+        { date: '2026-03-16T18:00:00.000Z' },
+      ]),
+    ])
+
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    const legs = tagTrends.value['Legs']
+    // Legs starts Mar 2 and is padded with zeros through the global last week (Mar 16).
+    expect(legs.map(e => e.date)).toEqual(['2026-03-02', '2026-03-09', '2026-03-16'])
+    expect(legs[0].value).toBeGreaterThan(0)
+    expect(legs[1].value).toBe(0)
+    expect(legs[2].value).toBe(0)
+  })
+
+  it('ignores exercises without tags', () => {
+    const exercises = ref([
+      makeExercise('Custom', [], [{ date: '2026-03-02T18:00:00.000Z' }]),
+    ])
+
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    expect(tagTrends.value).toEqual({})
+  })
+
+  it('returns an empty map when there are no sets', () => {
+    const exercises = ref<Exercise[]>([])
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    expect(tagTrends.value).toEqual({})
+  })
+
+  it('reacts to exercise changes', () => {
+    const exercises = ref<Exercise[]>([])
+    const { tagTrends } = useTagVolumeTrend(exercises)
+    expect(tagTrends.value).toEqual({})
+
+    exercises.value = [
+      makeExercise('Bench', ['Chest'], [
+        { date: '2026-03-02T18:00:00.000Z' },
+        { date: '2026-03-09T18:00:00.000Z' },
+      ]),
+    ]
+    expect(tagTrends.value['Chest']).toHaveLength(2)
+  })
+})

--- a/src/composables/useTagVolumeTrend.ts
+++ b/src/composables/useTagVolumeTrend.ts
@@ -1,0 +1,87 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { Exercise } from '../stores/workout'
+import type { TimeSeriesEntry } from './useSVGTimeSeries'
+
+export interface UseTagVolumeTrendReturn {
+  /**
+   * Per-tag weekly training volume (weight × reps, in stored lbs) across the
+   * full set history. Each tag's series runs from that tag's first trained week
+   * to the most recent trained week across ALL tags, filling intervening (and
+   * trailing) gaps with zero so a neglected muscle group shows a declining /
+   * flat-zero tail rather than silently dropping off the chart.
+   */
+  tagTrends: ComputedRef<Record<string, TimeSeriesEntry[]>>
+}
+
+/** Monday (ISO week start) of a YYYY-MM-DD local date key. */
+function mondayOfWeek(dateKey: string): string {
+  const [y, m, d] = dateKey.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  const dow = date.getDay()
+  const daysSinceMonday = dow === 0 ? 6 : dow - 1
+  date.setDate(date.getDate() - daysSinceMonday)
+  return toKey(date)
+}
+
+/** Advance a YYYY-MM-DD week-start key by 7 days. */
+function nextWeek(weekStart: string): string {
+  const [y, m, d] = weekStart.split('-').map(Number)
+  const date = new Date(y, m - 1, d)
+  date.setDate(date.getDate() + 7)
+  return toKey(date)
+}
+
+function toKey(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+/**
+ * Aggregates per-tag training volume per ISO week across the full set history.
+ * Surfaces whether each muscle group's volume is climbing, holding, or being
+ * neglected over time — the trend counterpart to the weekly snapshot in
+ * {@link useTagVolume}.
+ */
+export function useTagVolumeTrend(exercises: Ref<Exercise[]>): UseTagVolumeTrendReturn {
+  const tagTrends = computed((): Record<string, TimeSeriesEntry[]> => {
+    // tag -> (weekStart -> volume)
+    const byTag = new Map<string, Map<string, number>>()
+    let globalLast: string | null = null
+
+    for (const exercise of exercises.value) {
+      if (!exercise.tags || exercise.tags.length === 0) continue
+      for (const set of exercise.sets) {
+        const wk = mondayOfWeek(set.date.slice(0, 10))
+        if (globalLast === null || wk > globalLast) globalLast = wk
+        const vol = set.weight * set.reps
+        for (const tag of exercise.tags) {
+          let weeks = byTag.get(tag)
+          if (!weeks) {
+            weeks = new Map<string, number>()
+            byTag.set(tag, weeks)
+          }
+          weeks.set(wk, (weeks.get(wk) ?? 0) + vol)
+        }
+      }
+    }
+
+    if (globalLast === null) return {}
+
+    const result: Record<string, TimeSeriesEntry[]> = {}
+    for (const [tag, weeks] of byTag) {
+      const firstWeek = [...weeks.keys()].sort()[0]
+      const series: TimeSeriesEntry[] = []
+      let cursor = firstWeek
+      while (cursor <= globalLast) {
+        series.push({ date: cursor, value: Math.round(weeks.get(cursor) ?? 0) })
+        cursor = nextWeek(cursor)
+      }
+      result[tag] = series
+    }
+    return result
+  })
+
+  return { tagTrends }
+}

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -216,6 +216,7 @@
         :weekly-volume="weeklyVolume"
         :max-sets="maxSets"
         :total-sets="totalSets"
+        :tag-trends="tagTrends"
         :collapsed="volumeCollapsed"
         @toggle-collapsed="volumeCollapsed = !volumeCollapsed"
       />
@@ -314,6 +315,7 @@ import { useWeightUnit } from '../composables/useWeightUnit'
 import { usePRBaseline } from '../composables/usePRBaseline'
 import { useModal } from '../composables/useModal'
 import { useTagVolume } from '../composables/useTagVolume'
+import { useTagVolumeTrend } from '../composables/useTagVolumeTrend'
 import { useTagRecovery } from '../composables/useTagRecovery'
 import { useVolumeTrend } from '../composables/useVolumeTrend'
 
@@ -611,6 +613,7 @@ const weekDays = computed(() => {
 const weekDateStrings = computed(() => weekDays.value.map(d => d.dateStr))
 const exercisesRef = computed(() => filteredExercises.value)
 const { weeklyVolume, maxSets, totalSets } = useTagVolume(exercisesRef, weekDateStrings)
+const { tagTrends } = useTagVolumeTrend(exercisesRef)
 
 // ── Week-over-week volume trend (full history, respects tag filter) ──
 const { weeklyVolume: volumeTrend, totalVolume: volumeTrendTotal } = useVolumeTrend(exercisesRef)


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-731](https://github.com/aschung212/Lift/issues/731)



## Changes




## Commits
- [`30094d1`](https://github.com/aschung212/Lift/commit/30094d1) feat(LIFT-731): add per-muscle-group volume trend drill-down

## Test Results
- Before: 2107 passing
- After: 2127 passing (20 delta)

---
_Automated by overnight pipeline — Tue Jun 16 00:36:08 PDT 2026_

## Preview
Test on your phone: https://lift-ny5xq9o9n-aschung212-1101s-projects.vercel.app