### PR TITLE
feat(LIFT-798): tag share-flow URLs with a ?ref= attribution token

### DIFF
--- a/src/composables/__tests__/useAppShare.test.ts
+++ b/src/composables/__tests__/useAppShare.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { APP_URL, APP_NAME, APP_TAGLINE } from '../../lib/appMeta'
+import { appUrlWithRef, APP_NAME, APP_TAGLINE, SHARE_REF } from '../../lib/appMeta'
+
+// The app-share flow stamps the canonical URL with the share_app attribution
+// ref (#798) so a share-driven install isn't logged as "direct".
+const SHARE_URL = appUrlWithRef(SHARE_REF.app)
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 // useAppShare reads `isNative` from platform at module scope, so each test
@@ -48,7 +52,7 @@ describe('useAppShare', () => {
 
       expect(res).toEqual({ kind: 'shared' })
       expect(mockCapacitorShare).toHaveBeenCalledWith(
-        expect.objectContaining({ title: APP_NAME, text: APP_TAGLINE, url: APP_URL }),
+        expect.objectContaining({ title: APP_NAME, text: APP_TAGLINE, url: SHARE_URL }),
       )
     })
 
@@ -68,7 +72,7 @@ describe('useAppShare', () => {
       const res = await shareApp()
 
       expect(res).toEqual({ kind: 'copied' })
-      expect(writeText).toHaveBeenCalledWith(APP_URL)
+      expect(writeText).toHaveBeenCalledWith(SHARE_URL)
     })
   })
 
@@ -83,7 +87,7 @@ describe('useAppShare', () => {
       const res = await shareApp()
 
       expect(res).toEqual({ kind: 'shared' })
-      expect(shareFn).toHaveBeenCalledWith({ title: APP_NAME, text: APP_TAGLINE, url: APP_URL })
+      expect(shareFn).toHaveBeenCalledWith({ title: APP_NAME, text: APP_TAGLINE, url: SHARE_URL })
       expect(mockCapacitorShare).not.toHaveBeenCalled()
     })
 
@@ -106,7 +110,7 @@ describe('useAppShare', () => {
       const res = await shareApp()
 
       expect(res).toEqual({ kind: 'copied' })
-      expect(writeText).toHaveBeenCalledWith(APP_URL)
+      expect(writeText).toHaveBeenCalledWith(SHARE_URL)
     })
   })
 
