### PR TITLE
fix: drop the per-side plate breakdown from the warmup lens

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -458,7 +458,6 @@
                     <span class="wtPrTargetsReps">{{ Math.round(step.pct * 100) }}</span>
                     <span class="wtPrTargetsRepsLabel">%</span>
                     <span class="wtPrTargetsWeight">{{ displayWeight(step.weightLbs) }} {{ weightUnit }} × {{ step.reps }}</span>
-                    <span v-if="step.plates" class="wtPrTargetsE1rm">{{ step.plates.length ? formatPlates(step.plates) : 'bar' }}</span>
                   </button>
                 </div>
               </template>
@@ -741,7 +740,7 @@ import { usePRBurst } from '../composables/usePRBurst'
 import { useGoalCelebration } from '../composables/useGoalCelebration'
 import { decideGoalCelebration, readGoalCelebrationState, markGoalWeekCelebrated } from '../lib/goalCelebration'
 import { useProgressionStore } from '../stores/progression'
-import { platesToWeight, weightToPlates, formatPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
+import { platesToWeight, weightToPlates, LBS_PLATES, KG_PLATES } from '../lib/plateCalculator'
 import { generateWarmupRamp, type WarmupStep } from '../lib/warmupGenerator'
 import { calculateSetXP, calculateBest1RM, applyStreakMultiplier, checkRepPR, isExerciseEstablished, XP_CONFIG } from '../lib/xp'
 import { useXPCeremony } from '../composables/useXPCeremony'


### PR DESCRIPTION
Follow-up polish to the Suggestions drawer (#771, closes part of #770).

On-device (Eternal theme), the per-side plate-load strings in the Warmup lens — e.g. `1×45 + 1×25 + 1×10 + 1×5 + 1×2.5` — wrapped and crowded the rows, pushing the weight × reps onto two lines and looking messy.

This removes the plate-breakdown column from the warmup lens. The intensity % and weight × reps already convey each set, and plate loading stays available via the plate calculator on the weight input. The generator still computes per-side plates (used to seed the calculator when a row is tapped in plate mode) — only the display column is removed.

## Before / after
Before: `40 %   145 lbs × 8   1×45 + 1×5` (wraps on long loads)
After:  `40 %   ............   145 lbs × 8`

## Verification
- `npm run lint` clean; WorkoutTracker tests 149 pass (no assertion referenced the plate text).
- Verified in the dev preview (mobile, Eternal theme): warmup rows are single-line and clean; switching lenses, fill-on-tap, and the ghost-arm `Save` all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)