### PR TITLE
feat(LIFT-750): import shared Strong/Hevy CSV exports via Web Share Target

### DIFF
--- a/public/share-target-sw.js
+++ b/public/share-target-sw.js
@@ -1,0 +1,48 @@
+/* global self, caches, Response */
+/**
+ * Web Share Target handler for Lift.
+ *
+ * The PWA manifest registers a `share_target` (POST, multipart/form-data) at
+ * /share-target so users can share a Strong/Hevy/Lift CSV export from another
+ * app directly into Lift. This script is injected into the generated Workbox
+ * service worker via `workbox.importScripts` so its `fetch` listener is
+ * registered before Workbox's navigation routing — the first listener to call
+ * `respondWith` wins, so the POST never falls through to the index.html
+ * navigateFallback.
+ *
+ * Flow: extract the shared file -> stash its text in the Cache API under a
+ * known key -> 303-redirect to /?share-target=csv. The app reads and clears
+ * the cached entry on launch (see useShareTargetImport).
+ *
+ * Chromium/Android PWA only; iOS Safari does not implement Web Share Target.
+ */
+const SHARE_INBOX_CACHE = 'lift-share-inbox'
+const SHARE_INBOX_KEY = '/__shared-csv'
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  if (event.request.method === 'POST' && url.pathname === '/share-target') {
+    event.respondWith(handleShareTarget(event.request))
+  }
+})
+
+async function handleShareTarget(request) {
+  try {
+    const formData = await request.formData()
+    const file = formData.get('file')
+    if (file && typeof file.text === 'function') {
+      const text = await file.text()
+      if (text) {
+        const cache = await caches.open(SHARE_INBOX_CACHE)
+        await cache.put(
+          SHARE_INBOX_KEY,
+          new Response(text, { headers: { 'Content-Type': 'text/csv' } })
+        )
+      }
+    }
+  } catch {
+    // Swallow — a malformed share still redirects into the app, which simply
+    // finds nothing in the inbox and shows no import.
+  }
+  return Response.redirect('/?share-target=csv', 303)
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -125,6 +125,15 @@
       </Transition>
     </Teleport>
 
+    <!-- Shared CSV import toast (PWA Web Share Target) -->
+    <Teleport to="body">
+      <Transition name="undoToast">
+        <div v-if="shareImportToast" class="undoToastBar" role="status" aria-live="polite">
+          <span class="undoToastMsg">{{ shareImportToast }}</span>
+        </div>
+      </Transition>
+    </Teleport>
+
     <!-- Keyboard shortcuts help -->
     <Teleport to="body">
       <Transition name="undoToast">
@@ -225,6 +234,7 @@ import { requestPersistentStorage, ensureLocalStorage } from './lib/durableStora
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
 import { captureAcquisitionSource } from './composables/useAcquisitionSource'
+import { useShareTargetImport } from './composables/useShareTargetImport'
 import { usePreferencesStore } from './stores/preferences'
 import { useWorkoutStore } from './stores/workout'
 import { syncStatus } from './lib/syncQueue'
@@ -246,6 +256,27 @@ const { user, loading, init: initAuth, signOut } = useAuth()
 const { logEvent, tabSwitch, flushEngagement } = useAnalytics()
 const prefs = usePreferencesStore()
 const { toast: undoToast, performUndo } = useUndoToast()
+
+// ── Web Share Target (shared CSV import) ────────────────────────
+const { consumePendingShare } = useShareTargetImport()
+const shareImportToast = ref<string | null>(null)
+let shareToastTimer: ReturnType<typeof setTimeout> | null = null
+function showShareImportToast(message: string) {
+  shareImportToast.value = message
+  if (shareToastTimer) clearTimeout(shareToastTimer)
+  shareToastTimer = setTimeout(() => { shareImportToast.value = null }, 5000)
+}
+async function handleSharedCsvImport() {
+  const summary = await consumePendingShare()
+  if (!summary) return
+  switchTab('workouts')
+  if (summary.error) {
+    showShareImportToast(summary.error)
+  } else {
+    const fmt = summary.format.charAt(0).toUpperCase() + summary.format.slice(1)
+    showShareImportToast(`Imported ${summary.sets} sets from your ${fmt} export`)
+  }
+}
 
 // ── PWA install prompt ──────────────────────────────────────────
 const workoutStoreForInstall = useWorkoutStore()
@@ -573,10 +604,14 @@ onMounted(async () => {
       syncStatus.value = msg.status
     }
   })
