### PR TITLE
fix(LIFT-782): make stop() a terminal freeze so a stray enqueue can't resurrect data

### DIFF
--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -58,11 +58,13 @@ vi.mock('../../lib/supabase', () => ({
 // Mock syncQueue
 const mockSyncQueueClear = vi.fn()
 const mockSyncQueueStop = vi.fn()
+const mockSyncQueueResume = vi.fn()
 const mockSyncQueueRehydrate = vi.fn().mockResolvedValue(undefined)
 vi.mock('../../lib/syncQueue', () => ({
   syncQueue: {
     clear: () => mockSyncQueueClear(),
     stop: () => mockSyncQueueStop(),
+    resume: () => mockSyncQueueResume(),
     rehydrate: () => mockSyncQueueRehydrate(),
   }
 }))
@@ -345,14 +347,16 @@ describe('useAuth', () => {
 
       mockSyncQueueClear.mockClear()
       mockSyncQueueStop.mockClear()
+      mockSyncQueueResume.mockClear()
       await expect(deleteAccount()).rejects.toThrow('Failed to delete server data. Please try again.')
 
       // Local data must NOT have been wiped — the user can retry the deletion.
       expect(localStorage.getItem('workout-exercises')).toBe('precious-data')
-      // The queue is stopped (to prevent mid-delete resurrection) but the
-      // durable journal is NOT cleared, so pending offline writes survive a
-      // failed deletion and resume on the next mutation.
+      // The queue is stopped (to prevent mid-delete resurrection) and then
+      // resumed so the user can keep working; it is NEVER cleared on failure,
+      // so pending offline writes survive in the durable journal.
       expect(mockSyncQueueStop).toHaveBeenCalled()
+      expect(mockSyncQueueResume).toHaveBeenCalled()
       expect(mockSyncQueueClear).not.toHaveBeenCalled()
     })
 

--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -57,10 +57,12 @@ vi.mock('../../lib/supabase', () => ({
 
 // Mock syncQueue
 const mockSyncQueueClear = vi.fn()
+const mockSyncQueueStop = vi.fn()
 const mockSyncQueueRehydrate = vi.fn().mockResolvedValue(undefined)
 vi.mock('../../lib/syncQueue', () => ({
   syncQueue: {
     clear: () => mockSyncQueueClear(),
+    stop: () => mockSyncQueueStop(),
     rehydrate: () => mockSyncQueueRehydrate(),
   }
 }))
@@ -342,12 +344,15 @@ describe('useAuth', () => {
       })
 
       mockSyncQueueClear.mockClear()
+      mockSyncQueueStop.mockClear()
       await expect(deleteAccount()).rejects.toThrow('Failed to delete server data. Please try again.')
 
       // Local data must NOT have been wiped — the user can retry the deletion.
       expect(localStorage.getItem('workout-exercises')).toBe('precious-data')
-      // The durable sync journal must be preserved on failure so pending
-      // offline writes survive a failed deletion (cleared only after success).
+      // The queue is stopped (to prevent mid-delete resurrection) but the
+      // durable journal is NOT cleared, so pending offline writes survive a
+      // failed deletion and resume on the next mutation.
+      expect(mockSyncQueueStop).toHaveBeenCalled()
       expect(mockSyncQueueClear).not.toHaveBeenCalled()
     })
 

--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -309,6 +309,27 @@ describe('useAuth', () => {
       await expect(deleteAccount()).rejects.toThrow('Failed to delete server data. Please try again.')
     })
 
+    // Regression LIFT-782: Supabase DELETEs RESOLVE with a non-null `.error`
+    // (not reject) on a DB/RLS failure. deleteAccount must treat that as a hard
+    // failure and abort BEFORE wiping any local data, or the user's rows are
+    // orphaned on the server while the app reports success (privacy/GDPR).
+    it('throws and preserves local data when a Supabase delete resolves with an error', async () => {
+      const { deleteAccount, devSignIn } = useAuth()
+      await devSignIn()
+
+      localStorage.setItem('workout-exercises', 'precious-data')
+
+      // One of the deletes resolves with an error rather than rejecting
+      mockDelete.mockReturnValueOnce({
+        eq: vi.fn().mockResolvedValue({ error: { message: 'RLS policy violation' } })
+      })
+
+      await expect(deleteAccount()).rejects.toThrow('Failed to delete server data. Please try again.')
+
+      // Local data must NOT have been wiped — the user can retry the deletion.
+      expect(localStorage.getItem('workout-exercises')).toBe('precious-data')
+    })
+
     it('deletes all IndexedDB databases via indexedDB.databases() when available', async () => {
       const mockDeleteDatabase = vi.fn()
       const mockDatabases = vi.fn().mockResolvedValue([

--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -233,6 +233,23 @@ describe('useAuth', () => {
     })
   })
 
+  // Regression LIFT-782: migrate.ts now throws on a DB/RLS insert failure.
+  // initStores must swallow that so a migration error can't soft-lock the app
+  // (the init callers don't await its rejection, so an uncaught throw would
+  // leave `loading` stuck and the user signed-in state unset).
+  it('does not throw when the localStorage migration fails during init', async () => {
+    const migrateMod = await import('../../lib/migrate')
+    vi.mocked(migrateMod.migrateLocalStorageToSupabase).mockRejectedValueOnce(
+      new Error('Migration failed inserting exercises: RLS policy violation')
+    )
+
+    const { devSignIn, user } = useAuth()
+
+    await expect(devSignIn()).resolves.toBeUndefined()
+    // The user is still signed in locally — migration failure is non-fatal.
+    expect(user.value).not.toBeNull()
+  })
+
   describe('deleteAccount', () => {
     it('clears all localStorage keys used by the app', async () => {
       const { deleteAccount, devSignIn } = useAuth()
@@ -324,10 +341,14 @@ describe('useAuth', () => {
         eq: vi.fn().mockResolvedValue({ error: { message: 'RLS policy violation' } })
       })
 
+      mockSyncQueueClear.mockClear()
       await expect(deleteAccount()).rejects.toThrow('Failed to delete server data. Please try again.')
 
       // Local data must NOT have been wiped — the user can retry the deletion.
       expect(localStorage.getItem('workout-exercises')).toBe('precious-data')
+      // The durable sync journal must be preserved on failure so pending
+      // offline writes survive a failed deletion (cleared only after success).
+      expect(mockSyncQueueClear).not.toHaveBeenCalled()
     })
 
     it('deletes all IndexedDB databases via indexedDB.databases() when available', async () => {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -69,7 +69,17 @@ async function initStores(userId: string): Promise<void> {
   const bodyweightStore = useBodyweightStore()
   const preferencesStore = usePreferencesStore()
   const progressionStore = useProgressionStore()
-  await migrateLocalStorageToSupabase(userId)
+  // A migration failure (e.g. a transient RLS/server error on insert, which
+  // migrate.ts now throws on rather than swallowing) must NOT soft-lock the app
+  // on the loading screen — these callers don't await initStores' rejection, so
+  // an uncaught throw would leave `loading` stuck true. The local-first stores
+  // work without the migration and it retries on the next launch; log it so the
+  // failure stays observable instead of silently swallowed (LIFT-782).
+  try {
+    await migrateLocalStorageToSupabase(userId)
+  } catch (err) {
+    logError(err, { source: 'useAuth', action: 'migrate' })
+  }
   // Replay any writes that were journaled to IndexedDB but never reached the
   // server before the app last closed (LIFT-706). Safe + idempotent; runs
   // before store fetches so recovered writes are in flight during sync.
@@ -170,13 +180,11 @@ async function signOut(): Promise<void> {
  * Throws if Supabase deletion fails so the caller can show an error.
  */
 async function deleteAccount(): Promise<void> {
-  // Cancel any pending sync operations to avoid racing with deletion
-  syncQueue.clear()
-
   const userId = user.value?.id
   if (supabase && userId) {
-    // Delete from Supabase tables. exercises CASCADE deletes sets.
-    // Order: leaf tables first, then tables with foreign keys.
+    // Delete every table the user owns. Each row references only auth.users(id)
+    // (exercises additionally CASCADE-deletes sets), so there are no inter-table
+    // foreign-key dependencies and the deletes can safely run concurrently.
     const results = await Promise.allSettled([
       supabase.from('xp_events').delete().eq('user_id', userId),
       supabase.from('progression_snapshots').delete().eq('user_id', userId),
@@ -196,9 +204,19 @@ async function deleteAccount(): Promise<void> {
       r.status === 'rejected' || (r.value as { error: unknown } | null)?.error != null
     )
     if (failed) {
+      // Abort BEFORE touching any local state so the user can retry. The sync
+      // journal is left intact (it is only cleared after a confirmed delete
+      // below), so pending offline writes survive a failed deletion (LIFT-782).
       throw new Error('Failed to delete server data. Please try again.')
     }
   }
+
+  // Server data is gone (or there was none) — only now is it safe to discard
+  // pending sync operations. Clearing here (rather than at the top) means a
+  // FAILED server deletion above preserves the durable journal so the user
+  // doesn't lose unsynced writes; on success it stops a queued write from
+  // resurrecting the just-deleted rows before we wipe local state (LIFT-782).
+  syncQueue.clear()
 
   // Clear all localStorage keys used by the app
   const localStorageKeys = [

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -180,6 +180,12 @@ async function signOut(): Promise<void> {
  * Throws if Supabase deletion fails so the caller can show an error.
  */
 async function deleteAccount(): Promise<void> {
+  // Halt the sync queue (without discarding the journal) so an in-flight or
+  // debounced write can't resurrect a row mid-delete. We deliberately do NOT
+  // clear() here: if the server deletion below fails, the preserved journal
+  // lets the user's unsynced work survive for a retry (LIFT-782).
+  syncQueue.stop()
+
   const userId = user.value?.id
   if (supabase && userId) {
     // Delete every table the user owns. Each row references only auth.users(id)
@@ -205,17 +211,15 @@ async function deleteAccount(): Promise<void> {
     )
     if (failed) {
       // Abort BEFORE touching any local state so the user can retry. The sync
-      // journal is left intact (it is only cleared after a confirmed delete
-      // below), so pending offline writes survive a failed deletion (LIFT-782).
+      // journal was only stopped (not cleared) above, so pending offline writes
+      // survive a failed deletion and resume on the next mutation (LIFT-782).
       throw new Error('Failed to delete server data. Please try again.')
     }
   }
 
-  // Server data is gone (or there was none) — only now is it safe to discard
-  // pending sync operations. Clearing here (rather than at the top) means a
-  // FAILED server deletion above preserves the durable journal so the user
-  // doesn't lose unsynced writes; on success it stops a queued write from
-  // resurrecting the just-deleted rows before we wipe local state (LIFT-782).
+  // Server data is gone (or there was none) — only now discard the pending
+  // sync operations and durable journal so a queued write can't re-push the
+  // just-deleted rows, then wipe local state.
   syncQueue.clear()
 
   // Clear all localStorage keys used by the app

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -181,10 +181,12 @@ async function signOut(): Promise<void> {
  */
 async function deleteAccount(): Promise<void> {
   // Halt the sync queue (without discarding the journal) so an in-flight or
-  // debounced write can't resurrect a row mid-delete. We deliberately do NOT
-  // clear() here: if the server deletion below fails, the preserved journal
-  // lets the user's unsynced work survive for a retry (LIFT-782).
-  syncQueue.stop()
+  // debounced write can't resurrect a row mid-delete. Awaiting stop() ensures
+  // any flush already on the network settles BEFORE we delete, so no upsert
+  // lands afterward. We deliberately do NOT clear() here: if the server
+  // deletion below fails, the preserved journal lets the user's unsynced work
+  // survive for a retry (LIFT-782).
+  await syncQueue.stop()
 
   const userId = user.value?.id
   if (supabase && userId) {

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -186,9 +186,16 @@ async function deleteAccount(): Promise<void> {
       supabase.from('exercises').delete().eq('user_id', userId), // cascades to sets
     ])
 
-    // Check for hard failures (network errors, not RLS/empty-table errors)
-    const failed = results.filter(r => r.status === 'rejected')
-    if (failed.length > 0) {
+    // Supabase query builders RESOLVE (not reject) when a DELETE fails at the
+    // DB/RLS layer — the failure is surfaced in the resolved object's `.error`
+    // field, and the promise only rejects on transport errors. Treat BOTH a
+    // rejected promise AND a resolved-with-error response as a hard failure, so
+    // a silent server-side delete failure never lets us wipe local data while
+    // the user's rows remain on the server (privacy/GDPR orphaning, LIFT-782).
+    const failed = results.some(r =>
+      r.status === 'rejected' || (r.value as { error: unknown } | null)?.error != null
+    )
+    if (failed) {
       throw new Error('Failed to delete server data. Please try again.')
     }
   }

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -212,9 +212,11 @@ async function deleteAccount(): Promise<void> {
       r.status === 'rejected' || (r.value as { error: unknown } | null)?.error != null
     )
     if (failed) {
-      // Abort BEFORE touching any local state so the user can retry. The sync
-      // journal was only stopped (not cleared) above, so pending offline writes
-      // survive a failed deletion and resume on the next mutation (LIFT-782).
+      // Abort BEFORE touching any local state so the user can retry. Resume the
+      // sync queue (it was frozen by stop() above) so the user can keep working;
+      // the durable journal was never cleared, so unsynced writes survive the
+      // failed deletion (LIFT-782).
+      syncQueue.resume()
       throw new Error('Failed to delete server data. Please try again.')
     }
   }

--- a/src/lib/__tests__/migrate.test.ts
+++ b/src/lib/__tests__/migrate.test.ts
@@ -21,8 +21,8 @@ vi.mock('../supabase', () => ({
           }
         },
         insert: (rows: unknown[]) => {
-          mockInsert(table, rows)
-          return Promise.resolve({ error: null })
+          const result = mockInsert(table, rows)
+          return Promise.resolve(result ?? { error: null })
         },
       }
     },
@@ -153,5 +153,59 @@ describe('migrateLocalStorageToSupabase', () => {
     await migrateLocalStorageToSupabase('user-1')
 
     expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  // Regression LIFT-782: Supabase inserts RESOLVE with an `.error` field on a
+  // DB/RLS failure rather than rejecting. The migration must surface that as a
+  // thrown error so it is not silently marked complete and can be re-run.
+  it('throws and skips dependent set inserts when the exercises insert fails', async () => {
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      {
+        name: 'Bench Press',
+        sets: [{ date: '2026-03-30', weight: 100, reps: 8, estimated1RM: 125 }],
+      },
+    ])
+
+    // exercises insert resolves with an error (e.g. RLS denial)
+    mockInsert.mockReturnValueOnce({ error: { message: 'RLS policy violation' } })
+
+    await expect(migrateLocalStorageToSupabase('user-1')).rejects.toThrow(
+      /Migration failed inserting exercises/
+    )
+
+    // Sets must NOT be inserted when the parent exercises insert failed —
+    // otherwise we strand sets pointing at rows that don't exist.
+    expect(mockInsert).toHaveBeenCalledWith('exercises', expect.anything())
+    expect(mockInsert).not.toHaveBeenCalledWith('sets', expect.anything())
+  })
+
+  it('throws when the sets insert fails after exercises succeed', async () => {
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      {
+        name: 'Squat',
+        sets: [{ date: '2026-03-30', weight: 140, reps: 5, estimated1RM: 163 }],
+      },
+    ])
+
+    // exercises insert succeeds, sets insert resolves with an error
+    mockInsert
+      .mockReturnValueOnce({ error: null })
+      .mockReturnValueOnce({ error: { message: 'server error' } })
+
+    await expect(migrateLocalStorageToSupabase('user-1')).rejects.toThrow(
+      /Migration failed inserting sets/
+    )
+  })
+
+  it('throws when the bodyweight insert fails', async () => {
+    localStorageMock['bodyweight-entries'] = JSON.stringify([
+      { date: '2026-03-30', weight: 185 },
+    ])
+
+    mockInsert.mockReturnValueOnce({ error: { message: 'server error' } })
+
+    await expect(migrateLocalStorageToSupabase('user-1')).rejects.toThrow(
+      /Migration failed inserting bodyweight entries/
+    )
   })
 })

--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -147,6 +147,29 @@ describe('SyncQueue', () => {
     expect(queue.pending).toBe(0)
   })
 
+  it('stop() awaits an in-flight flush and suppresses retry repopulation', async () => {
+    const queue = new SyncQueue(100)
+    let rejectOp: (() => void) | null = null
+    const op = vi.fn().mockImplementation(
+      () => new Promise<void>((_resolve, reject) => { rejectOp = () => reject(new Error('network fail')) })
+    )
+
+    queue.enqueue('a', op)
+    // Kick off a flush so the op is mid-network (the promise is unresolved).
+    const flushPromise = queue.flush()
+    expect(op).toHaveBeenCalledOnce()
+
+    // Stop mid-flight, then let the in-flight op fail.
+    const stopPromise = queue.stop()
+    rejectOp!()
+    await stopPromise
+    await flushPromise
+
+    // A failed op would normally be requeued for retry; once stopped it must
+    // NOT be — the queue is being torn down, so nothing resurrects it.
+    expect(queue.pending).toBe(0)
+  })
+
   it('should not double-flush if flush() called while already flushing', async () => {
     const queue = new SyncQueue(100)
     let callCount = 0

--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -147,7 +147,7 @@ describe('SyncQueue', () => {
     expect(queue.pending).toBe(0)
   })
 
-  it('stop() awaits the in-flight flush; a following clear() tears it down with no retry', async () => {
+  it('stop() leaves no live timer even when the awaited in-flight flush fails', async () => {
     const queue = new SyncQueue(100)
     let rejectOp: (() => void) | null = null
     const op = vi.fn().mockImplementation(
@@ -161,21 +161,48 @@ describe('SyncQueue', () => {
 
     // stop() must not resolve until the in-flight op settles.
     const stopPromise = queue.stop()
-    rejectOp!()
+    rejectOp!() // in-flight op fails WHILE stopped
     await stopPromise
     await flushPromise
 
-    // The awaited flush ran to completion: the failed op was requeued for retry
-    // (so the failure path resumes naturally) rather than being silently lost.
+    // The settling flush requeued the failed op (so it isn't lost)...
     expect(queue.pending).toBe(1)
 
-    // On a confirmed deletion the caller clears the queue; because stop()
-    // already settled the flush, clear() tears down all retry state and no
-    // background flush re-fires for the signed-out user.
-    queue.clear()
-    expect(queue.pending).toBe(0)
+    // ...but it armed NO timer (the schedulers are inhibited while stopped), so
+    // advancing well past any retry backoff re-runs nothing. This is what stops
+    // an upsert from firing mid-deletion and resurrecting a row (LIFT-782).
+    vi.advanceTimersByTime(120000)
     await vi.runAllTimersAsync()
     expect(op).toHaveBeenCalledOnce()
+
+    // A confirmed deletion then tears everything down cleanly.
+    queue.clear()
+    expect(queue.pending).toBe(0)
+  })
+
+  it('resumes a stranded retry on the next enqueue after a stop()', async () => {
+    const queue = new SyncQueue(100)
+    let rejectOp: (() => void) | null = null
+    const failingOp = vi.fn().mockImplementation(
+      () => new Promise<void>((_resolve, reject) => { rejectOp = () => reject(new Error('fail')) })
+    )
+
+    queue.enqueue('a', failingOp)
+    const flushPromise = queue.flush()
+    const stopPromise = queue.stop()
+    rejectOp!()
+    await stopPromise
+    await flushPromise
+    // 'a' is stranded in the retry queue with no timer.
+    expect(queue.pending).toBe(1)
+
+    // A new write resumes the queue and re-arms the stranded retry.
+    const okOp = vi.fn().mockResolvedValue(undefined)
+    failingOp.mockResolvedValue(undefined) // 'a' now succeeds on retry
+    queue.enqueue('b', okOp)
+    await vi.runAllTimersAsync()
+    expect(okOp).toHaveBeenCalled()
+    expect(queue.pending).toBe(0)
   })
 
   it('should not double-flush if flush() called while already flushing', async () => {

--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -147,7 +147,7 @@ describe('SyncQueue', () => {
     expect(queue.pending).toBe(0)
   })
 
-  it('stop() awaits an in-flight flush and suppresses retry repopulation', async () => {
+  it('stop() awaits the in-flight flush; a following clear() tears it down with no retry', async () => {
     const queue = new SyncQueue(100)
     let rejectOp: (() => void) | null = null
     const op = vi.fn().mockImplementation(
@@ -159,15 +159,23 @@ describe('SyncQueue', () => {
     const flushPromise = queue.flush()
     expect(op).toHaveBeenCalledOnce()
 
-    // Stop mid-flight, then let the in-flight op fail.
+    // stop() must not resolve until the in-flight op settles.
     const stopPromise = queue.stop()
     rejectOp!()
     await stopPromise
     await flushPromise
 
-    // A failed op would normally be requeued for retry; once stopped it must
-    // NOT be — the queue is being torn down, so nothing resurrects it.
+    // The awaited flush ran to completion: the failed op was requeued for retry
+    // (so the failure path resumes naturally) rather than being silently lost.
+    expect(queue.pending).toBe(1)
+
+    // On a confirmed deletion the caller clears the queue; because stop()
+    // already settled the flush, clear() tears down all retry state and no
+    // background flush re-fires for the signed-out user.
+    queue.clear()
     expect(queue.pending).toBe(0)
+    await vi.runAllTimersAsync()
+    expect(op).toHaveBeenCalledOnce()
   })
 
   it('should not double-flush if flush() called while already flushing', async () => {

--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -110,6 +110,43 @@ describe('SyncQueue', () => {
     expect(op).not.toHaveBeenCalled()
   })
 
+  // LIFT-782: stop() halts the debounce flush WITHOUT discarding queued work,
+  // so account deletion can prevent a mid-delete resurrection while still
+  // preserving unsynced writes if the deletion fails.
+  it('stop() halts the pending flush but preserves queued operations', () => {
+    const queue = new SyncQueue(500)
+    const op = vi.fn().mockResolvedValue(undefined)
+
+    queue.enqueue('a', op)
+    queue.enqueue('b', op)
+    expect(queue.pending).toBe(2)
+
+    queue.stop()
+    // Timer cancelled — op must not fire even after the debounce window passes.
+    vi.advanceTimersByTime(1000)
+    expect(op).not.toHaveBeenCalled()
+    // But the work is preserved (unlike clear()).
+    expect(queue.pending).toBe(2)
+  })
+
+  it('stop() preserves the durable journal so a later enqueue can resume it', async () => {
+    const queue = new SyncQueue(500)
+    const op = vi.fn().mockResolvedValue(undefined)
+
+    queue.enqueue('a', op, { op: 'upsert', table: 'exercises', row: { id: 'a' } })
+    expect(queue.journalSize).toBe(1)
+
+    queue.stop()
+    expect(queue.journalSize).toBe(1)
+
+    // A subsequent enqueue reschedules a flush that drains the preserved work.
+    queue.enqueue('b', op)
+    vi.advanceTimersByTime(500)
+    await vi.runAllTimersAsync()
+    expect(op).toHaveBeenCalled()
+    expect(queue.pending).toBe(0)
+  })
+
   it('should not double-flush if flush() called while already flushing', async () => {
     const queue = new SyncQueue(100)
     let callCount = 0

--- a/src/lib/__tests__/syncQueue.test.ts
+++ b/src/lib/__tests__/syncQueue.test.ts
@@ -129,22 +129,40 @@ describe('SyncQueue', () => {
     expect(queue.pending).toBe(2)
   })
 
-  it('stop() preserves the durable journal so a later enqueue can resume it', async () => {
+  it('stop() preserves the durable journal; resume() drains the preserved work', async () => {
     const queue = new SyncQueue(500)
     const op = vi.fn().mockResolvedValue(undefined)
 
     queue.enqueue('a', op, { op: 'upsert', table: 'exercises', row: { id: 'a' } })
     expect(queue.journalSize).toBe(1)
 
-    queue.stop()
+    await queue.stop()
     expect(queue.journalSize).toBe(1)
 
-    // A subsequent enqueue reschedules a flush that drains the preserved work.
+    // A stray enqueue while stopped does NOT lift the stop or schedule a flush.
     queue.enqueue('b', op)
+    vi.advanceTimersByTime(1000)
+    await vi.runAllTimersAsync()
+    expect(op).not.toHaveBeenCalled()
+
+    // resume() re-arms the flush that drains the preserved work.
+    queue.resume()
     vi.advanceTimersByTime(500)
     await vi.runAllTimersAsync()
     expect(op).toHaveBeenCalled()
     expect(queue.pending).toBe(0)
+  })
+
+  // While stopped, a stray enqueue must NOT re-enable syncing — otherwise a
+  // background write during account deletion could flush and resurrect a row.
+  it('enqueue while stopped does not lift the stop or schedule a flush', () => {
+    const queue = new SyncQueue(100)
+    const op = vi.fn().mockResolvedValue(undefined)
+
+    queue.stop()
+    queue.enqueue('a', op)
+    vi.advanceTimersByTime(5000)
+    expect(op).not.toHaveBeenCalled()
   })
 
   it('stop() leaves no live timer even when the awaited in-flight flush fails', async () => {
@@ -180,7 +198,7 @@ describe('SyncQueue', () => {
     expect(queue.pending).toBe(0)
   })
 
-  it('resumes a stranded retry on the next enqueue after a stop()', async () => {
+  it('resume() re-arms a retry stranded by a stop()', async () => {
     const queue = new SyncQueue(100)
     let rejectOp: (() => void) | null = null
     const failingOp = vi.fn().mockImplementation(
@@ -196,12 +214,10 @@ describe('SyncQueue', () => {
     // 'a' is stranded in the retry queue with no timer.
     expect(queue.pending).toBe(1)
 
-    // A new write resumes the queue and re-arms the stranded retry.
-    const okOp = vi.fn().mockResolvedValue(undefined)
+    // resume() (failure-deletion path) re-arms the stranded retry.
     failingOp.mockResolvedValue(undefined) // 'a' now succeeds on retry
-    queue.enqueue('b', okOp)
+    queue.resume()
     await vi.runAllTimersAsync()
-    expect(okOp).toHaveBeenCalled()
     expect(queue.pending).toBe(0)
   })
 

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -69,9 +69,22 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
       }
     }
 
-    await supabase.from('exercises').insert(exerciseRows)
+    // Supabase inserts RESOLVE (not reject) on a DB/RLS failure — the error is
+    // returned in the resolved object's `.error` field. Throwing on a non-null
+    // error (a) aborts before inserting dependent `sets` when the parent
+    // `exercises` insert failed, so we never strand sets pointing at rows that
+    // don't exist, and (b) leaves the count guard tripped only on a genuinely
+    // successful exercises insert, so a partial failure can be safely re-run
+    // on the next launch instead of being silently marked complete (LIFT-782).
+    const { error: exercisesError } = await supabase.from('exercises').insert(exerciseRows)
+    if (exercisesError) {
+      throw new Error(`Migration failed inserting exercises: ${exercisesError.message}`)
+    }
     if (setRows.length > 0) {
-      await supabase.from('sets').insert(setRows)
+      const { error: setsError } = await supabase.from('sets').insert(setRows)
+      if (setsError) {
+        throw new Error(`Migration failed inserting sets: ${setsError.message}`)
+      }
     }
   }
 
@@ -83,6 +96,9 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
       date: e.date,
       weight: e.weight
     }))
-    await supabase.from('bodyweight_entries').insert(bwRows)
+    const { error: bodyweightError } = await supabase.from('bodyweight_entries').insert(bwRows)
+    if (bodyweightError) {
+      throw new Error(`Migration failed inserting bodyweight entries: ${bodyweightError.message}`)
+    }
   }
 }

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -73,9 +73,14 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
     // returned in the resolved object's `.error` field. Throwing on a non-null
     // error (a) aborts before inserting dependent `sets` when the parent
     // `exercises` insert failed, so we never strand sets pointing at rows that
-    // don't exist, and (b) leaves the count guard tripped only on a genuinely
-    // successful exercises insert, so a partial failure can be safely re-run
-    // on the next launch instead of being silently marked complete (LIFT-782).
+    // don't exist, and (b) surfaces the failure to the caller instead of
+    // silently reporting success (LIFT-782).
+    //
+    // CAVEAT: these inserts are not wrapped in a transaction, so if `exercises`
+    // commits but a later insert fails, the `count > 0` guard at the top will
+    // skip the migration on the next launch and the remaining `sets` /
+    // bodyweight rows are never migrated. Making the migration transactional or
+    // re-runnable per-row is tracked separately in LIFT-787.
     const { error: exercisesError } = await supabase.from('exercises').insert(exerciseRows)
     if (exercisesError) {
       throw new Error(`Migration failed inserting exercises: ${exercisesError.message}`)

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -116,6 +116,12 @@ export class SyncQueue {
   // Promise of the currently-executing flush (null when idle). stop() awaits it
   // so callers can guarantee no write is still in flight (LIFT-782).
   private _currentFlush: Promise<void> | null = null
+  // When true, the flush/retry schedulers are inhibited so NO new timer can be
+  // armed — even by an in-flight flush settling after stop(). This guarantees
+  // that once stop() returns there are zero live timers that could fire an
+  // upsert mid-deletion and resurrect a row. Reset on the next enqueue so
+  // normal sync resumes (e.g. after a failed deletion) (LIFT-782).
+  private _stopped = false
 
   constructor(flushDelay = 1000) {
     this._flushDelay = flushDelay
@@ -152,6 +158,11 @@ export class SyncQueue {
    */
   enqueue(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
+    // A new write means normal operation has resumed after a stop() — lift the
+    // inhibit so the flush scheduled below (and any retries stranded by the
+    // stop) can run again (LIFT-782).
+    const wasStopped = this._stopped
+    this._stopped = false
     // Journal first — before rate-limit deferral — so the durable record
     // exists the instant the user acts, even if execution is deferred.
     if (descriptor) this._journalSet(key, descriptor, false)
@@ -180,6 +191,10 @@ export class SyncQueue {
     this._queue.set(key, op)
     this._retryQueue.delete(key)
     this._scheduleFlush()
+    // If a prior stop() left failed ops stranded in the retry queue without a
+    // timer (the scheduler was inhibited), re-arm their retry now that we've
+    // resumed so they drain instead of waiting for an app restart (LIFT-782).
+    if (wasStopped && this._retryQueue.size > 0) this._scheduleRetry()
   }
 
   /**
@@ -340,11 +355,15 @@ export class SyncQueue {
    * stop an in-flight write from resurrecting a row mid-delete while still
    * preserving unsynced work if the deletion fails and the user retries.
    *
-   * Note: the awaited flush settles fully BEFORE the caller proceeds, so a
-   * subsequent clear() (on a confirmed deletion) tears down any retry state it
-   * left behind — the two run sequentially, never concurrently (LIFT-782).
+   * Note: the awaited flush settles fully BEFORE the caller proceeds, and the
+   * _stopped flag inhibits the schedulers so that flush can't arm a new timer
+   * as it settles. Once stop() returns there are zero live timers, so nothing
+   * fires an upsert during the caller's subsequent deletes (LIFT-782).
    */
   async stop(): Promise<void> {
+    // Set BEFORE awaiting the flush: the awaited flush's _scheduleRetry /
+    // _scheduleFlush calls then become no-ops, leaving no live timer behind.
+    this._stopped = true
     if (this._timer) {
       clearTimeout(this._timer)
       this._timer = null
@@ -423,11 +442,15 @@ export class SyncQueue {
   }
 
   private _scheduleFlush(): void {
+    // Inhibited while stopped so a flush settling during teardown can't re-arm
+    // a timer that would fire an upsert mid-deletion (LIFT-782).
+    if (this._stopped) return
     if (this._timer) clearTimeout(this._timer)
     this._timer = setTimeout(() => this.flush(), this._flushDelay)
   }
 
   private _scheduleRetry(): void {
+    if (this._stopped) return // inhibited while stopped (see _scheduleFlush)
     if (this._retryTimer) return // already scheduled
     // Exponential backoff based on highest attempt count
     const maxAttempt = Math.max(...[...this._retryQueue.values()].map(r => r.attempt))

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -113,10 +113,6 @@ export class SyncQueue {
   // seen, so descriptor-less queues never touch IndexedDB.
   private _journal = new Map<string, JournalEntry>()
   private _journalActive = false
-  // When true, a flush that is already in flight must NOT repopulate the retry
-  // queue or schedule further work — the queue is being torn down (e.g. account
-  // deletion). Reset to false on the next enqueue so normal sync resumes.
-  private _stopped = false
   // Promise of the currently-executing flush (null when idle). stop() awaits it
   // so callers can guarantee no write is still in flight (LIFT-782).
   private _currentFlush: Promise<void> | null = null
@@ -156,9 +152,6 @@ export class SyncQueue {
    */
   enqueue(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
-    // A new write means normal operation has resumed — lift any prior stop()
-    // so the flush it schedules below isn't suppressed (LIFT-782).
-    this._stopped = false
     // Journal first — before rate-limit deferral — so the durable record
     // exists the instant the user acts, even if execution is deferred.
     if (descriptor) this._journalSet(key, descriptor, false)
@@ -281,9 +274,7 @@ export class SyncQueue {
     } finally {
       this._currentFlush = null
       this._flushing = false
-      // Skip rescheduling once stopped — the queue is being torn down and a new
-      // timer would re-fire after clear()/sign-out (LIFT-782).
-      if (!this._stopped && this._queue.size > 0) this._scheduleFlush()
+      if (this._queue.size > 0) this._scheduleFlush()
     }
   }
 
@@ -298,11 +289,6 @@ export class SyncQueue {
     const results = await Promise.allSettled(
       entries.map(([, op]) => op()),
     )
-
-    // If the queue was stopped while these ops were in flight (e.g. account
-    // deletion awaited this flush), do NOT repopulate the retry queue or
-    // reschedule — that would resurrect work after the queue is torn down.
-    if (this._stopped) return
 
     let hasFailure = false
     let journalChanged = false
@@ -344,18 +330,21 @@ export class SyncQueue {
   }
 
   /**
-   * Halt pending flushes WITHOUT discarding queued work or the durable journal.
+   * Quiesce the queue WITHOUT discarding queued work or the durable journal.
    *
-   * Cancels the debounce/retry timers, marks the queue stopped (so an in-flight
-   * flush won't repopulate or reschedule), and AWAITS any flush already on the
-   * network so the caller can guarantee no write is still in flight. Every
-   * pending operation and its journal entry is preserved, so flushing resumes
-   * on the next enqueue. Account deletion uses this to stop an in-flight write
-   * from resurrecting a row mid-delete while still preserving unsynced work if
-   * the deletion fails and the user retries (LIFT-782).
+   * Cancels the pending debounce/retry timers and AWAITS any flush already on
+   * the network so the caller can guarantee no write is still in flight when it
+   * returns. Every pending operation and its journal entry is preserved, so
+   * flushing resumes on the next enqueue (or, on the failure path, on the retry
+   * timer the awaited flush may have scheduled). Account deletion uses this to
+   * stop an in-flight write from resurrecting a row mid-delete while still
+   * preserving unsynced work if the deletion fails and the user retries.
+   *
+   * Note: the awaited flush settles fully BEFORE the caller proceeds, so a
+   * subsequent clear() (on a confirmed deletion) tears down any retry state it
+   * left behind — the two run sequentially, never concurrently (LIFT-782).
    */
   async stop(): Promise<void> {
-    this._stopped = true
     if (this._timer) {
       clearTimeout(this._timer)
       this._timer = null
@@ -364,8 +353,6 @@ export class SyncQueue {
       clearTimeout(this._retryTimer)
       this._retryTimer = null
     }
-    // Wait for any flush already issuing network writes to settle, so no
-    // upsert can land after the caller's subsequent deletes.
     await this._currentFlush
   }
 

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -158,11 +158,10 @@ export class SyncQueue {
    */
   enqueue(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
-    // A new write means normal operation has resumed after a stop() — lift the
-    // inhibit so the flush scheduled below (and any retries stranded by the
-    // stop) can run again (LIFT-782).
-    const wasStopped = this._stopped
-    this._stopped = false
+    // NOTE: enqueue does NOT lift a stop(). While the queue is stopped (account
+    // deletion), _scheduleFlush below is inhibited so a stray write enqueued in
+    // the deletion window cannot schedule a flush that resurrects a just-deleted
+    // row. Sync resumes only via resume() (failure path) or clear() (LIFT-782).
     // Journal first — before rate-limit deferral — so the durable record
     // exists the instant the user acts, even if execution is deferred.
     if (descriptor) this._journalSet(key, descriptor, false)
@@ -191,10 +190,6 @@ export class SyncQueue {
     this._queue.set(key, op)
     this._retryQueue.delete(key)
     this._scheduleFlush()
-    // If a prior stop() left failed ops stranded in the retry queue without a
-    // timer (the scheduler was inhibited), re-arm their retry now that we've
-    // resumed so they drain instead of waiting for an app restart (LIFT-782).
-    if (wasStopped && this._retryQueue.size > 0) this._scheduleRetry()
   }
 
   /**
@@ -347,18 +342,16 @@ export class SyncQueue {
   /**
    * Quiesce the queue WITHOUT discarding queued work or the durable journal.
    *
-   * Cancels the pending debounce/retry timers and AWAITS any flush already on
-   * the network so the caller can guarantee no write is still in flight when it
-   * returns. Every pending operation and its journal entry is preserved, so
-   * flushing resumes on the next enqueue (or, on the failure path, on the retry
-   * timer the awaited flush may have scheduled). Account deletion uses this to
-   * stop an in-flight write from resurrecting a row mid-delete while still
-   * preserving unsynced work if the deletion fails and the user retries.
+   * Cancels the pending debounce/retry timers, sets the terminal _stopped flag,
+   * and AWAITS any flush already on the network so the caller can guarantee no
+   * write is still in flight when it returns. While _stopped, BOTH the
+   * schedulers AND enqueue() are inhibited, so a stray write in the deletion
+   * window can neither flush an in-flight op nor schedule a new one — nothing
+   * can resurrect a just-deleted row. The stop persists until clear() (success)
+   * or resume() (failure) is called; it is NOT lifted by a passing enqueue.
    *
-   * Note: the awaited flush settles fully BEFORE the caller proceeds, and the
-   * _stopped flag inhibits the schedulers so that flush can't arm a new timer
-   * as it settles. Once stop() returns there are zero live timers, so nothing
-   * fires an upsert during the caller's subsequent deletes (LIFT-782).
+   * Account deletion uses this to fully freeze sync across its server deletes
+   * while still preserving unsynced work if the deletion fails (LIFT-782).
    */
   async stop(): Promise<void> {
     // Set BEFORE awaiting the flush: the awaited flush's _scheduleRetry /
@@ -375,6 +368,19 @@ export class SyncQueue {
     await this._currentFlush
   }
 
+  /**
+   * Lift a stop() and resume normal syncing, re-arming a flush/retry for any
+   * work that was queued or stranded while stopped. Used on the account-deletion
+   * FAILURE path so the user can keep working; the success path calls clear()
+   * instead (LIFT-782).
+   */
+  resume(): void {
+    if (!this._stopped) return
+    this._stopped = false
+    if (this._queue.size > 0) this._scheduleFlush()
+    if (this._retryQueue.size > 0) this._scheduleRetry()
+  }
+
   /** Cancel all pending operations without executing them. */
   clear(): void {
     if (this._timer) {
@@ -389,6 +395,9 @@ export class SyncQueue {
     this._retryQueue.clear()
     this._attemptMap.clear()
     _deferredOps.clear()
+    // A full reset also lifts any stop() — the queue is empty, so the next
+    // lifecycle (e.g. a new user on a shared device) starts un-inhibited.
+    this._stopped = false
     const hadJournal = this._journal.size > 0
     this._journal.clear()
     if (hadJournal) this._persistJournal()

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -316,6 +316,26 @@ export class SyncQueue {
     return this._queue.size + this._retryQueue.size + _deferredOps.size
   }
 
+  /**
+   * Halt pending flushes WITHOUT discarding queued work or the durable journal.
+   *
+   * Unlike clear(), this only cancels the debounce/retry timers; every pending
+   * operation and its journal entry is preserved, so flushing resumes on the
+   * next enqueue. Account deletion uses this to stop an in-flight write from
+   * resurrecting a row mid-delete while still preserving unsynced work if the
+   * deletion fails and the user retries (LIFT-782).
+   */
+  stop(): void {
+    if (this._timer) {
+      clearTimeout(this._timer)
+      this._timer = null
+    }
+    if (this._retryTimer) {
+      clearTimeout(this._retryTimer)
+      this._retryTimer = null
+    }
+  }
+
   /** Cancel all pending operations without executing them. */
   clear(): void {
     if (this._timer) {

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -113,6 +113,13 @@ export class SyncQueue {
   // seen, so descriptor-less queues never touch IndexedDB.
   private _journal = new Map<string, JournalEntry>()
   private _journalActive = false
+  // When true, a flush that is already in flight must NOT repopulate the retry
+  // queue or schedule further work — the queue is being torn down (e.g. account
+  // deletion). Reset to false on the next enqueue so normal sync resumes.
+  private _stopped = false
+  // Promise of the currently-executing flush (null when idle). stop() awaits it
+  // so callers can guarantee no write is still in flight (LIFT-782).
+  private _currentFlush: Promise<void> | null = null
 
   constructor(flushDelay = 1000) {
     this._flushDelay = flushDelay
@@ -149,6 +156,9 @@ export class SyncQueue {
    */
   enqueue(key: string, op: SyncOperation, descriptor?: SyncDescriptor): void {
     if (!supabase || isPreviewMode.value) return
+    // A new write means normal operation has resumed — lift any prior stop()
+    // so the flush it schedules below isn't suppressed (LIFT-782).
+    this._stopped = false
     // Journal first — before rate-limit deferral — so the durable record
     // exists the instant the user acts, even if execution is deferred.
     if (descriptor) this._journalSet(key, descriptor, false)
@@ -264,51 +274,68 @@ export class SyncQueue {
     if (this._flushing || this._queue.size === 0) return
 
     this._flushing = true
+    const work = this._runFlush()
+    this._currentFlush = work
+    try {
+      await work
+    } finally {
+      this._currentFlush = null
+      this._flushing = false
+      // Skip rescheduling once stopped — the queue is being torn down and a new
+      // timer would re-fire after clear()/sign-out (LIFT-782).
+      if (!this._stopped && this._queue.size > 0) this._scheduleFlush()
+    }
+  }
+
+  /** Execute one batch of the current queue. Extracted so flush() can track
+   *  the in-flight promise (this._currentFlush) for stop() to await. */
+  private async _runFlush(): Promise<void> {
     syncStatus.value = 'syncing'
     broadcastSyncStatus('syncing')
     const entries = [...this._queue.entries()]
     this._queue.clear()
 
-    try {
-      const results = await Promise.allSettled(
-        entries.map(([, op]) => op()),
-      )
-      let hasFailure = false
-      let journalChanged = false
-      results.forEach((result, i) => {
-        const key = entries[i][0]
-        if (result.status === 'fulfilled') {
-          // Clear retry counter on success so future failures get full retries
-          this._attemptMap.delete(key)
-          // Write durably landed on the server — drop its journal entry.
+    const results = await Promise.allSettled(
+      entries.map(([, op]) => op()),
+    )
+
+    // If the queue was stopped while these ops were in flight (e.g. account
+    // deletion awaited this flush), do NOT repopulate the retry queue or
+    // reschedule — that would resurrect work after the queue is torn down.
+    if (this._stopped) return
+
+    let hasFailure = false
+    let journalChanged = false
+    results.forEach((result, i) => {
+      const key = entries[i][0]
+      if (result.status === 'fulfilled') {
+        // Clear retry counter on success so future failures get full retries
+        this._attemptMap.delete(key)
+        // Write durably landed on the server — drop its journal entry.
+        if (this._journal.delete(key)) journalChanged = true
+      } else if (result.status === 'rejected') {
+        hasFailure = true
+        const op = entries[i][1]
+        const prevAttempt = this._attemptMap.get(key) ?? 0
+        const attempt = prevAttempt + 1
+        if (attempt <= this._maxRetries) {
+          this._retryQueue.set(key, { op, attempt })
+          this._attemptMap.set(key, attempt)
+          logWarn(`Sync failed, will retry (attempt ${attempt}/${this._maxRetries})`, { key })
+        } else {
+          logError(result.reason, { source: 'SyncQueue', key, attempts: attempt })
+          // Retries exhausted — the op is dropped, so drop its journal entry
+          // too. (Reconciliation in the store's _fetchFromSupabase is the
+          // last line of defense for recovering such writes.)
           if (this._journal.delete(key)) journalChanged = true
-        } else if (result.status === 'rejected') {
-          hasFailure = true
-          const op = entries[i][1]
-          const prevAttempt = this._attemptMap.get(key) ?? 0
-          const attempt = prevAttempt + 1
-          if (attempt <= this._maxRetries) {
-            this._retryQueue.set(key, { op, attempt })
-            this._attemptMap.set(key, attempt)
-            logWarn(`Sync failed, will retry (attempt ${attempt}/${this._maxRetries})`, { key })
-          } else {
-            logError(result.reason, { source: 'SyncQueue', key, attempts: attempt })
-            // Retries exhausted — the op is dropped, so drop its journal entry
-            // too. (Reconciliation in the store's _fetchFromSupabase is the
-            // last line of defense for recovering such writes.)
-            if (this._journal.delete(key)) journalChanged = true
-          }
         }
-      })
-      if (journalChanged) this._persistJournal()
-      if (this._retryQueue.size > 0) this._scheduleRetry()
-      const newStatus = hasFailure ? 'error' : 'synced' as const
-      syncStatus.value = newStatus
-      broadcastSyncStatus(newStatus)
-    } finally {
-      this._flushing = false
-      if (this._queue.size > 0) this._scheduleFlush()
-    }
+      }
+    })
+    if (journalChanged) this._persistJournal()
+    if (this._retryQueue.size > 0) this._scheduleRetry()
+    const newStatus = hasFailure ? 'error' : 'synced' as const
+    syncStatus.value = newStatus
+    broadcastSyncStatus(newStatus)
   }
 
   /** Number of pending (unflushed) operations. */
@@ -319,13 +346,16 @@ export class SyncQueue {
   /**
    * Halt pending flushes WITHOUT discarding queued work or the durable journal.
    *
-   * Unlike clear(), this only cancels the debounce/retry timers; every pending
-   * operation and its journal entry is preserved, so flushing resumes on the
-   * next enqueue. Account deletion uses this to stop an in-flight write from
-   * resurrecting a row mid-delete while still preserving unsynced work if the
-   * deletion fails and the user retries (LIFT-782).
+   * Cancels the debounce/retry timers, marks the queue stopped (so an in-flight
+   * flush won't repopulate or reschedule), and AWAITS any flush already on the
+   * network so the caller can guarantee no write is still in flight. Every
+   * pending operation and its journal entry is preserved, so flushing resumes
+   * on the next enqueue. Account deletion uses this to stop an in-flight write
+   * from resurrecting a row mid-delete while still preserving unsynced work if
+   * the deletion fails and the user retries (LIFT-782).
    */
-  stop(): void {
+  async stop(): Promise<void> {
+    this._stopped = true
     if (this._timer) {
       clearTimeout(this._timer)
       this._timer = null
@@ -334,6 +364,9 @@ export class SyncQueue {
       clearTimeout(this._retryTimer)
       this._retryTimer = null
     }
+    // Wait for any flush already issuing network writes to settle, so no
+    // upsert can land after the caller's subsequent deletes.
+    await this._currentFlush
   }
 
   /** Cancel all pending operations without executing them. */


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-782](https://github.com/aschung212/Lift/issues/782)



## Changes




## Commits
- [`97b184d`](https://github.com/aschung212/Lift/commit/97b184d) fix(LIFT-782): make stop() a terminal freeze so a stray enqueue can't resurrect data
- [`19ee1ed`](https://github.com/aschung212/Lift/commit/19ee1ed) fix(LIFT-782): inhibit flush/retry schedulers while stopped to close the resurrection race
- [`298ba6e`](https://github.com/aschung212/Lift/commit/298ba6e) refactor(LIFT-782): simplify stop() — drop the _stopped early-return
- [`67c987c`](https://github.com/aschung212/Lift/commit/67c987c) fix(LIFT-782): make stop() await in-flight flush and suppress post-stop reschedule
- [`cb5c71c`](https://github.com/aschung212/Lift/commit/cb5c71c) fix(LIFT-782): halt (not clear) the sync queue during account deletion
- [`e94d5e8`](https://github.com/aschung212/Lift/commit/e94d5e8) fix(LIFT-782): address review — prevent migrate soft-lock and premature journal wipe
- [`94b7bd6`](https://github.com/aschung212/Lift/commit/94b7bd6) fix(LIFT-782): treat resolved-with-error Supabase responses as failures in deleteAccount + migrate

## Test Results
- Before: 2201 passing
- After: 2211 passing (10 delta)

---
_Automated by overnight pipeline — Wed Jun 17 23:58:51 PDT 2026_

## Preview
Test on your phone: https://lift-5tyfhhb77-aschung212-1101s-projects.vercel.app