### PR TITLE
fix(LIFT-809): hash inline theme bootstrap and drop script-src 'unsafe-inline'

### DIFF
--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { createHash } from 'node:crypto'
 
 interface HeaderRule {
   source: string
@@ -30,6 +31,21 @@ function loadVercelConfig(): VercelConfig {
   const path = resolve(__dirname, '../../../vercel.json')
   const raw = readFileSync(path, 'utf8')
   return JSON.parse(raw) as VercelConfig
+}
+
+/**
+ * Compute the CSP `'sha256-…'` source-expression for every attribute-less
+ * inline `<script>` block in index.html, exactly the way a browser does:
+ * SHA-256 over the raw UTF-8 bytes between the tags, base64-encoded. Vite
+ * emits these inline blocks verbatim (it only rewrites the external
+ * `type="module"` entry), so the source hash matches what ships.
+ */
+function inlineScriptHashes(): string[] {
+  const html = readFileSync(resolve(__dirname, '../../../index.html'), 'utf8')
+  const matches = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)]
+  return matches.map(
+    m => `sha256-${createHash('sha256').update(m[1], 'utf8').digest('base64')}`
+  )
 }
 
 function findGlobalHeaderRule(config: VercelConfig): HeaderRule {
@@ -80,13 +96,32 @@ describe('vercel.json security headers', () => {
       expect(csp).toMatch(/default-src\s+'self'/)
     })
 
-    it('restricts script-src to self (+ unsafe-inline for the index.html theme script)', () => {
-      expect(csp).toMatch(/script-src\s+[^;]*'self'/)
-      // We still allow 'unsafe-inline' for the splash theme bootstrap
-      // script — remove this branch once we ship a nonce/hash strategy.
-      expect(csp).toMatch(/script-src\s+[^;]*'unsafe-inline'/)
+    it('restricts script-src to self + a hash of the inline theme bootstrap (no unsafe-inline)', () => {
+      const scriptSrc = csp.match(/script-src\s+([^;]*)/)?.[1] ?? ''
+      expect(scriptSrc).toMatch(/'self'/)
+      // 'unsafe-inline' negates almost all script-XSS protection (LIFT-809).
+      // The single static inline script (index.html theme bootstrap) is
+      // allow-listed by its SHA-256 hash instead.
+      expect(scriptSrc).not.toContain("'unsafe-inline'")
       // Explicitly ensure no third-party CDN is allow-listed
-      expect(csp).not.toMatch(/script-src[^;]*https?:\/\//)
+      expect(scriptSrc).not.toMatch(/https?:\/\//)
+    })
+
+    /**
+     * Pins the inline-script hash to the actual bytes of index.html. If the
+     * theme bootstrap script changes without vercel.json being updated, its
+     * hash no longer appears in the CSP and the script is blocked at runtime —
+     * this test fails loudly in CI instead of shipping a broken page.
+     */
+    it('allow-lists every inline index.html script by its current SHA-256 hash', () => {
+      const hashes = inlineScriptHashes()
+      // Guard against a future refactor that adds/removes inline scripts
+      // silently — there must be exactly the one theme bootstrap block.
+      expect(hashes).toHaveLength(1)
+      const scriptSrc = csp.match(/script-src\s+([^;]*)/)?.[1] ?? ''
+      for (const hash of hashes) {
+        expect(scriptSrc).toContain(`'${hash}'`)
+      }
     })
 
     it('allows Supabase REST + realtime on connect-src', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -38,7 +38,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://vitals.vercel-insights.com; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'sha256-gdavMfd7R79xglXona5yKo4oOaKd9LKzVPC4qWNJri8='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://vitals.vercel-insights.com; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-809](https://github.com/aschung212/Lift/issues/809)

Implement LIFT-809 (priority 2-high, Security): remove `script-src 'unsafe-inline'` from the CSP in `vercel.json` by allow-listing the single static inline theme-bootstrap script (`index.html`) via its SHA-256 hash, and pin that hash with a regression test that breaks loudly if the inline script changes.

## Changes
- **`vercel.json`** — replaced `script-src 'self' 'unsafe-inline'` with `script-src 'self' 'sha256-gdavMfd7R79xglXona5yKo4oOaKd9LKzVPC4qWNJri8='`. `style-src 'unsafe-inline'` is intentionally kept (Vue/splash inject runtime styles; out of scope).
- **`src/lib/__tests__/vercelHeadersRegression.test.ts`** — added `inlineScriptHashes()` that derives the `'sha256-…'` source-expression from `index.html`'s exact bytes the way a browser does. Rewrote the script-src test to assert no `'unsafe-inline'` and added a test that pins the live hash into the CSP (fails in CI if the bootstrap script changes without updating `vercel.json`), plus a guard that there is exactly one inline block.

Verified Vercel Analytics/Speed Insights inject same-origin (`/_vercel/...`) external scripts already covered by `'self'`, and confirmed via a production build that Vite emits the inline block verbatim, so the source hash matches what ships.

## Verification
- `npm run lint` — clean
- `npm run typecheck` (`vue-tsc --noEmit`) — clean
- `npx vitest run` — 2270 passed, 1 skipped (the lone parallel-import warning on `MuscleGroupChart.vue` is pre-existing and disappears when the file runs in isolation)
- `npm run build` — succeeds; dist/index.html inline script byte-identical to source (hash valid)
- Targeted: `vercelHeadersRegression.test.ts` — 18 passed

Note: had to `npm install` first — node_modules was out of sync (`html-to-image` in package.json but absent on disk), which was failing the build independent of this change.

## Screenshots
N/A — config + test change only, no UI surface.

## Commits
- [`614cf76`](https://github.com/aschung212/Lift/commit/614cf76) fix(LIFT-809): hash inline theme bootstrap and drop script-src 'unsafe-inline'

## Test Results
- Before: 2196 passing
- After: 2270 passing (74 delta)

---
_Automated by overnight pipeline — Tue Jun 23 23:29:25 PDT 2026_

## Preview
Test on your phone: https://lift-fsh6txh91-aschung212-1101s-projects.vercel.app