+
+  // Consume a CSV shared into the app via the PWA Web Share Target.
+  handleSharedCsvImport()
 })
 let unsubCrossTab: (() => void) | null = null
 onUnmounted(() => {
   window.removeEventListener('beforeunload', onBeforeUnload)
   unsubCrossTab?.()
+  if (shareToastTimer) clearTimeout(shareToastTimer)
 })
 </script>

--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -660,7 +660,7 @@ import { useAnalytics } from '../composables/useAnalytics'
 import { hashUserId, buildJsonExport, buildCsvExport } from '../lib/dataExport'
 import { buildTrainingReport, type ReportPeriod } from '../lib/trainingReport'
 import { renderReport, openReportWindow } from '../lib/reportRenderer'
-import { importCSV } from '../lib/csvImport'
+import { useCsvImport } from '../composables/useCsvImport'
 import { usePreferencesStore } from '../stores/preferences'
 import type { WeightGoalDirection } from '../stores/preferences'
 import { useWorkoutStore } from '../stores/workout'
@@ -686,6 +686,7 @@ const progressionStore = useProgressionStore()
 const { celebrateUnlocks } = useXPCeremony()
 const { user } = useAuth()
 const { logEvent } = useAnalytics()
+const { importFromText } = useCsvImport()
 const prefs = usePreferencesStore()
 const workoutStore = useWorkoutStore()
 const bodyweightStore = useBodyweightStore()
