### PR TITLE
feat(LIFT-794): include a tappable app link in the workout-card Web Share payload

### DIFF
--- a/src/composables/__tests__/useWorkoutShare.test.ts
+++ b/src/composables/__tests__/useWorkoutShare.test.ts
@@ -151,6 +151,41 @@ describe('useWorkoutShare', () => {
       )
     })
 
+    it('includes the canonical app link in the Web Share payload (#794)', async () => {
+      const shareFn = vi.fn().mockResolvedValue(undefined)
+      const canShareFn = vi.fn().mockReturnValue(true)
+      Object.defineProperty(navigator, 'share', { value: shareFn, writable: true, configurable: true })
+      Object.defineProperty(navigator, 'canShare', { value: canShareFn, writable: true, configurable: true })
+
+      const { shareCard } = await getComposable()
+      await shareCard(makeRequest())
+
+      expect(shareFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          files: expect.arrayContaining([expect.any(File)]),
+          title: 'Lift workout',
+          url: 'https://spa-rho-sandy.vercel.app',
+          text: expect.stringContaining('Lift'),
+        }),
+      )
+    })
+
+    it('degrades to an image-only payload when the link-carrying payload is rejected (#794)', async () => {
+      const shareFn = vi.fn().mockResolvedValue(undefined)
+      // canShare rejects any payload carrying a url, accepts files-only.
+      const canShareFn = vi.fn((data: ShareData) => !('url' in data))
+      Object.defineProperty(navigator, 'share', { value: shareFn, writable: true, configurable: true })
+      Object.defineProperty(navigator, 'canShare', { value: canShareFn, writable: true, configurable: true })
+
+      const { shareCard } = await getComposable()
+      const result = await shareCard(makeRequest())
+
+      expect(result).toEqual({ kind: 'shared' })
+      const payload = shareFn.mock.calls[0][0] as ShareData
+      expect(payload.files).toBeDefined()
+      expect('url' in payload).toBe(false)
+    })
+
     it('returns cancelled when user dismisses share sheet (AbortError)', async () => {
       const abortError = new DOMException('User cancelled', 'AbortError')
       const shareFn = vi.fn().mockRejectedValue(abortError)

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -22,6 +22,10 @@ import {
 } from '../lib/shareImage'
 import type { SessionSummary } from '../lib/sessionSummary'
 import { useAnalytics } from './useAnalytics'
+import { APP_URL, APP_TAGLINE } from '../lib/appMeta'
+
+/** Title shown in the share sheet for a rasterized workout card. */
+const SHARE_TITLE = 'Lift workout'
 
 export interface ShareCardRequest {
   /** The Vue component that renders the card. */
@@ -48,16 +52,27 @@ export type ShareResult =
   | { kind: 'error'; error: Error }
 
 /**
- * Browsers that support image files in the Web Share API.
+ * Pick the richest Web Share payload a platform will actually accept for a
+ * rendered card. We prefer a payload that carries both the card image AND a
+ * tappable link back to the app (#794) so a recipient can convert in one tap
+ * instead of retyping the printed handle — but some platforms reject a
+ * files+url combo via `canShare`, so we degrade to image-only rather than
+ * drop the share entirely. Returns null when no payload is sharable (caller
+ * falls back to download).
+ *
  * iOS Safari 16.4+ and Android Chrome both report `canShare({ files })` as true.
  */
-function canWebShareFiles(files: File[]): boolean {
-  if (typeof navigator === 'undefined' || !navigator.share || !navigator.canShare) return false
+function pickWebSharePayload(file: File): ShareData | null {
+  if (typeof navigator === 'undefined' || !navigator.share || !navigator.canShare) return null
+  const withLink: ShareData = { files: [file], title: SHARE_TITLE, text: APP_TAGLINE, url: APP_URL }
+  const imageOnly: ShareData = { files: [file], title: SHARE_TITLE }
   try {
-    return navigator.canShare({ files })
+    if (navigator.canShare(withLink)) return withLink
+    if (navigator.canShare(imageOnly)) return imageOnly
   } catch {
-    return false
+    return null
   }
+  return null
 }
 
 /** Triggers a download via a temporary anchor element. Matches the dataExport.ts pattern. */
@@ -196,9 +211,10 @@ export function useWorkoutShare(): UseWorkoutShareReturn {
       // alone would silently drop the rendered image, which is worse than
       // surfacing the download.
 
-      if (canWebShareFiles([file])) {
+      const sharePayload = pickWebSharePayload(file)
+      if (sharePayload) {
         try {
-          await navigator.share({ files: [file], title: 'Lift workout' })
+          await navigator.share(sharePayload)
           logEvent('share_completed', { format: req.format, method: 'share', outcome: 'shared' })
           return { kind: 'shared' }
         } catch (err) {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-794](https://github.com/aschung212/Lift/issues/794)

Implement LIFT-794 (priority:2-high): add a tappable canonical app link to the workout-card Web Share payload so shared PR/workout cards carry a one-tap path back to the app, closing the share→install conversion loop that LIFT-714's printed handle only gestured at.

## Changes
- **`src/composables/useWorkoutShare.ts`** — Replaced `canWebShareFiles` with `pickWebSharePayload(file)`, which prefers a payload carrying the card image **plus** `url: APP_URL` and `text: APP_TAGLINE`, and gracefully degrades to image-only when a platform's `canShare` rejects the `files`+`url` combo (so the image share is never dropped). Imported `APP_URL`/`APP_TAGLINE` from the existing `appMeta.ts` source of truth (no fabricated identifiers). Extracted the `'Lift workout'` title to a `SHARE_TITLE` constant.
- **`src/composables/__tests__/useWorkoutShare.test.ts`** — Added two regression tests: (1) the canonical link is present in the Web Share payload, (2) the flow degrades to image-only and still shares when `canShare` rejects any `url`-bearing payload.

## Verification
- `npx vitest run src/composables/__tests__/useWorkoutShare.test.ts` → 37 passed
- Full suite: 2271 passed / 1 skipped (added +2)
- `npm run lint` → clean
- `npm run build` → success
- Pushed `enhance/run1-2026-06-18` to origin (pre-push Gemini review failed on an unrelated auth/tier error in the environment, not a code finding).

## Screenshots
N/A — change is in the non-visual share-payload composable; no UI surface changed.

## Commits
- [`e6105c5`](https://github.com/aschung212/Lift/commit/e6105c5) feat(LIFT-794): include a tappable app link in the workout-card Web Share payload

## Test Results
- Before: 2269 passing
- After: 2271 passing (2 delta)

---
_Automated by overnight pipeline — Thu Jun 18 23:05:54 PDT 2026_

## Preview
Test on your phone: https://lift-dfha2tqfi-aschung212-1101s-projects.vercel.app