### PR TITLE
chore(LIFT-812): migrate share-card rasterizer from html-to-image to modern-screenshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@supabase/supabase-js": "^2.108.2",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "html-to-image": "^1.11.13",
+        "modern-screenshot": "^4.7.0",
         "pinia": "^3.0.4",
         "vue": "^3.5.38"
       },
@@ -6630,12 +6630,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/html-to-image": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
-      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
-      "license": "MIT"
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -7950,6 +7944,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/modern-screenshot": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/modern-screenshot/-/modern-screenshot-4.7.0.tgz",
+      "integrity": "sha512-9YxN+ddPSMMlhylOv25VHzXrl9u67QRxoh7+SEewGtgUw7t6hHTrjptSDJUSne9oG4Xk/h2cwG15nIt4Hc9ujg==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@supabase/supabase-js": "^2.108.2",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "html-to-image": "^1.11.13",
+    "modern-screenshot": "^4.7.0",
     "pinia": "^3.0.4",
     "vue": "^3.5.38"
   },

--- a/src/composables/__tests__/useWorkoutShare.test.ts
+++ b/src/composables/__tests__/useWorkoutShare.test.ts
@@ -5,7 +5,7 @@ import type { SessionSummary } from '../../lib/sessionSummary'
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
-// Mock html-to-image at the module level — renderNodeToBlob calls `toBlob`
+// Mock modern-screenshot at the module level — renderNodeToBlob calls `domToBlob`
 // internally. We mock the higher-level shareImage module so we don't need
 // a real DOM rasterizer.
 const mockRenderNodeToBlob = vi.fn<(node: HTMLElement, opts: unknown) => Promise<Blob>>()

--- a/src/composables/useWorkoutShare.ts
+++ b/src/composables/useWorkoutShare.ts
@@ -3,7 +3,7 @@
  *   1. Mount a card component offscreen (detached Vue app, no Pinia needed —
  *      cards are pure presentational components that take a typed summary prop).
  *   2. Wait for the next tick so the DOM and CSS are settled, then rasterize
- *      the card to a PNG Blob via `html-to-image`.
+ *      the card to a PNG Blob via `modern-screenshot`.
  *   3. Share via the native iOS share sheet (Capacitor), the Web Share API
  *      (browser, iOS Safari 16.4+ supports image files), or fall back to a
  *      direct download — same Blob → URL.createObjectURL pattern App.vue