@@ -1350,20 +1351,7 @@ function handleImportFile(event: Event) {
   const reader = new FileReader()
   reader.onload = () => {
     const text = reader.result as string
-    const result = importCSV(text)
-    if (result.format === 'unknown' || result.exercises.length === 0) {
-      importResult.value = { exercises: 0, sets: 0, format: 'unknown', error: 'Unrecognized format. Supported: Strong, Hevy, Lift CSV.' }
-      return
-    }
-    for (const ex of result.exercises) {
-      const existingId = workoutStore.addExercise(ex.name, ex.tags, { sync: false })
-      if (!existingId) continue
-      for (const set of ex.sets) {
-        workoutStore.logSet(existingId, set.weight, set.reps, set.date.slice(0, 10), { sync: false })
-      }
-    }
-    importResult.value = { exercises: result.exercises.length, sets: result.totalSets, format: result.format }
-    logEvent('data_import', { format: result.format, exercises: result.exercises.length, sets: result.totalSets })
+    importResult.value = importFromText(text, 'file')
   }
   reader.readAsText(file)
   if (importFileInput.value) importFileInput.value.value = ''

--- a/src/composables/__tests__/useCsvImport.test.ts
+++ b/src/composables/__tests__/useCsvImport.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn() },
+}))
+vi.mock('../../lib/conflictResolver', () => ({
+  mergeEntities: vi.fn(() => ({ merged: [], localOnly: [] })),
+}))
+
+const mockLogEvent = vi.fn()
+vi.mock('../useAnalytics', () => ({
+  useAnalytics: () => ({
+    logEvent: mockLogEvent,
+    tabSwitch: vi.fn(),
+    flushEngagement: vi.fn(),
+  }),
+}))
+
+import { useCsvImport } from '../useCsvImport'
+import { useWorkoutStore } from '../../stores/workout'
+
+const STRONG_CSV = `Date,Workout Name,Exercise Name,Set Order,Weight,Reps,Distance,Seconds,Notes,Workout Notes,RPE
+2026-04-01,Morning,Bench Press,1,185,5,,,,,
+2026-04-01,Morning,Bench Press,2,185,5,,,,,
+2026-04-01,Morning,Squat,1,225,3,,,,,`
+
+describe('useCsvImport', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+    mockLogEvent.mockReset()
+  })
+
+  it('writes parsed exercises and sets into the workout store', () => {
+    const { importFromText } = useCsvImport()
+    const summary = importFromText(STRONG_CSV)
+
+    expect(summary).toEqual({ exercises: 2, sets: 3, format: 'strong' })
+
+    const store = useWorkoutStore()
+    expect(store.exercises).toHaveLength(2)
+    const bench = store.exercises.find(e => e.name === 'Bench Press')!
+    expect(bench.sets).toHaveLength(2)
+    expect(bench.sets[0].weight).toBe(185)
+  })
+
+  it('logs a data_import analytics event tagged with the source', () => {
+    const { importFromText } = useCsvImport()
+    importFromText(STRONG_CSV, 'share_target')
+
+    expect(mockLogEvent).toHaveBeenCalledWith('data_import', {
+      format: 'strong',
+      exercises: 2,
+      sets: 3,
+      source: 'share_target',
+    })
+  })
+
+  it("defaults the source to 'file' when not specified", () => {
+    const { importFromText } = useCsvImport()
+    importFromText(STRONG_CSV)
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      'data_import',
+      expect.objectContaining({ source: 'file' }),
+    )
+  })
+
+  it('returns an error summary for unrecognized formats without writing or logging', () => {
+    const { importFromText } = useCsvImport()
+    const summary = importFromText('foo,bar,baz\n1,2,3')
+
+    expect(summary.format).toBe('unknown')
+    expect(summary.error).toBeTruthy()
+    expect(useWorkoutStore().exercises).toHaveLength(0)
+    expect(mockLogEvent).not.toHaveBeenCalled()
+  })
+
+  it('returns an error summary for empty input', () => {
+    const { importFromText } = useCsvImport()
+    const summary = importFromText('')
+    expect(summary.error).toBeTruthy()
+    expect(mockLogEvent).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/__tests__/useShareTargetImport.test.ts
+++ b/src/composables/__tests__/useShareTargetImport.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the shared importer so this suite focuses on the Share-Target plumbing
+// (query-param detection, Cache API read/clear) without touching Pinia.
+const importFromText = vi.fn()
+vi.mock('../useCsvImport', () => ({
+  useCsvImport: () => ({ importFromText }),
+}))
+
+import { useShareTargetImport } from '../useShareTargetImport'
+
+const SHARE_INBOX_CACHE = 'lift-share-inbox'
+const SHARE_INBOX_KEY = '/__shared-csv'
+
+class FakeCache {
+  store = new Map<string, Response>()
+  async match(key: string): Promise<Response | undefined> {
+    return this.store.get(key)
+  }
+  async put(key: string, res: Response): Promise<void> {
+    this.store.set(key, res)
+  }
+  async delete(key: string): Promise<boolean> {
+    return this.store.delete(key)
+  }
+}
+
+let cacheMap: Map<string, FakeCache>
+
+function setLocation(search: string): void {
+  window.history.replaceState({}, '', '/' + search)
+}
+
+async function seedInbox(text: string): Promise<void> {
+  const cache = cacheMap.get(SHARE_INBOX_CACHE) ?? new FakeCache()
+  cacheMap.set(SHARE_INBOX_CACHE, cache)
+  await cache.put(SHARE_INBOX_KEY, new Response(text, { headers: { 'Content-Type': 'text/csv' } }))
+}
+
+describe('useShareTargetImport', () => {
+  beforeEach(() => {
+    importFromText.mockReset()
+    importFromText.mockReturnValue({ exercises: 2, sets: 5, format: 'strong' })
+    setLocation('')
+    cacheMap = new Map<string, FakeCache>()
+    ;(globalThis as unknown as { caches: unknown }).caches = {
+      open: vi.fn(async (name: string) => {
+        if (!cacheMap.has(name)) cacheMap.set(name, new FakeCache())
+        return cacheMap.get(name)!
+      }),
+    }
+  })
+
+  it('hasPendingShare detects the share-target query flag', () => {
+    setLocation('?share-target=csv')
+    expect(useShareTargetImport().hasPendingShare()).toBe(true)
+  })
+
+  it('hasPendingShare is false without the flag', () => {
+    setLocation('?tab=calendar')
+    expect(useShareTargetImport().hasPendingShare()).toBe(false)
+  })
+
+  it('returns null and does not import when there is no pending share', async () => {
+    setLocation('')
+    const summary = await useShareTargetImport().consumePendingShare()
+    expect(summary).toBeNull()
+    expect(importFromText).not.toHaveBeenCalled()
+  })
+
+  it('imports the cached CSV and tags the source as share_target', async () => {
+    await seedInbox('Date,Exercise Name,Set Order,Weight,Reps\n2026-04-01,Bench,1,185,5')
+    setLocation('?share-target=csv')
+
+    const summary = await useShareTargetImport().consumePendingShare()
+
+    expect(importFromText).toHaveBeenCalledTimes(1)
+    expect(importFromText).toHaveBeenCalledWith(
+      expect.stringContaining('Bench'),
+      'share_target',
+    )
+    expect(summary).toEqual({ exercises: 2, sets: 5, format: 'strong' })
+  })
+
+  it('clears the cached inbox entry after consuming it', async () => {
+    await seedInbox('some,csv')
+    setLocation('?share-target=csv')
+
+    await useShareTargetImport().consumePendingShare()
+
+    const cache = cacheMap.get(SHARE_INBOX_CACHE)!
+    expect(await cache.match(SHARE_INBOX_KEY)).toBeUndefined()
+  })
+
+  it('strips the share-target param so a reload cannot replay the import', async () => {
+    await seedInbox('some,csv')
+    setLocation('?share-target=csv')
+
+    await useShareTargetImport().consumePendingShare()
+
+    expect(window.location.search).toBe('')
+  })
+
+  it('preserves unrelated query params while stripping share-target', async () => {
+    await seedInbox('some,csv')
+    setLocation('?share-target=csv&tab=calendar')
+
+    await useShareTargetImport().consumePendingShare()
+
+    expect(window.location.search).toBe('?tab=calendar')
+  })
+
+  it('returns null when the flag is set but the inbox is empty', async () => {
+    setLocation('?share-target=csv')
+    const summary = await useShareTargetImport().consumePendingShare()
+    expect(summary).toBeNull()
+    expect(importFromText).not.toHaveBeenCalled()
+  })
+
+  it('ignores a blank/whitespace-only shared file', async () => {
+    await seedInbox('   \n  ')
+    setLocation('?share-target=csv')
+    const summary = await useShareTargetImport().consumePendingShare()
+    expect(summary).toBeNull()
+    expect(importFromText).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when the Cache API is unavailable', async () => {
+    delete (globalThis as unknown as { caches?: unknown }).caches
+    setLocation('?share-target=csv')
+    await expect(useShareTargetImport().consumePendingShare()).resolves.toBeNull()
+    // The param is still cleared so the app does not loop on it.
+    expect(window.location.search).toBe('')
+  })
+})

--- a/src/composables/useCsvImport.ts
+++ b/src/composables/useCsvImport.ts
@@ -1,0 +1,50 @@
+import { importCSV } from '../lib/csvImport'
+import { useWorkoutStore } from '../stores/workout'
+import { useAnalytics } from './useAnalytics'
+
+export interface CsvImportSummary {
+  exercises: number
+  sets: number
+  format: string
+  error?: string
+}
+
+/**
+ * Shared CSV import flow used by both the Settings file-picker and the PWA
+ * Web Share Target. Parses Strong/Hevy/Lift CSV text, writes the resulting
+ * exercises and sets into the local-first workout store (sync deferred so the
+ * batch debounces into a single background push), and logs an analytics event
+ * tagged with the entry point.
+ */
+export function useCsvImport() {
+  const workoutStore = useWorkoutStore()
+  const { logEvent } = useAnalytics()
+
+  function importFromText(text: string, source: 'file' | 'share_target' = 'file'): CsvImportSummary {
+    const result = importCSV(text)
+    if (result.format === 'unknown' || result.exercises.length === 0) {
+      return {
+        exercises: 0,
+        sets: 0,
+        format: 'unknown',
+        error: 'Unrecognized format. Supported: Strong, Hevy, Lift CSV.',
+      }
+    }
+    for (const ex of result.exercises) {
+      const existingId = workoutStore.addExercise(ex.name, ex.tags, { sync: false })
+      if (!existingId) continue
+      for (const set of ex.sets) {
+        workoutStore.logSet(existingId, set.weight, set.reps, set.date.slice(0, 10), { sync: false })
+      }
+    }
+    logEvent('data_import', {
+      format: result.format,
+      exercises: result.exercises.length,
+      sets: result.totalSets,
+      source,
+    })
+    return { exercises: result.exercises.length, sets: result.totalSets, format: result.format }
+  }
+
+  return { importFromText }
+}

--- a/src/composables/useShareTargetImport.ts
+++ b/src/composables/useShareTargetImport.ts
@@ -1,0 +1,46 @@
+import { useCsvImport, type CsvImportSummary } from './useCsvImport'
+
+/**
+ * Client half of the PWA Web Share Target flow. The service worker
+ * (share-target-sw.js) stashes a shared CSV in the Cache API and redirects to
+ * /?share-target=csv; on launch the app calls `consumePendingShare` to read
+ * that cached file, run it through the shared importer, and clear the inbox so
+ * a reload never re-imports. Returns the import summary (or null when there is
+ * nothing to import) so the caller can surface a toast.
+ */
+const SHARE_INBOX_CACHE = 'lift-share-inbox'
+const SHARE_INBOX_KEY = '/__shared-csv'
+
+export function useShareTargetImport() {
+  const { importFromText } = useCsvImport()
+
+  function hasPendingShare(): boolean {
+    return new URLSearchParams(window.location.search).get('share-target') === 'csv'
+  }
+
+  function clearShareParam(): void {
+    const url = new URL(window.location.href)
+    url.searchParams.delete('share-target')
+    window.history.replaceState({}, '', url.pathname + url.search)
+  }
+
+  async function consumePendingShare(): Promise<CsvImportSummary | null> {
+    if (!hasPendingShare()) return null
+    // Strip the param up front so a manual reload can't replay the import.
+    clearShareParam()
+    if (typeof caches === 'undefined') return null
+    try {
+      const cache = await caches.open(SHARE_INBOX_CACHE)
+      const res = await cache.match(SHARE_INBOX_KEY)
+      if (!res) return null
+      const text = await res.text()
+      await cache.delete(SHARE_INBOX_KEY)
+      if (!text.trim()) return null
+      return importFromText(text, 'share_target')
+    } catch {
+      return null
+    }
+  }
+
+  return { hasPendingShare, consumePendingShare }
+}

--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -119,6 +119,28 @@ describe('PWA manifest regression tests', () => {
     })
   })
 
