### PR TITLE
fix(#780): keep the log-set modal on the inputs after saving a set

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -762,6 +762,7 @@ import EditExerciseModal, { type EditExerciseSave } from './EditExerciseModal.vu
 import TagManagerModal from './TagManagerModal.vue'
 import ExercisePickerModal from './ExercisePickerModal.vue'
 import { scrollInputAboveKeyboard } from '../lib/keyboardViewport'
+import { ladderChipScrollLeft } from '../lib/ladderScroll'
 import { MAX_WEIGHT, MAX_REPS } from '../lib/inputLimits'
 import { loadJSON } from '../lib/storage'
 
@@ -1404,15 +1405,23 @@ const ghostArmed = computed(() =>
 )
 
 // Keep the highlighted "next" chip visible as the user works up the ladder.
+// HORIZONTAL ONLY: scrollIntoView() would scroll every ancestor, including the
+// vertical modal — yanking the inputs (and the just-saved confirmation) off
+// screen after each save (#780). We scroll the chip row by itself instead.
 const ladderChipsEl = ref<HTMLElement | null>(null)
 watch(nextRungIndex, async (idx) => {
   if (idx < 0 || !showModal.value) return
   await nextTick()
-  const el = ladderChipsEl.value?.querySelector('.wtPrevSessionChipNext')
-  if (el) {
-    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    el.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: reduced ? 'auto' : 'smooth' })
-  }
+  const container = ladderChipsEl.value
+  const el = container?.querySelector<HTMLElement>('.wtPrevSessionChipNext')
+  if (!container || !el) return
+  const delta = ladderChipScrollLeft(
+    container.getBoundingClientRect(),
+    el.getBoundingClientRect(),
+  )
+  if (delta === 0) return
+  const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  container.scrollBy({ left: delta, behavior: reduced ? 'auto' : 'smooth' })
 })
 
 // ── Overload nudge: rate-limited "go heavier" suggestion (#741) ───

--- a/src/lib/__tests__/ladderScroll.test.ts
+++ b/src/lib/__tests__/ladderScroll.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { ladderChipScrollLeft } from '../ladderScroll'
+
+/**
+ * Regression guard for #780: saving a set must keep the highlighted "next"
+ * ladder chip visible WITHOUT vertically scrolling the modal off the inputs.
+ * The fix replaced `scrollIntoView` (scrolls every ancestor) with a pure
+ * horizontal delta applied to the chip row alone. These tests pin the delta's
+ * "nearest edge, with inset" semantics so the bug can't silently return.
+ */
+describe('ladderChipScrollLeft', () => {
+  // A 200px-wide row positioned at viewport x = [100, 300].
+  const container = { left: 100, right: 300 }
+
+  it('returns 0 when the chip is already fully visible', () => {
+    expect(ladderChipScrollLeft(container, { left: 150, right: 190 })).toBe(0)
+  })
+
+  it('returns 0 when the chip sits exactly at the inset boundary', () => {
+    // inset defaults to 16 → comfortable zone is [116, 284].
+    expect(ladderChipScrollLeft(container, { left: 116, right: 284 })).toBe(0)
+  })
+
+  it('scrolls LEFT (negative) when the chip is off the left edge', () => {
+    // chip at [80, 120]: left (80) < container.left + inset (116).
+    // delta = 80 - 100 - 16 = -36.
+    expect(ladderChipScrollLeft(container, { left: 80, right: 120 })).toBe(-36)
+  })
+
+  it('scrolls RIGHT (positive) when the chip is off the right edge', () => {
+    // chip at [290, 360]: right (360) > container.right - inset (284).
+    // delta = 360 - 300 + 16 = 76.
+    expect(ladderChipScrollLeft(container, { left: 290, right: 360 })).toBe(76)
+  })
+
+  it('nudges a chip whose right edge intrudes into the inset zone', () => {
+    // chip at [250, 290]: right (290) > 284 → delta = 290 - 300 + 16 = 6.
+    expect(ladderChipScrollLeft(container, { left: 250, right: 290 })).toBe(6)
+  })
+
+  it('honors a custom inset', () => {
+    // inset 0 → comfortable zone is the raw container [100, 300].
+    expect(ladderChipScrollLeft(container, { left: 100, right: 300 }, 0)).toBe(0)
+    expect(ladderChipScrollLeft(container, { left: 305, right: 340 }, 0)).toBe(40)
+  })
+
+  it('prioritizes the left edge when a chip is wider than the row', () => {
+    // An over-wide chip [80, 400] trips the left branch first (matching
+    // scrollIntoView's left-anchoring) — delta = 80 - 100 - 16 = -36.
+    expect(ladderChipScrollLeft(container, { left: 80, right: 400 })).toBe(-36)
+  })
+})