@@ -121,7 +125,7 @@ describe('useAppShare', () => {
       const res = await shareApp()
 
       expect(res).toEqual({ kind: 'copied' })
-      expect(writeText).toHaveBeenCalledWith(APP_URL)
+      expect(writeText).toHaveBeenCalledWith(SHARE_URL)
     })
 
     it('returns unavailable when neither share nor clipboard works', async () => {

--- a/src/composables/useAppShare.ts
+++ b/src/composables/useAppShare.ts
@@ -14,7 +14,7 @@
 
 import { ref, type Ref } from 'vue'
 import { isNative } from '../lib/platform'
-import { APP_URL, APP_NAME, APP_TAGLINE } from '../lib/appMeta'
+import { appUrlWithRef, APP_NAME, APP_TAGLINE, SHARE_REF } from '../lib/appMeta'
 
 export type AppShareResult =
   | { kind: 'shared' }       // native sheet / Web Share resolved
@@ -53,6 +53,9 @@ export function useAppShare(): UseAppShareReturn {
   async function shareApp(): Promise<AppShareResult> {
     if (isSharing.value) return { kind: 'cancelled' }
     isSharing.value = true
+    // Tag the shared link with the app-share attribution ref (#798) so a
+    // share-driven install is credited to this surface instead of "direct".
+    const shareUrl = appUrlWithRef(SHARE_REF.app)
     try {
       // Tier 1: native system share sheet.
       if (isNative) {
@@ -61,7 +64,7 @@ export function useAppShare(): UseAppShareReturn {
           await Share.share({
             title: APP_NAME,
             text: APP_TAGLINE,
-            url: APP_URL,
+            url: shareUrl,
             dialogTitle: 'Share Lift',
           })
           return { kind: 'shared' }
@@ -74,7 +77,7 @@ export function useAppShare(): UseAppShareReturn {
       // Tier 2: Web Share API (iOS Safari PWA, Android Chrome).
       if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
         try {
-          await navigator.share({ title: APP_NAME, text: APP_TAGLINE, url: APP_URL })
+          await navigator.share({ title: APP_NAME, text: APP_TAGLINE, url: shareUrl })
           return { kind: 'shared' }
         } catch (err) {
           if (isCancellation(err)) return { kind: 'cancelled' }
@@ -83,7 +86,7 @@ export function useAppShare(): UseAppShareReturn {
       }
 
       // Tier 3: copy the link so the user can paste it anywhere.
-      if (await copyToClipboard(APP_URL)) return { kind: 'copied' }
+      if (await copyToClipboard(shareUrl)) return { kind: 'copied' }
       return { kind: 'unavailable' }
     } catch (err) {
       return { kind: 'error', error: err as Error }

--- a/src/lib/__tests__/appMeta.test.ts
+++ b/src/lib/__tests__/appMeta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { APP_URL, APP_NAME, APP_TAGLINE } from '../appMeta'
+import { APP_URL, APP_NAME, APP_TAGLINE, SHARE_REF, appUrlWithRef } from '../appMeta'
 
 /**
  * Pins the app-share identity constants. These feed the "Share Lift" entry
@@ -23,5 +23,36 @@ describe('appMeta', () => {
   it('APP_TAGLINE is non-empty and mentions the app', () => {
     expect(APP_TAGLINE.length).toBeGreaterThan(0)
     expect(APP_TAGLINE).toContain('Lift')
+  })
+})
+
+/**
+ * Pins the share-attribution helper (#798). The `?ref=` token it stamps must be
+ * read back verbatim by the acquisition capture (#715) — a drift here silently
+ * breaks the share → install funnel, logging every share-driven install as
+ * "direct".
+ */
+describe('appUrlWithRef', () => {
+  it('returns APP_URL unchanged when no ref is given', () => {
+    expect(appUrlWithRef()).toBe(APP_URL)
+  })
+
+  it('appends the share_app ref as a ?ref= query param', () => {
+    expect(appUrlWithRef(SHARE_REF.app)).toBe(`${APP_URL}/?ref=share_app`)
+  })
+
+  it('appends the share_card ref as a ?ref= query param', () => {
+    expect(appUrlWithRef(SHARE_REF.card)).toBe(`${APP_URL}/?ref=share_card`)
+  })
+
+  it('still targets the canonical deployment domain', () => {
+    expect(appUrlWithRef(SHARE_REF.app)).toContain('spa-rho-sandy.vercel.app')
+    expect(appUrlWithRef(SHARE_REF.app)).not.toContain('liftracker.app')
+  })
+
+  it('produces a ref the acquisition capture reads back to the same token', () => {
+    // Mirror useAcquisitionSource's parse: read `ref` from the URL's query.
+    const ref = new URL(appUrlWithRef(SHARE_REF.app)).searchParams.get('ref')
+    expect(ref).toBe(SHARE_REF.app)
   })
 })

--- a/src/lib/appMeta.ts
+++ b/src/lib/appMeta.ts
@@ -20,3 +20,32 @@ export const APP_NAME = 'Lift'
  */
 export const APP_TAGLINE =
   'Lift — a free, offline-capable workout tracker. Log sets, track estimated 1RM progress, and hit new PRs.'
+
+/**
+ * Attribution `?ref=` tokens stamped onto shared URLs so a share-driven install
+ * can be attributed back to the surface it came from (#798). These are the exact
+ * tokens the acquisition capture (#715) reads on first load — keep them short
+ * and matched there. Without a ref, every share-originated install logs as
+ * "direct" and the share→install funnel can't be measured.
+ */
+export const SHARE_REF = {
+  /** The "Share Lift" entry point that shares the app itself (#713). */
+  app: 'share_app',
+  /** A rasterized workout / PR card shared from the share sheet (#305 / #794). */
+  card: 'share_card',
+} as const
+
+export type ShareRef = (typeof SHARE_REF)[keyof typeof SHARE_REF]
+
+/**
+ * Build the canonical app URL with a `?ref=` attribution token appended, so the
+ * acquisition capture (#715) can close the share → install funnel. Returns
+ * `APP_URL` unchanged when no ref is supplied. Uses the URL API so an existing
+ * query (none today) would be preserved rather than clobbered.
+ */
+export function appUrlWithRef(ref?: ShareRef): string {
+  if (!ref) return APP_URL
+  const url = new URL(APP_URL)
+  url.searchParams.set('ref', ref)
+  return url.toString()
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-798](https://github.com/aschung212/Lift/issues/798)

Implement LIFT-798 (Growth, priority:3-medium): the app-share flow shared `APP_URL` verbatim, so every share-driven install logged as "direct" — the LIFT-715 acquisition capture reads `?ref=` but the shared link never carried one, breaking the share→install funnel. Add a ref-URL helper and stamp `share_app` onto the shared link across all share tiers.

## Changes
- `src/lib/appMeta.ts` — added `SHARE_REF` tokens (`share_app`, `share_card`), the `ShareRef` type, and `appUrlWithRef(ref?)` which builds the canonical URL with a `?ref=` query param via the URL API (returns `APP_URL` unchanged when no ref).
- `src/composables/useAppShare.ts` — compute `appUrlWithRef(SHARE_REF.app)` once and share it across all three tiers (native Capacitor, Web Share API, clipboard fallback) so the attribution survives whichever path fires.
- `src/lib/__tests__/appMeta.test.ts` — pin the helper: no-ref passthrough, `share_app`/`share_card` param shape, canonical-domain guard, and a round-trip asserting the acquisition capture (`new URL(...).searchParams.get('ref')`) reads back the exact token.
- `src/composables/__tests__/useAppShare.test.ts` — updated all tier expectations from `APP_URL` to the ref-tagged URL.

Scope note: the `share_card` token is defined but not yet wired — the card-share flow has no URL in master today (that's LIFT-794, which has its own open PR). The card flow can adopt `appUrlWithRef(SHARE_REF.card)` when it merges, without re-deriving the convention.

## Verification
- `npx vitest run` — 2274 passed, 1 skipped (118 files)
- `npm run lint` — clean
- `npm run build` — succeeds
- Gemini pre-push review did not run (`IneligibleTierError` — same environment/auth problem flagged in run1, not a finding)

## Screenshots
None — no UI surface changed (share payload URL only).

## Commits
- [`a49ab5a`](https://github.com/aschung212/Lift/commit/a49ab5a) feat(LIFT-798): tag share-flow URLs with a ?ref= attribution token

## Test Results
- Before: 2269 passing
- After: 2274 passing (5 delta)

---
_Automated by overnight pipeline — Thu Jun 18 23:26:10 PDT 2026_

## Preview
Test on your phone: https://lift-2nwarftse-aschung212-1101s-projects.vercel.app