### PR TITLE
feat(LIFT-796): log theme-unlock and streak-milestone analytics events

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -1040,6 +1040,12 @@ function maybeCelebrateWeeklyGoal(prShown: boolean): boolean {
   markGoalWeekCelebrated(decision.weekKey)
   const celebrated = presentGoalCelebration({ streak: decision.streak, milestone: decision.milestone, target: info.target })
   logEvent('weekly_goal_celebrated', { streak: decision.streak, milestone: decision.milestone })
+  // A streak-tier crossing (2/4/8/12-week multiplier bump) is a distinct
+  // progression-depth signal from simply hitting the weekly goal — emit a
+  // dedicated event so streak retention is filterable in the dashboard (#796).
+  if (decision.milestone) {
+    logEvent('streak_milestone', { streak: decision.streak, target: info.target })
+  }
   return celebrated
 }
 

--- a/src/composables/__tests__/useXPCeremony.test.ts
+++ b/src/composables/__tests__/useXPCeremony.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Spy on the analytics sink directly so we assert the real logEvent → track path.
+vi.mock('@vercel/analytics', () => ({ track: vi.fn() }))
+import { track } from '@vercel/analytics'
+const mockTrack = vi.mocked(track)
+
+// App review and XP instrumentation are side-effecting no-ops here.
+vi.mock('../useAppReview', () => ({
+  useAppReview: () => ({ requestReviewAtMoment: vi.fn() }),
+}))
+vi.mock('../../lib/xpInstrumentation', () => ({
+  logXPEvent: vi.fn(),
+  logBodyweightXPEvent: vi.fn(),
+}))
+
+// Configurable fake progression store. `checkUnlocks` drives the unlock path.
+const fakeStore = {
+  _userId: 'user-1',
+  epoch: 0,
+  progressionEnabled: true,
+  starterConfirmed: true,
+  starterTheme: 'fire',
+  showProgression: false,
+  progressPercent: 0,
+  totalXP: 0,
+  nextUnlockThreshold: 100,
+  unlockedThemes: [] as unknown[],
+  recordSetXP: vi.fn(),
+  creditSetXP: vi.fn(),
+  checkUnlocks: vi.fn(() => [] as string[]),
+}
+
+vi.mock('../../stores/progression', () => ({
+  useProgressionStore: () => fakeStore,
+  showXPToast: vi.fn(),
+  showUnlockCelebration: vi.fn(),
+}))
+
+import { useXPCeremony } from '../useXPCeremony'
+
+function ceremonyInput(overrides: Record<string, unknown> = {}) {
+  return {
+    setId: 'set-1',
+    exerciseId: 'ex-1',
+    xp: 10,
+    baseXP: 10,
+    zone: 'working' as const,
+    isPR: false,
+    isTie: false,
+    isRepPR: false,
+    activeTheme: 'eternal',
+    estimated1RM: 100,
+    exerciseBest1RM: 120,
+    streakMultiplier: 1,
+    ...overrides,
+  }
+}
+
+describe('useXPCeremony — theme_unlocked analytics (#796)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockTrack.mockClear()
+    fakeStore.checkUnlocks.mockReturnValue([])
+    fakeStore.unlockedThemes = []
+    fakeStore.totalXP = 0
+    fakeStore.epoch = 0
+  })
+
+  it('does not log theme_unlocked when no themes unlock', () => {
+    fakeStore.checkUnlocks.mockReturnValue([])
+    const { logSetXPCeremony } = useXPCeremony()
+    logSetXPCeremony(ceremonyInput())
+    const calls = mockTrack.mock.calls.filter(([name]) => name === 'theme_unlocked')
+    expect(calls).toHaveLength(0)
+  })
+
+  it('logs theme_unlocked with progression-depth props on an organic unlock', () => {
+    fakeStore.checkUnlocks.mockReturnValue(['water'])
+    fakeStore.unlockedThemes = [{ id: 'fire' }, { id: 'water' }]
+    fakeStore.totalXP = 250
+    fakeStore.epoch = 1
+    const { logSetXPCeremony } = useXPCeremony()
+    logSetXPCeremony(ceremonyInput())
+
+    expect(mockTrack).toHaveBeenCalledWith('theme_unlocked', {
+      theme: 'water',
+      totalXP: 250,
+      unlockedCount: 2,
+      epoch: 1,
+    })
+  })
+
+  it('logs one theme_unlocked event per newly unlocked theme', () => {
+    fakeStore.checkUnlocks.mockReturnValue(['fire', 'water', 'luck'])
+    fakeStore.unlockedThemes = [{ id: 'fire' }, { id: 'water' }, { id: 'luck' }]
+    const { logSetXPCeremony } = useXPCeremony()
+    logSetXPCeremony(ceremonyInput())
+
+    const calls = mockTrack.mock.calls.filter(([name]) => name === 'theme_unlocked')
+    expect(calls).toHaveLength(3)
+    expect(calls.map(([, props]) => (props as { theme: string }).theme)).toEqual([
+      'fire', 'water', 'luck',
+    ])
+  })
+
+  it('does not log theme_unlocked when progression is disabled (no unlock path)', () => {
+    fakeStore.progressionEnabled = false
+    fakeStore.checkUnlocks.mockReturnValue(['water'])
+    const { logSetXPCeremony } = useXPCeremony()
+    logSetXPCeremony(ceremonyInput())
+    const calls = mockTrack.mock.calls.filter(([name]) => name === 'theme_unlocked')
+    expect(calls).toHaveLength(0)
+    fakeStore.progressionEnabled = true
+  })
+})