@@ -83,7 +83,7 @@ function downloadBlob(blob: Blob, filename: string): void {
 /**
  * The list of theme custom properties consumed by share cards. Snapshotted
  * from the live document at render time and inlined onto the offscreen
- * host so theme variables resolve inside `html-to-image`'s cloned subtree
+ * host so theme variables resolve inside `modern-screenshot`'s cloned subtree
  * (where the original `[data-theme="X"][data-mode="Y"]` selectors don't
  * reliably match — the clone lives outside the original cascade).
  */
@@ -122,9 +122,9 @@ function snapshotThemeVars(): string {
 async function renderCardOffscreen(req: ShareCardRequest): Promise<Blob> {
   const { width, height } = PREVIEW_SIZE[req.format]
   const host = document.createElement('div')
-  // Offscreen but rendered: html-to-image needs the node in the DOM with real
-  // layout. Inline the resolved theme variables onto the host so they survive
-  // html-to-image's clone-and-rehome step (the `[data-theme=…]` selectors
+  // Offscreen but rendered: modern-screenshot needs the node in the DOM with
+  // real layout. Inline the resolved theme variables onto the host so they
+  // survive modern-screenshot's clone-and-rehome step (the `[data-theme=…]` selectors
   // don't reliably match in the cloned subtree, which leaves the rasterized
   // image blank). Explicit `position: relative` on the inner provides the
   // containing block for cards' absolute children.

--- a/src/lib/__tests__/shareImage.test.ts
+++ b/src/lib/__tests__/shareImage.test.ts
@@ -1,13 +1,56 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock modern-screenshot's domToBlob so we can assert the option mapping
+// without a real DOM rasterizer. Pins the html-to-image → modern-screenshot
+// migration (#812): `pixelRatio` → `scale`, `cacheBust` → `fetch.bypassingCache`.
+const mockDomToBlob = vi.fn<() => Promise<Blob>>(() => Promise.resolve(new Blob()))
+vi.mock('modern-screenshot', () => ({
+  domToBlob: (...args: unknown[]) => mockDomToBlob(...(args as [])),
+}))
+
 import {
   defaultShareFilename,
   PREVIEW_SIZE,
   EXPORT_PIXEL_RATIO,
   WATERMARK_TEXT,
   createWatermarkElement,
+  renderNodeToBlob,
 } from '../shareImage'
 
 describe('shareImage', () => {
+  describe('renderNodeToBlob', () => {
+    beforeEach(() => {
+      mockDomToBlob.mockClear()
+    })
+
+    it('rasterizes via modern-screenshot domToBlob with mapped options', async () => {
+      const node = document.createElement('div')
+      await renderNodeToBlob(node, { width: 360, height: 640 })
+
+      expect(mockDomToBlob).toHaveBeenCalledTimes(1)
+      const [passedNode, opts] = mockDomToBlob.mock.calls[0] as [HTMLElement, Record<string, unknown>]
+      expect(passedNode).toBe(node)
+      expect(opts.width).toBe(360)
+      expect(opts.height).toBe(640)
+      // pixelRatio defaults to EXPORT_PIXEL_RATIO and maps to `scale`.
+      expect(opts.scale).toBe(EXPORT_PIXEL_RATIO)
+      // cacheBust maps to modern-screenshot's fetch.bypassingCache.
+      expect(opts.fetch).toEqual({ bypassingCache: true })
+      // Transparent background so card corners aren't filled.
+      expect(opts.backgroundColor).toBeNull()
+    })
+
+    it('honors an explicit pixelRatio override via the scale option', async () => {
+      await renderNodeToBlob(document.createElement('div'), {
+        width: 100,
+        height: 100,
+        pixelRatio: 2,
+      })
+      const [, opts] = mockDomToBlob.mock.calls[0] as [HTMLElement, Record<string, unknown>]
+      expect(opts.scale).toBe(2)
+    })
+  })
+
   describe('defaultShareFilename', () => {
     it('builds a YYYY-MM-DD prefixed filename for square format', () => {
       expect(defaultShareFilename('2026-04-21')).toBe('lift-2026-04-21.png')
@@ -41,7 +84,7 @@ describe('shareImage', () => {
       expect(createWatermarkElement().hasAttribute('data-share-watermark')).toBe(true)
     })
 
-    it('inlines positioning styles so they survive html-to-image cloning', () => {
+    it('inlines positioning styles so they survive modern-screenshot cloning', () => {
       // Class-based styles are stripped in the cloned subtree; inline styles
       // are not. The watermark must be anchored bottom-right and non-interactive.
       const { style } = createWatermarkElement()

--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -8,7 +8,7 @@
  * the pixelRatio multiplier produces the resolution platforms expect.
  */
 
-import { toBlob } from 'html-to-image'
+import { domToBlob } from 'modern-screenshot'
 
 export type CardFormat = 'square' | 'story'
 
@@ -34,19 +34,23 @@ export const EXPORT_PIXEL_RATIO = 3 // 360 → 1080, 640 → 1920
  *
  * The node is expected to be already mounted in the DOM. The caller's
  * positioning (typically `position:absolute; left:-10000px` to keep it
- * offscreen) is overridden via the `style` option below — html-to-image
+ * offscreen) is overridden via the `style` option below — modern-screenshot
  * preserves the cloned element's positioning into its SVG foreignObject,
  * and a clone with `left: -10000px` renders entirely outside the SVG
  * viewport, producing a transparent PNG. Forcing the clone to render at
  * (0,0) inside the foreignObject is what we want.
  */
 export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): Promise<Blob> {
-  const blob = await toBlob(node, {
+  return domToBlob(node, {
     width: opts.width,
     height: opts.height,
-    pixelRatio: opts.pixelRatio ?? EXPORT_PIXEL_RATIO,
-    cacheBust: true,
-    backgroundColor: undefined,
+    // modern-screenshot calls the density multiplier `scale` (html-to-image
+    // called it `pixelRatio`); both mean "DPI = 96 * value".
+    scale: opts.pixelRatio ?? EXPORT_PIXEL_RATIO,
+    // Cache-bust embedded image fetches so a stale CORS-tainted response
+    // can't poison the canvas (html-to-image's `cacheBust: true`).
+    fetch: { bypassingCache: true },
+    backgroundColor: null,
     style: {
       position: 'static',
       left: 'auto',
@@ -57,8 +61,6 @@ export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): 
       margin: '0',
     },
   })
-  if (!blob) throw new Error('html-to-image returned null blob')
-  return blob
 }
 
 /**
@@ -85,7 +87,7 @@ export const SHARE_CARD_HANDLE = 'spa-rho-sandy.vercel.app'
 /**
  * Build the watermark element used by the offscreen export pipeline.
  *
- * Styles are inlined (not class-based) so they survive `html-to-image`'s
+ * Styles are inlined (not class-based) so they survive `modern-screenshot`'s
  * clone-and-rehome step, which strips selectors that don't match in the
  * cloned subtree. Positioned absolute in the bottom-right corner of the
  * card's `position:relative` host.


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-812](https://github.com/aschung212/Lift/issues/812)

Implement LIFT-812 (priority 3-medium, Security/dependency-maintenance): replace the sparsely-maintained `html-to-image@1.11.13` share-card rasterizer with the actively maintained, near-drop-in `modern-screenshot` fork, validating against the existing share snapshot/unit tests.

## Changes
- **`src/lib/shareImage.ts`** — swapped `import { toBlob } from 'html-to-image'` for `import { domToBlob } from 'modern-screenshot'`. Mapped options: `pixelRatio` → `scale`, `cacheBust: true` → `fetch: { bypassingCache: true }`, `backgroundColor: undefined` → `null`. Removed the now-impossible null-blob guard (`domToBlob` returns `Promise<Blob>`, never null). Updated doc comments referencing the old lib.
- **`src/composables/useWorkoutShare.ts`** — updated the three `html-to-image` comment references (clone-and-rehome behavior is identical between the libs, so no logic change).
- **`src/lib/__tests__/shareImage.test.ts`** — added a `renderNodeToBlob` regression suite mocking `modern-screenshot` to pin the option mapping (`scale`, `fetch.bypassingCache`, transparent `backgroundColor`), so future API drift breaks loudly. Updated the watermark test description.
- **`src/composables/__tests__/useWorkoutShare.test.ts`** — updated the module-mock comment.
- **`package.json` / `package-lock.json`** — added `modern-screenshot@^4.7.0`, removed `html-to-image`.

## Verification
- `npm run lint` — clean
- `npm run build` — succeeds (typecheck + vite build); SharePickerSheet chunk now bundles modern-screenshot
- `npx vitest run` — 2269 passed, 1 skipped (118 files); shareImage suite now 9 tests
- Branch pushed to `origin/enhance/run3-2026-06-23`. Gemini pre-push review gate errored (`IneligibleTierError: UNSUPPORTED_CLIENT` — same outage flagged in run 2; needs operator re-auth, not a code issue).

## Screenshots
None — this is a dependency swap with identical rendering API; no visual surface change. Share-card visual parity should be sanity-checked on the Vercel preview before merge.

## Commits
- [`e4f6000`](https://github.com/aschung212/Lift/commit/e4f6000) chore(LIFT-812): migrate share-card rasterizer from html-to-image to modern-screenshot

## Test Results
- Before: 2269 passing
- After: 2271 passing (2 delta)

---
_Automated by overnight pipeline — Tue Jun 23 23:19:45 PDT 2026_

## Preview
Test on your phone: https://lift-8zw7okjad-aschung212-1101s-projects.vercel.app