+  describe('manifest registers a Web Share Target for CSV import', () => {
+    it('has a share_target with the /share-target POST action', () => {
+      expect(viteConfig).toContain('share_target: {')
+      expect(viteConfig).toContain("action: '/share-target'")
+      expect(viteConfig).toContain("method: 'POST'")
+      expect(viteConfig).toContain("enctype: 'multipart/form-data'")
+    })
+
+    it('accepts CSV files under the "file" param', () => {
+      expect(viteConfig).toContain("name: 'file'")
+      expect(viteConfig).toContain("'text/csv'")
+    })
+
+    it('injects the share-target service worker handler via importScripts', () => {
+      expect(viteConfig).toContain("importScripts: ['share-target-sw.js']")
+    })
+
+    it('the share-target service worker handler exists in public/', () => {
+      expect(existsSync(resolve(publicDir, 'share-target-sw.js'))).toBe(true)
+    })
+  })
+
   describe('manifest includes screenshots for richer install UI', () => {
     it('has narrow (mobile) screenshot entries', () => {
       expect(viteConfig).toContain("form_factor: 'narrow'")

--- a/vite.config.js
+++ b/vite.config.js
@@ -102,6 +102,25 @@ export default defineConfig({
         launch_handler: {
           client_mode: 'navigate-existing',
         },
+        // Web Share Target: lets users share a Strong/Hevy/Lift CSV export from
+        // another app straight into Lift's importer. The POST is intercepted by
+        // the service worker (share-target-sw.js), which stashes the file in the
+        // Cache API and redirects to /?share-target=csv where the app consumes it.
+        // Chromium/Android PWA only — iOS Safari ignores share_target, so this is
+        // additive reach with no impact on the App Store build.
+        share_target: {
+          action: '/share-target',
+          method: 'POST',
+          enctype: 'multipart/form-data',
+          params: {
+            files: [
+              {
+                name: 'file',
+                accept: ['text/csv', 'text/comma-separated-values', '.csv'],
+              },
+            ],
+          },
+        },
         screenshots: [
           {
             src: 'screenshot-mobile.png',
@@ -134,6 +153,11 @@ export default defineConfig({
           'icon-source.png',
           'og-preview.html',
         ],
+        // Custom fetch handler for the Web Share Target POST (see manifest
+        // share_target above). importScripts registers it ahead of Workbox's
+        // own routing so the /share-target navigation is captured before the
+        // navigateFallback would otherwise serve index.html.
+        importScripts: ['share-target-sw.js'],
         navigateFallback: 'index.html',
         navigateFallbackDenylist: [/^\/api\//],
         navigationPreload: true,


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-750](https://github.com/aschung212/Lift/issues/750)



## Changes




## Commits
- [`a41b856`](https://github.com/aschung212/Lift/commit/a41b856) feat(LIFT-750): import shared Strong/Hevy CSV exports via Web Share Target

## Test Results
- Before: 2107 passing
- After: 2126 passing (19 delta)

---
_Automated by overnight pipeline — Tue Jun 16 01:19:10 PDT 2026_

## Preview
Test on your phone: https://lift-4bx5hxpc2-aschung212-1101s-projects.vercel.app