--- a/src/composables/useXPCeremony.ts
+++ b/src/composables/useXPCeremony.ts
@@ -13,6 +13,7 @@ import { useProgressionStore, showXPToast, showUnlockCelebration } from '../stor
 import { XP_CONFIG } from '../lib/xp'
 import { logXPEvent, logBodyweightXPEvent } from '../lib/xpInstrumentation'
 import { useAppReview } from './useAppReview'
+import { useAnalytics } from './useAnalytics'
 import type { ThemeId } from './useTheme'
 
 export interface SetXPCeremonyInput {
@@ -46,6 +47,7 @@ export interface UseXPCeremonyReturn {
 export function useXPCeremony(): UseXPCeremonyReturn {
   const progressionStore = useProgressionStore()
   const { requestReviewAtMoment } = useAppReview()
+  const { logEvent } = useAnalytics()
 
   /**
    * Run the full XP ceremony for a logged workout set.
@@ -164,6 +166,22 @@ export function useXPCeremony(): UseXPCeremonyReturn {
   function _checkUnlocksAndCelebrate(onUnlock?: () => void): void {
     const newUnlocks = progressionStore.checkUnlocks()
     if (newUnlocks.length > 0) {
+      // Record each organically-earned unlock. Progression depth (how many
+      // themes a user has unlocked) is the strongest in-app correlate of
+      // long-term retention, so surface it in the analytics dashboard (#796).
+      // Fired from the in-session ceremony only — NOT the bulk migration path
+      // (celebrateUnlocks), which would otherwise log a burst of retroactive
+      // unlocks that don't reflect real engagement.
+      const unlockedCount = progressionStore.unlockedThemes.length
+      for (const themeId of newUnlocks) {
+        logEvent('theme_unlocked', {
+          theme: themeId,
+          totalXP: progressionStore.totalXP,
+          unlockedCount,
+          epoch: progressionStore.epoch,
+        })
+      }
+
       const theme = THEMES.find(t => t.id === newUnlocks[0])
       if (theme) {
         setTimeout(() => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-796](https://github.com/aschung212/Lift/issues/796)

Implement LIFT-796 (Growth, priority:3-medium): the XP system's theme-unlock and streak-milestone ceremonies fire visible celebrations but were never recorded as analytics events. Progression depth is the strongest in-app correlate of long-term retention, so the dashboard was blind to whether the XP system actually retains users. Add lightweight events at the existing celebration call sites.

## Changes
- **`src/composables/useXPCeremony.ts`** — imported `useAnalytics`; in `_checkUnlocksAndCelebrate` emit one `theme_unlocked` event per newly unlocked theme with progression-depth props (`theme`, `totalXP`, `unlockedCount`, `epoch`). Fired only from the in-session ceremony, deliberately NOT from the bulk migration path (`celebrateUnlocks`), which would log a burst of retroactive unlocks that don't reflect real engagement.
- **`src/components/WorkoutTracker.vue`** — in `maybeCelebrateWeeklyGoal`, emit a dedicated `streak_milestone` event (`streak`, `target`) only on streak-tier crossings (`decision.milestone`), distinct from the existing `weekly_goal_celebrated` that fires on every weekly-goal hit — gives a cleanly filterable streak-retention signal.
- **`src/composables/__tests__/useXPCeremony.test.ts`** (new) — 4 tests covering no-unlock, single-unlock (asserts exact props), multi-unlock (one event per theme), and progression-disabled paths. The milestone gating logic is already covered by `goalCelebration.test.ts:56`.

## Verification
- `npm run lint` — clean
- `npm test` — 2273 passed | 1 skipped (added 4 new tests). The single non-failing console error from `CalendarView.test.ts` → `MuscleGroupChart.vue:64` is pre-existing (passes in isolation; unrelated to this diff, which only touches XP ceremony + WorkoutTracker celebration paths).
- `npm run build` — built successfully (PWA precache 51 entries)

## Screenshots
None — analytics-only change with no UI surface.

## Commits
- [`f0cee7e`](https://github.com/aschung212/Lift/commit/f0cee7e) feat(LIFT-796): log theme-unlock and streak-milestone analytics events

## Test Results
- Before: 2269 passing
- After: 2273 passing (4 delta)

---
_Automated by overnight pipeline — Thu Jun 18 23:35:03 PDT 2026_

## Preview
Test on your phone: https://lift-hvbn4a2my-aschung212-1101s-projects.vercel.app