### PR TITLE
feat(LIFT-811): add cross-origin isolation headers (COOP / CORP) to vercel.json

### DIFF
--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -64,6 +64,34 @@ describe('vercel.json security headers', () => {
     })
   })
 
+  describe('cross-origin isolation (LIFT-811)', () => {
+    /**
+     * COOP severs the window.opener relationship for cross-origin
+     * navigations, defeating tabnabbing and enabling browser process
+     * isolation. The `same-origin-allow-popups` variant (not the stricter
+     * `same-origin`) is deliberate: it keeps the opener reference for
+     * popups WE open, which the Supabase OAuth and native share-sheet
+     * redirect flows rely on. Do not tighten to `same-origin` without
+     * re-verifying those flows.
+     */
+    it('sets Cross-Origin-Opener-Policy to same-origin-allow-popups', () => {
+      expect(getHeader(globalRule, 'Cross-Origin-Opener-Policy')).toBe(
+        'same-origin-allow-popups'
+      )
+    })
+
+    /**
+     * CORP blocks other origins from embedding our responses as
+     * sub-resources. Everything Lift serves is same-origin, so
+     * `same-origin` is the safe, maximally-restrictive choice.
+     */
+    it('sets Cross-Origin-Resource-Policy to same-origin', () => {
+      expect(getHeader(globalRule, 'Cross-Origin-Resource-Policy')).toBe(
+        'same-origin'
+      )
+    })
+  })
+
   describe('Content-Security-Policy', () => {
     const csp = getHeader(globalRule, 'Content-Security-Policy') ?? ''
 

--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,8 @@
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" },
+        { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://vitals.vercel-insights.com; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-811](https://github.com/aschung212/Lift/issues/811)

Implement LIFT-811 (priority 3-medium, Security): add cross-origin isolation headers to the global `/(.*)` header rule in `vercel.json`, complementing the existing HSTS / X-Frame-Options / CSP hardening.

## Changes
- **`vercel.json`** — added two headers to the global rule:
  - `Cross-Origin-Opener-Policy: same-origin-allow-popups` — severs `window.opener` on cross-origin navigations (tabnabbing defense + browser process isolation). The `allow-popups` variant is deliberate so the Supabase OAuth and native share-sheet popup flows keep working.
  - `Cross-Origin-Resource-Policy: same-origin` — blocks other origins from embedding our responses; safe because everything Lift serves is same-origin.
- **`src/lib/__tests__/vercelHeadersRegression.test.ts`** — added a `cross-origin isolation (LIFT-811)` describe block pinning both header values, with comments documenting why `same-origin-allow-popups` (not the stricter `same-origin`) was chosen.

## Verification
- `vercelHeadersRegression.test.ts`: 19 passed (2 new)
- `npm run lint`: clean
- `npm run build`: succeeded
- Branch `enhance/run2-2026-06-23` pushed to origin (PR not yet opened by pipeline)

Note: the pre-push Gemini 3.1 Pro review could not run — `IneligibleTierError: UNSUPPORTED_CLIENT` (the Gemini Code Assist free tier was decommissioned for this client). This is an environment/auth failure, not a code issue. Flagging so the review gate can be re-pointed.

## Screenshots
N/A — configuration/headers change only, no UI surface.

## Commits
- [`faf686d`](https://github.com/aschung212/Lift/commit/faf686d) feat(LIFT-811): add cross-origin isolation headers (COOP / CORP) to vercel.json

## Test Results
- Before: 2269 passing
- After: 2271 passing (2 delta)

---
_Automated by overnight pipeline — Tue Jun 23 23:11:47 PDT 2026_

## Preview
Test on your phone: https://lift-j6vsbrxx5-aschung212-1101s-projects.vercel.app