### PR TITLE
fix: suppress routine light tap when weekly-goal celebration haptic fires (closes #778)

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1024,17 +1024,22 @@ const weeklyGoalInfo = computed(() => {
  * so the two overlays never stack — the week is left unmarked so the
  * celebration still fires on the next non-PR set. The once-per-week guard lives
  * in device-local storage, mirroring the overload nudge.
+ *
+ * Returns `true` when a celebration (and its success/milestone haptic) actually
+ * fired, so the caller can suppress the routine light tap and avoid two native
+ * haptics colliding into a muddy buzz on Capacitor/iOS.
  */
-function maybeCelebrateWeeklyGoal(prShown: boolean): void {
-  if (prShown) return
+function maybeCelebrateWeeklyGoal(prShown: boolean): boolean {
+  if (prShown) return false
   const info = weeklyGoalInfo.value
-  if (!info) return
+  if (!info) return false
   const state = readGoalCelebrationState()
   const decision = decideGoalCelebration(info.met, progressionStore.streakWeeks, state.lastCelebratedWeek)
-  if (!decision) return
+  if (!decision) return false
   markGoalWeekCelebrated(decision.weekKey)
-  presentGoalCelebration({ streak: decision.streak, milestone: decision.milestone, target: info.target })
+  const celebrated = presentGoalCelebration({ streak: decision.streak, milestone: decision.milestone, target: info.target })
   logEvent('weekly_goal_celebrated', { streak: decision.streak, milestone: decision.milestone })
+  return celebrated
 }
 
 /**
@@ -2331,11 +2336,17 @@ function saveSet() {
         if (prCountBefore === 0) {
           logEvent('first_pr', { exercise: selectedExerciseName.value })
         }
-      } else {
+      }
+      // Celebrate the first weekly-goal completion of the week (LIFT-764). When
+      // it fires its own success/milestone haptic, suppress the routine light
+      // tap: two native haptics fired back-to-back collapse into a muddy /
+      // truncated buzz on Capacitor/iOS. The light tap stays for the common
+      // non-PR, no-celebration path. (PRs already played notifySuccess above and
+      // skip the goal banner, so they never reach the light tap.)
+      const celebrated = maybeCelebrateWeeklyGoal(wasPR)
+      if (!wasPR && !celebrated) {
         impactLight()
       }
-      // Celebrate the first weekly-goal completion of the week (LIFT-764).
-      maybeCelebrateWeeklyGoal(wasPR)
       if (restTimerEnabled.value && restTimerAutoStart.value) {
         timerCtrl.startRestTimer()
       }

--- a/src/composables/__tests__/useGoalCelebration.test.ts
+++ b/src/composables/__tests__/useGoalCelebration.test.ts
@@ -39,7 +39,10 @@ describe('useGoalCelebration', () => {
 
   it('presents the banner and fires a success haptic', () => {
     const { presentGoalCelebration, visible, payload } = useGoalCelebration()
-    presentGoalCelebration({ streak: 1, milestone: false, target: 3 })
+    const fired = presentGoalCelebration({ streak: 1, milestone: false, target: 3 })
+    // Returns true so the caller (saveSet) suppresses its routine light tap and
+    // the two native haptics don't collide on iOS.
+    expect(fired).toBe(true)
     expect(visible.value).toBe(true)
     expect(payload.value).toEqual({ streak: 1, milestone: false, target: 3 })
     expect(notifySuccessMock).toHaveBeenCalledTimes(1)
@@ -57,7 +60,10 @@ describe('useGoalCelebration', () => {
     const prefs = usePreferencesStore()
     prefs.setExperienceFlag('prCelebrations', false)
     const { presentGoalCelebration, visible } = useGoalCelebration()
-    presentGoalCelebration({ streak: 1, milestone: false, target: 3 })
+    const fired = presentGoalCelebration({ streak: 1, milestone: false, target: 3 })
+    // Returns false (no celebration haptic) so the caller still plays its
+    // routine light tap for the logged set.
+    expect(fired).toBe(false)
     expect(visible.value).toBe(false)
     expect(notifySuccessMock).not.toHaveBeenCalled()
   })

--- a/src/composables/useGoalCelebration.ts
+++ b/src/composables/useGoalCelebration.ts
@@ -30,11 +30,19 @@ const payload: Ref<GoalCelebrationPayload | null> = ref(null)
 let autoDismissId: ReturnType<typeof setTimeout> | null = null
 let clearPayloadId: ReturnType<typeof setTimeout> | null = null
 
-function presentGoalCelebration(p: GoalCelebrationPayload): void {
+/**
+ * Present the banner and fire its celebration haptic. Returns `true` when the
+ * celebration was actually presented (and thus a success / milestone haptic was
+ * fired), `false` when it was suppressed by the celebrations opt-out. Callers
+ * use the return value to avoid firing a second, colliding haptic: two native
+ * haptics fired back-to-back collapse into a muddy/truncated buzz on
+ * Capacitor/iOS (see WorkoutTracker.saveSet).
+ */
+function presentGoalCelebration(p: GoalCelebrationPayload): boolean {
   // Honor the celebrations opt-out (Settings → Experience).
   try {
     const prefs = usePreferencesStore()
-    if (prefs.experience?.prCelebrations === false) return
+    if (prefs.experience?.prCelebrations === false) return false
   } catch {
     // Pinia unavailable (e.g. some test setups) — proceed.
   }
@@ -57,6 +65,7 @@ function presentGoalCelebration(p: GoalCelebrationPayload): void {
   // Auto-dismiss — celebrations should never block the next set.
   if (autoDismissId !== null) clearTimeout(autoDismissId)
   autoDismissId = setTimeout(dismissGoalCelebration, AUTO_DISMISS_MS)
+  return true
 }
 
 function dismissGoalCelebration(): void {
@@ -73,7 +82,7 @@ function dismissGoalCelebration(): void {
 export interface UseGoalCelebrationReturn {
   visible: Ref<boolean>
   payload: Ref<GoalCelebrationPayload | null>
-  presentGoalCelebration: (p: GoalCelebrationPayload) => void
+  presentGoalCelebration: (p: GoalCelebrationPayload) => boolean
   dismissGoalCelebration: () => void
 }
 


### PR DESCRIPTION
## Summary

Fixes a haptic-feedback collision in `WorkoutTracker.saveSet()`. When a non-PR set was logged and the weekly training goal was met, two native haptics fired back-to-back — the routine `impactLight()` tap, then the celebration's `notifySuccess()` (and `impactHeavy()` on a milestone). Capacitor/iOS collapses simultaneous haptics into a muddy / truncated / skipped buzz.

The fix threads a "did a celebration haptic fire?" signal up from the composable so the routine tap is suppressed when the celebration takes precedence.

Closes #778.

## Changes

- **`useGoalCelebration.ts`** — `presentGoalCelebration` now returns `boolean`: `true` when it presents the banner (and fires its success/milestone haptic), `false` when the `prCelebrations` opt-out suppresses it. Interface updated.
- **`WorkoutTracker.vue` — `maybeCelebrateWeeklyGoal`** — now returns `boolean`, propagating that result (and `false` on every early-return).
- **`WorkoutTracker.vue` — `saveSet`** — evaluates the goal celebration first, then fires the light tap only when no celebration haptic played:
  ```js
  const celebrated = maybeCelebrateWeeklyGoal(wasPR)
  if (!wasPR && !celebrated) {
    impactLight()
  }
  ```

## Path-by-path behavior

| Path | Haptics |
|------|---------|
| non-PR + goal met | exactly one — the celebration's; light tap suppressed |
| non-PR + no goal (or celebrations opted out) | one — the light tap, as before |
| PR | `notifySuccess` + PRBurst; light tap gated out — unchanged |

## Testing

- Extended `useGoalCelebration.test.ts` to assert the new boolean contract via the existing haptic mocks (present → `true`; opt-out → `false` + no haptic).
- Full suite green: **2162 tests pass**. Lint clean. `npm run build` succeeds.

## Notes

- Pre-existing bug — **not** introduced by the Intensity-lens PR #770. Flagged by code review.
- Haptics no-op on desktop/iOS Safari, so this only manifests on the native Capacitor build — browser preview can't exercise it; verified via the test suite. (Related: #534 native walkthrough.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
