### PR TITLE
fix(LIFT-785): tolerate retired warmup_scheme column in replay allowlist

### DIFF
--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -267,6 +267,15 @@ describe('replay allowlist (LIFT-785)', () => {
       })).toBe(true)
     })
 
+    it('tolerates retired-but-dormant DB columns so legacy offline writes still replay', () => {
+      // warmup_scheme was retired in #770 but the column still exists in the DB.
+      // An offline write journaled by a pre-#770 client must not be dropped.
+      expect(isReplayableDescriptor({
+        op: 'upsert', table: 'exercises',
+        row: { id: 'e1', user_id: 'u1', name: 'Bench', warmup_scheme: [] },
+      })).toBe(true)
+    })
+
     it('rejects unknown tables, columns, and ops', () => {
       // Table not in the allowlist (e.g. a tampered entry targeting auth state)
       expect(isReplayableDescriptor({ op: 'upsert', table: 'user_progression', row: { id: 'x' } })).toBe(false)

--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -55,6 +55,7 @@ vi.mock('../logger', () => ({ logError: vi.fn(), logWarn: vi.fn(), logInfo: vi.f
 import {
   SyncQueue,
   executeDescriptor,
+  isReplayableDescriptor,
   syncStatus,
   _resetRateLimit,
   _resetCircuitBreaker,
@@ -234,5 +235,97 @@ describe('executeDescriptor (LIFT-706)', () => {
     expect(fakeSupabase.calls).toEqual([
       { op: 'update', table: 'sets', data: { deleted_at: null }, filters: { id: 's1', user_id: 'u1' } },
     ])
+  })
+})
+
+// Replay allowlist: a journaled descriptor lives in user-writable IndexedDB, so
+// rehydrate()/executeDescriptor must validate it against an allowlist of tables
+// and writable columns before ever building a query (LIFT-785).
+describe('replay allowlist (LIFT-785)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    syncStatus.value = 'synced'
+    idbStore.clear()
+    fakeSupabase.reset()
+    _resetRateLimit()
+    _resetCircuitBreaker()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('isReplayableDescriptor', () => {
+    it('accepts the real descriptors the app produces', () => {
+      expect(isReplayableDescriptor({ op: 'upsert', table: 'sets', row: { id: 's1', weight: 100 } })).toBe(true)
+      expect(isReplayableDescriptor({ op: 'upsert', table: 'exercises', row: { id: 'e1', name: 'Bench' } })).toBe(true)
+      expect(isReplayableDescriptor({
+        op: 'update', table: 'sets', values: { deleted_at: null }, match: { id: 's1', user_id: 'u1' },
+      })).toBe(true)
+      expect(isReplayableDescriptor({
+        op: 'update', table: 'exercises', values: { deleted_at: 'x' }, match: { id: 'e1' },
+      })).toBe(true)
+    })
+
+    it('rejects unknown tables, columns, and ops', () => {
+      // Table not in the allowlist (e.g. a tampered entry targeting auth state)
+      expect(isReplayableDescriptor({ op: 'upsert', table: 'user_progression', row: { id: 'x' } })).toBe(false)
+      expect(isReplayableDescriptor({ op: 'upsert', table: 'profiles', row: { is_admin: true } })).toBe(false)
+      // Column not writable on an allowlisted table
+      expect(isReplayableDescriptor({ op: 'upsert', table: 'sets', row: { id: 's1', injected: 1 } })).toBe(false)
+      // Op outside the idempotent upsert/update set
+      expect(isReplayableDescriptor({ op: 'delete', table: 'sets', row: { id: 's1' } })).toBe(false)
+    })
+
+    it('rejects malformed shapes without throwing', () => {
+      const malformed: unknown[] = [
+        null, undefined, 42, 'sets', [], {},
+        { op: 'upsert', table: 'sets' },               // missing row
+        { op: 'upsert', table: 'sets', row: null },    // null row
+        { op: 'upsert', table: 'sets', row: [] },      // array row
+        { op: 'upsert', table: 'sets', row: {} },      // empty row
+        { op: 'update', table: 'sets', values: { deleted_at: 'x' }, match: {} }, // empty match → would hit every row
+        { op: 'update', table: 'sets', values: {}, match: { id: 's1' } },        // empty values
+      ]
+      for (const d of malformed) {
+        expect(isReplayableDescriptor(d)).toBe(false)
+      }
+    })
+  })
+
+  it('executeDescriptor refuses to issue a write for a non-allowlisted table', async () => {
+    await executeDescriptor({ op: 'upsert', table: 'profiles', row: { id: 'x' } } as unknown as SyncDescriptor)
+    expect(fakeSupabase.calls).toHaveLength(0)
+  })
+
+  it('executeDescriptor refuses an update whose match would target the whole table', async () => {
+    await executeDescriptor({
+      op: 'update', table: 'sets', values: { deleted_at: 'x' }, match: {},
+    } as unknown as SyncDescriptor)
+    expect(fakeSupabase.calls).toHaveLength(0)
+  })
+
+  it('rehydrate() drops a tampered journal entry and replays only the valid ones', async () => {
+    idbStore.set('lift-sync-journal', JSON.stringify([
+      // Tampered: targets a table outside the allowlist
+      { key: 'evil:1', isDelete: false, descriptor: { op: 'upsert', table: 'profiles', row: { is_admin: true } } },
+      // Tampered: an unbounded delete on the whole sets table
+      { key: 'evil:2', isDelete: true, descriptor: { op: 'update', table: 'sets', values: { deleted_at: 'x' }, match: {} } },
+      // Legitimate write that must still replay
+      { key: 'set:s1', isDelete: false, descriptor: UPSERT },
+    ]))
+
+    const queue = new SyncQueue(100)
+    await queue.rehydrate()
+
+    // Only the legitimate entry was enqueued/journaled
+    expect(queue.pending).toBe(1)
+    expect(queue.journalSize).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    // Exactly one write reached Supabase — the valid set upsert
+    expect(fakeSupabase.calls).toHaveLength(1)
+    expect(fakeSupabase.calls[0]).toMatchObject({ op: 'upsert', table: 'sets', data: { id: 's1', weight: 100 } })
   })
 })

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -54,6 +54,10 @@ const REPLAYABLE_COLUMNS: Record<string, ReadonlySet<string>> = {
   exercises: new Set([
     'id', 'user_id', 'name', 'tags', 'archived_at',
     'input_mode', 'bar_weight', 'intensity_max_reps', 'deleted_at',
+    // Retired in #770 but the DB column still exists (left dormant, never
+    // dropped). Tolerated so an offline write journaled by a pre-#770 client
+    // still replays after an upgrade instead of being silently dropped.
+    'warmup_scheme',
   ]),
   sets: new Set([
     'id', 'user_id', 'exercise_id', 'date', 'weight', 'reps',

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -34,14 +34,82 @@ interface JournalEntry {
 const JOURNAL_KEY = 'lift-sync-journal'
 
 /**
+ * Allowlist of tables (and their writable columns) that a journaled descriptor
+ * is permitted to target on replay (LIFT-785).
+ *
+ * The journal lives in IndexedDB, which is user-writable. `rehydrate()` replays
+ * whatever was persisted, and `executeDescriptor` casts the typed client to a
+ * loose surface to target a dynamic table name — so without validation a
+ * tampered (or corrupted) journal entry could issue an upsert/update against an
+ * arbitrary table or column, with RLS as the only backstop. This allowlist is a
+ * client-side defense-in-depth layer: only the tables the app actually journals
+ * (`exercises`, `sets`) and only their real columns are replayable; anything
+ * else is dropped before a query is ever built.
+ *
+ * Keep this in sync with the descriptors built in `src/stores/workout.ts`
+ * (`_buildExerciseUpsert`, `_enqueueSetUpsert`, `_enqueueSoftDelete`,
+ * `_enqueueRestore`) — those are the only descriptor producers in the app.
+ */
+const REPLAYABLE_COLUMNS: Record<string, ReadonlySet<string>> = {
+  exercises: new Set([
+    'id', 'user_id', 'name', 'tags', 'archived_at',
+    'input_mode', 'bar_weight', 'intensity_max_reps', 'deleted_at',
+  ]),
+  sets: new Set([
+    'id', 'user_id', 'exercise_id', 'date', 'weight', 'reps',
+    'estimated_1rm', 'deleted_at',
+  ]),
+}
+
+/** True when `obj` is a non-empty plain map whose keys are all in `allowed`. */
+function isAllowedColumnMap(obj: unknown, allowed: ReadonlySet<string>): boolean {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return false
+  const keys = Object.keys(obj)
+  // Empty maps are rejected: an empty upsert row is meaningless, and an empty
+  // update `match` would target EVERY row in the table — exactly the kind of
+  // unbounded write this allowlist exists to prevent.
+  if (keys.length === 0) return false
+  return keys.every(col => allowed.has(col))
+}
+
+/**
+ * Validate that a descriptor is safe to replay (LIFT-785): a known op, an
+ * allowlisted table, and only writable columns of that table in its row /
+ * values / match. Used both as the gate in `rehydrate()` (drop + warn) and as
+ * the final guard inside `executeDescriptor` (no-op) so a bad descriptor can
+ * never reach Supabase regardless of how it was enqueued.
+ */
+export function isReplayableDescriptor(descriptor: unknown): descriptor is SyncDescriptor {
+  if (!descriptor || typeof descriptor !== 'object') return false
+  const d = descriptor as Record<string, unknown>
+  if (typeof d.table !== 'string') return false
+  const allowed = REPLAYABLE_COLUMNS[d.table]
+  if (!allowed) return false
+  if (d.op === 'upsert') return isAllowedColumnMap(d.row, allowed)
+  if (d.op === 'update') {
+    return isAllowedColumnMap(d.values, allowed) && isAllowedColumnMap(d.match, allowed)
+  }
+  return false
+}
+
+/**
  * Rebuild a runnable Supabase operation from its serializable descriptor.
  * Used to replay journaled writes after a reload. Returns a no-op promise when
- * Supabase is unavailable so replay degrades gracefully offline.
+ * Supabase is unavailable so replay degrades gracefully offline, or when the
+ * descriptor falls outside the replay allowlist (LIFT-785).
  */
 export function executeDescriptor(descriptor: SyncDescriptor): PromiseLike<unknown> {
   if (!supabase) return Promise.resolve()
+  if (!isReplayableDescriptor(descriptor)) {
+    logWarn('Refusing to execute sync descriptor outside the replay allowlist', {
+      op: (descriptor as { op?: unknown } | null)?.op,
+      table: (descriptor as { table?: unknown } | null)?.table,
+    })
+    return Promise.resolve()
+  }
   // The table name is dynamic here (driven by the descriptor), so the strongly
-  // typed supabase client surface doesn't apply — cast to a loose client.
+  // typed supabase client surface doesn't apply — cast to a loose client. The
+  // allowlist check above bounds `table` to the known set before we cast.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const client = supabase as any
   if (descriptor.op === 'upsert') {
@@ -364,6 +432,17 @@ export class SyncQueue {
     }
     for (const entry of entries) {
       if (!entry || typeof entry.key !== 'string' || !entry.descriptor) continue
+      // Drop any journaled entry whose descriptor falls outside the replay
+      // allowlist (LIFT-785) — the journal is user-writable IndexedDB, so a
+      // tampered or corrupted entry must never be rebuilt into a query.
+      if (!isReplayableDescriptor(entry.descriptor)) {
+        logWarn('Dropping journaled descriptor outside the replay allowlist', {
+          key: entry.key,
+          op: (entry.descriptor as { op?: unknown }).op,
+          table: (entry.descriptor as { table?: unknown }).table,
+        })
+        continue
+      }
       const { key, descriptor, isDelete } = entry
       // Don't clobber a newer in-session write: if the user acted on this key
       // while the (async) journal read was in flight, the live queue/retry entry


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-785](https://github.com/aschung212/Lift/issues/785)



## Changes




## Commits
- [`c931009`](https://github.com/aschung212/Lift/commit/c931009) fix(LIFT-785): tolerate retired warmup_scheme column in replay allowlist
- [`f7b13e0`](https://github.com/aschung212/Lift/commit/f7b13e0) feat(LIFT-785): validate journaled sync descriptors against a replay allowlist

## Test Results
- Before: 2201 passing
- After: 2208 passing (7 delta)

---
_Automated by overnight pipeline — Thu Jun 18 00:14:46 PDT 2026_

## Preview
Test on your phone: https://lift-mtz9ij0jr-aschung212-1101s-projects.vercel.app