### PR TITLE
fix(LIFT-787): harden localStorage→Supabase migration against partial failures

### DIFF
--- a/src/lib/__tests__/migrate.test.ts
+++ b/src/lib/__tests__/migrate.test.ts
@@ -5,6 +5,9 @@ const mockSelect = vi.fn()
 const mockEq = vi.fn()
 const mockInsert = vi.fn()
 const mockFrom = vi.fn()
+const mockDelete = vi.fn()
+const mockDeleteEq = vi.fn()
+const mockDeleteIn = vi.fn()
 
 vi.mock('../supabase', () => ({
   supabase: {
@@ -12,17 +15,35 @@ vi.mock('../supabase', () => ({
       mockFrom(table)
       return {
         select: (...args: unknown[]) => {
-          mockSelect(...args)
+          mockSelect(table, ...args)
           return {
             eq: (...eqArgs: unknown[]) => {
-              mockEq(...eqArgs)
-              return Promise.resolve({ count: 0 })
+              // Tests can override the count-query result via mockEq's return
+              // value (e.g. an error or a non-zero count); default to empty.
+              const result = mockEq(...eqArgs)
+              return result ?? Promise.resolve({ count: 0 })
             },
           }
         },
         insert: (rows: unknown[]) => {
-          mockInsert(table, rows)
-          return Promise.resolve({ error: null })
+          // Tests can override the result per table via mockInsert's return
+          // value; default to a clean success.
+          const result = mockInsert(table, rows)
+          return Promise.resolve(result ?? { error: null })
+        },
+        delete: () => {
+          mockDelete(table)
+          return {
+            eq: (...eqArgs: unknown[]) => {
+              mockDeleteEq(...eqArgs)
+              return {
+                in: (...inArgs: unknown[]) => {
+                  mockDeleteIn(...inArgs)
+                  return Promise.resolve({ error: null })
+                },
+              }
+            },
+          }
         },
       }
     },
@@ -41,6 +62,10 @@ describe('migrateLocalStorageToSupabase', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // clearAllMocks does not reset implementations, so restore the default
+    // (clean-success / empty-count) behavior between tests that override them.
+    mockInsert.mockReset()
+    mockEq.mockReset()
     uuidCounter = 0
     localStorageMock = {}
 
@@ -153,5 +178,76 @@ describe('migrateLocalStorageToSupabase', () => {
     await migrateLocalStorageToSupabase('user-1')
 
     expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  it('aborts without migrating when the count guard query errors (LIFT-787)', async () => {
+    // A transient count-query failure returns null count + an error. The old
+    // guard read null as "empty" and would have duplicated existing cloud data.
+    mockEq.mockReturnValueOnce(Promise.resolve({ count: null, error: { message: 'network' } }))
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      { name: 'Bench Press', sets: [{ date: '2026-03-30', weight: 100, reps: 8, estimated1RM: 125 }] },
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  it('aborts before inserting sets if the exercises insert fails (LIFT-787)', async () => {
+    mockInsert.mockImplementation((table: string) =>
+      table === 'exercises' ? { error: { message: 'insert failed' } } : { error: null }
+    )
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      { name: 'Bench Press', sets: [{ date: '2026-03-30', weight: 100, reps: 8, estimated1RM: 125 }] },
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).toHaveBeenCalledWith('exercises', expect.anything())
+    // Sets must not be inserted, and no rollback is needed (nothing landed).
+    expect(mockInsert).not.toHaveBeenCalledWith('sets', expect.anything())
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('rolls back orphaned exercises if the sets insert fails (LIFT-787)', async () => {
+    // Exercises land but sets fail — without rollback the user is left with
+    // exercises-without-sets AND the count guard permanently blocks a re-run.
+    mockInsert.mockImplementation((table: string) =>
+      table === 'sets' ? { error: { message: 'sets failed' } } : { error: null }
+    )
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      { name: 'Bench Press', sets: [{ date: '2026-03-30', weight: 100, reps: 8, estimated1RM: 125 }] },
+      { name: 'Squat', sets: [{ date: '2026-03-30', weight: 140, reps: 5, estimated1RM: 163 }] },
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    // The freshly-minted exercise rows are deleted, scoped to this user and to
+    // exactly the UUIDs we created this run.
+    expect(mockDelete).toHaveBeenCalledWith('exercises')
+    expect(mockDeleteEq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(mockDeleteIn).toHaveBeenCalledWith('id', ['test-uuid-1', 'test-uuid-3'])
+  })
+
+  it('skips bodyweight migration when the bodyweight count guard errors (LIFT-787)', async () => {
+    mockEq
+      .mockReturnValueOnce(Promise.resolve({ count: 0 })) // exercises count
+      .mockReturnValueOnce(Promise.resolve({ count: null, error: { message: 'rls' } })) // bodyweight count
+    localStorageMock['bodyweight-entries'] = JSON.stringify([{ date: '2026-03-28', weight: 185 }])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).not.toHaveBeenCalledWith('bodyweight_entries', expect.anything())
+  })
+
+  it('skips bodyweight migration when bodyweight already exists in the cloud (LIFT-787)', async () => {
+    mockEq
+      .mockReturnValueOnce(Promise.resolve({ count: 0 })) // exercises count
+      .mockReturnValueOnce(Promise.resolve({ count: 3 })) // bodyweight already migrated
+    localStorageMock['bodyweight-entries'] = JSON.stringify([{ date: '2026-03-28', weight: 185 }])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).not.toHaveBeenCalledWith('bodyweight_entries', expect.anything())
   })
 })

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -22,12 +22,18 @@ interface LocalBodyweightEntry {
 export async function migrateLocalStorageToSupabase(userId: string): Promise<void> {
   if (!supabase) return
 
-  // Check if user already has data in Supabase
-  const { count } = await supabase
+  // Guard: only migrate into an account that has no cloud data yet. We MUST
+  // check the query error — if the count query fails transiently (network /
+  // RLS hiccup), `count` comes back null, the `count && count > 0` guard reads
+  // as "empty", and migration proceeds, duplicating any data that is actually
+  // already in the cloud. When the guard can't be trusted, abort and let a
+  // later session retry. (LIFT-787)
+  const { count, error: countError } = await supabase
     .from('exercises')
     .select('*', { count: 'exact', head: true })
     .eq('user_id', userId)
 
+  if (countError) return // can't trust the guard — retry next session
   if (count && count > 0) return // User already has cloud data, skip
 
   // Read localStorage data
@@ -69,14 +75,45 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
       }
     }
 
-    await supabase.from('exercises').insert(exerciseRows)
+    const { error: exerciseError } = await supabase.from('exercises').insert(exerciseRows)
+    // Abort before touching dependent sets if the exercises insert failed.
+    // Nothing has landed, so the count guard stays open and a later session
+    // can re-run the migration cleanly. (LIFT-787)
+    if (exerciseError) return
+
     if (setRows.length > 0) {
-      await supabase.from('sets').insert(setRows)
+      const { error: setError } = await supabase.from('sets').insert(setRows)
+      if (setError) {
+        // The exercises landed but their sets did not. Roll back the just-
+        // inserted exercises so we leave no orphaned exercises-without-sets
+        // AND the count guard reopens — otherwise the now-present exercises
+        // would permanently block any re-run. We delete strictly by the UUIDs
+        // we minted this run (scoped to this user), so this can only remove
+        // rows we just created; the account was verified empty above, so there
+        // is no pre-existing data to clobber. (LIFT-787; cf. SEV1 2026-04-12)
+        await supabase
+          .from('exercises')
+          .delete()
+          .eq('user_id', userId)
+          .in('id', exerciseRows.map(r => r.id))
+        return
+      }
     }
   }
 
-  // Migrate bodyweight entries
+  // Migrate bodyweight entries. Guarded independently of the exercises table so
+  // a partial failure (e.g. exercises migrated but a previous run died before
+  // this insert) can resume without duplicating already-migrated bodyweight,
+  // and a transient error here leaves the door open for a clean retry. (LIFT-787)
   if (bodyweightEntries.length > 0) {
+    const { count: bwCount, error: bwCountError } = await supabase
+      .from('bodyweight_entries')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', userId)
+
+    if (bwCountError) return // can't trust the guard — retry next session
+    if (bwCount && bwCount > 0) return // bodyweight already migrated, skip
+
     const bwRows = bodyweightEntries.map(e => ({
       id: uuid(),
       user_id: userId,


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-787](https://github.com/aschung212/Lift/issues/787)

Fix LIFT-787: harden the one-shot `localStorage → Supabase` migration so it is idempotent and self-healing under partial/transient failures.

## Changes
- **`src/lib/migrate.ts`**
  - Count guard now destructures and checks `error`. A transient count-query failure (null count) was previously read as "empty" and would duplicate existing cloud data — now we abort and let a later session retry.
  - Exercises insert result is checked before inserting dependent sets; abort early on failure (nothing landed, guard stays open).
  - If the sets insert fails after exercises landed, we **roll back** the freshly-minted exercises — scoped to `user_id` + exactly the UUIDs created this run — so no orphaned exercises-without-sets remain and the count guard reopens for a clean re-run.
  - Bodyweight migration now has its **own independent count guard**, so a partial failure resumes without duplicating already-migrated bodyweight.
- **`src/lib/__tests__/migrate.test.ts`**
  - Added 5 regression tests: count-guard error abort, exercise-insert-failure abort, sets-insert-failure rollback (asserts scoped delete), bodyweight count-guard error, bodyweight already-migrated skip.
  - Fixed the test mock so the count-query return value is actually honored (the prior mock hard-coded `{count:0}`, making the existing count-guard test pass vacuously) and added a `delete().eq().in()` chain. Reset insert/eq implementations between tests.

## Verification
- `npx vitest run src/lib/__tests__/migrate.test.ts` → 12 passed
- `npx vitest run` (full suite) → 2206 passed, 1 skipped (+5 new tests)
- `npm run lint` → clean
- `npm run build` → built successfully

## Screenshots
N/A — pure data-layer / logic change, no UI surface.

## Commits
- [`50db736`](https://github.com/aschung212/Lift/commit/50db736) fix(LIFT-787): harden localStorage→Supabase migration against partial failures

## Test Results
- Before: 2201 passing
- After: 2206 passing (5 delta)

---
_Automated by overnight pipeline — Thu Jun 18 00:38:29 PDT 2026_

## Preview
Test on your phone: https://lift-qms0eo4mm-aschung212-1101s-projects.vercel.app