--- a/src/lib/ladderScroll.ts
+++ b/src/lib/ladderScroll.ts
@@ -1,0 +1,46 @@
+/**
+ * Horizontal-only scrolling for the routine-ladder chip row (#780).
+ *
+ * The log-set modal keeps the highlighted "next" rung chip visible as the user
+ * works up the ladder. That nudge must be PURELY horizontal — the chips live in
+ * a horizontally-scrolling row (`.wtPrevSessionChips`) nested inside the
+ * vertically-scrolling modal (`.repMaxModal`).
+ *
+ * The old implementation used `Element.scrollIntoView({ block: 'nearest' })`,
+ * which scrolls EVERY scroll ancestor. With the keyboard up and the modal
+ * scrolled down to the inputs (chip row off the top), saving a set yanked the
+ * modal back up to reveal the chip and pushed the weight/reps inputs — and the
+ * just-saved confirmation — off-screen. This helper computes only the horizontal
+ * delta, which the caller applies via `container.scrollBy`, leaving vertical
+ * scroll untouched.
+ */
+
+/** The horizontal extent (in viewport px) of an element — `getBoundingClientRect`'s left/right. */
+export interface HorizontalBounds {
+  left: number
+  right: number
+}
+
+/**
+ * Horizontal scroll delta (px, for `scrollBy`'s `left`) that brings `el` fully
+ * inside `container` with `inset` breathing room at each edge. Returns:
+ *   - a negative value when the chip sits off the left edge (scroll left),
+ *   - a positive value when it sits off the right edge (scroll right),
+ *   - 0 when it is already visible (no scroll — never disturbs the row).
+ *
+ * Mirrors `scrollIntoView({ inline: 'nearest' })`: the chip is moved to the
+ * NEAREST edge, not centered, so an already-visible chip never jumps.
+ */
+export function ladderChipScrollLeft(
+  container: HorizontalBounds,
+  el: HorizontalBounds,
+  inset = 16,
+): number {
+  if (el.left < container.left + inset) {
+    return el.left - container.left - inset
+  }
+  if (el.right > container.right - inset) {
+    return el.right - container.right + inset
+  }
+  return 0
+}


### PR DESCRIPTION
Closes #780.

## Problem

After saving a set in the log-set modal, the modal auto-scrolled vertically and the user had to scroll back down to bring the weight/reps inputs into view. Because the modal scrolled away from the input area, the user also lost the visual confirmation that the set logged — the ladder chip flipping to its `done` state (and the next chip highlighting) happened off-screen.

## Root cause

The `nextRungIndex` watcher in `WorkoutTracker.vue` keeps the highlighted "next" ladder chip visible as the user works up the routine ladder. It did so via:

```ts
el.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: ... })
```

The intent is purely **horizontal** — keep the next chip visible inside the horizontally-scrolling `.wtPrevSessionChips` row. But `Element.scrollIntoView()` scrolls **every** scroll ancestor, including the vertically-scrolling `.repMaxModal`. With the keyboard up and the modal scrolled down to the inputs (so the chip row is off the top), saving a set fired the watcher, which scrolled the modal back up to reveal the chip — pushing the inputs (and the just-saved confirmation) out of view.

## Fix

Replace `scrollIntoView` with a horizontal-only `scrollBy` on the chip row container, computed by a new pure helper `ladderChipScrollLeft` (`src/lib/ladderScroll.ts`). It returns the nearest-edge delta with edge inset, or `0` when the chip is already visible. Vertical modal scroll is never touched, so the inputs stay put and the `done`/`next` chip confirmation stays visible.

## Verification

Browser preview (mobile 375×430, keyboard simulated by shrinking the viewport so the modal overflows vertically), seeded with a 7-rung usual ladder:

| | before fix (old `scrollIntoView`) | after fix |
|---|---|---|
| modal vertical scroll after save | yanks up to reveal chip | **stays pinned to the inputs** (`scrollTop` == max) |
| weight input after save | scrolled off-screen | **stays visible**, same position |
| saved chip → `done` state | confirmed off-screen | **confirmed in place** |
| next chip horizontal visibility | (worked, via side effect) | **still scrolls the row horizontally** to keep it in view (`scrollLeft` 0 → 77 when the next chip went off the right edge) |

No console errors. Lint clean, full test suite green (2192 tests), production build passes.

## Tests

`src/lib/__tests__/ladderScroll.test.ts` pins the nearest-edge-with-inset delta semantics (already-visible → 0, off-left → negative, off-right → positive, custom inset, over-wide chip left-anchoring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)