### PR TITLE
feat(LIFT-810): forward CSP violations to Sentry via a client-side listener

### DIFF
--- a/src/lib/__tests__/cspReporting.test.ts
+++ b/src/lib/__tests__/cspReporting.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for client-side CSP violation reporting (LIFT-810).
+ *
+ * The reporter is the only telemetry path for blocked resources, so the dedupe
+ * and rate-cap behavior is load-bearing: without it a single misconfigured
+ * policy (or a hostile injection loop) could flood Sentry from one page load.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  createCspReporter,
+  extractViolation,
+  violationKey,
+  violationSummary,
+  type CspViolationReport,
+} from '../cspReporting'
+
+/** Build a fake SecurityPolicyViolationEvent with sensible defaults. */
+function fakeEvent(
+  overrides: Partial<SecurityPolicyViolationEvent> = {},
+): SecurityPolicyViolationEvent {
+  return {
+    documentURI: 'https://spa-rho-sandy.vercel.app/',
+    violatedDirective: 'script-src',
+    effectiveDirective: 'script-src',
+    blockedURI: 'https://evil.example.com/x.js',
+    sourceFile: 'https://spa-rho-sandy.vercel.app/',
+    lineNumber: 10,
+    columnNumber: 5,
+    disposition: 'enforce',
+    ...overrides,
+  } as SecurityPolicyViolationEvent
+}
+
+describe('extractViolation', () => {
+  it('pulls the reportable fields off the event', () => {
+    const report = extractViolation(fakeEvent())
+    expect(report).toEqual<CspViolationReport>({
+      documentURI: 'https://spa-rho-sandy.vercel.app/',
+      violatedDirective: 'script-src',
+      effectiveDirective: 'script-src',
+      blockedURI: 'https://evil.example.com/x.js',
+      sourceFile: 'https://spa-rho-sandy.vercel.app/',
+      lineNumber: 10,
+      columnNumber: 5,
+      disposition: 'enforce',
+    })
+  })
+
+  it('falls back from effectiveDirective to legacy violatedDirective', () => {
+    const report = extractViolation(
+      fakeEvent({ effectiveDirective: '', violatedDirective: 'img-src' }),
+    )
+    expect(report.effectiveDirective).toBe('img-src')
+    expect(report.violatedDirective).toBe('img-src')
+  })
+
+  it('defaults missing numeric/string fields rather than emitting undefined', () => {
+    const report = extractViolation({
+      effectiveDirective: 'style-src',
+    } as SecurityPolicyViolationEvent)
+    expect(report.lineNumber).toBe(0)
+    expect(report.columnNumber).toBe(0)
+    expect(report.blockedURI).toBe('')
+    expect(report.documentURI).toBe('')
+  })
+})
+
+describe('violationKey', () => {
+  it('keys on directive + blocked resource', () => {
+    expect(violationKey(extractViolation(fakeEvent()))).toBe(
+      'script-src|https://evil.example.com/x.js',
+    )
+  })
+})
+
+describe('violationSummary', () => {
+  it('produces a readable one-liner for grouping in Sentry', () => {
+    expect(violationSummary(extractViolation(fakeEvent()))).toBe(
+      'CSP violation: script-src blocked https://evil.example.com/x.js',
+    )
+  })
+
+  it('labels an inline (empty blockedURI) violation as inline', () => {
+    const report = extractViolation(fakeEvent({ blockedURI: '' }))
+    expect(violationSummary(report)).toBe('CSP violation: script-src blocked inline')
+  })
+})
+
+describe('createCspReporter', () => {
+  it('forwards a violation to the sink', () => {
+    const sink = vi.fn()
+    const reporter = createCspReporter(sink)
+    reporter.handleViolation(fakeEvent())
+    expect(sink).toHaveBeenCalledTimes(1)
+    expect(sink.mock.calls[0][0].blockedURI).toBe('https://evil.example.com/x.js')
+  })
+
+  it('dedupes repeated violations of the same directive + resource', () => {
+    const sink = vi.fn()
+    const reporter = createCspReporter(sink)
+    reporter.handleViolation(fakeEvent())
+    reporter.handleViolation(fakeEvent())
+    reporter.handleViolation(fakeEvent())
+    expect(sink).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reports distinct directive/resource pairs', () => {
+    const sink = vi.fn()
+    const reporter = createCspReporter(sink)
+    reporter.handleViolation(fakeEvent({ blockedURI: 'https://a.example/x.js' }))
+    reporter.handleViolation(fakeEvent({ blockedURI: 'https://b.example/y.js' }))
+    reporter.handleViolation(fakeEvent({ effectiveDirective: 'img-src' }))
+    expect(sink).toHaveBeenCalledTimes(3)
+  })
+
+  it('caps total forwards per page load', () => {
+    const sink = vi.fn()
+    const reporter = createCspReporter(sink, { maxReports: 2 })
+    reporter.handleViolation(fakeEvent({ blockedURI: 'https://a.example/1.js' }))
+    reporter.handleViolation(fakeEvent({ blockedURI: 'https://b.example/2.js' }))
+    reporter.handleViolation(fakeEvent({ blockedURI: 'https://c.example/3.js' }))
+    expect(sink).toHaveBeenCalledTimes(2)
+  })
+
+  it('start/stop bind and unbind the document listener', () => {
+    const target = new EventTarget()
+    const sink = vi.fn()
+    const reporter = createCspReporter(sink)
+
+    reporter.start(target)
+    target.dispatchEvent(
+      Object.assign(new Event('securitypolicyviolation'), fakeEvent()),
+    )
+    expect(sink).toHaveBeenCalledTimes(1)
+
+    reporter.stop(target)
+    target.dispatchEvent(
+      Object.assign(new Event('securitypolicyviolation'), fakeEvent({
+        blockedURI: 'https://other.example/z.js',
+      })),
+    )
+    expect(sink).toHaveBeenCalledTimes(1)
+  })
+
+  it('start is idempotent (no duplicate listeners)', () => {
+    const target = new EventTarget()
+    const sink = vi.fn()
+    const reporter = createCspReporter(sink)
+    reporter.start(target)
+    reporter.start(target)
+    target.dispatchEvent(
+      Object.assign(new Event('securitypolicyviolation'), fakeEvent()),
+    )
+    expect(sink).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('main.ts wiring (LIFT-810)', () => {
+  const mainSrc = readFileSync(resolve(__dirname, '../../main.ts'), 'utf-8')
+
+  it('imports the CSP reporter', () => {
+    expect(mainSrc).toMatch(/from\s*['"]\.\/lib\/cspReporting['"]/)
+  })
+
+  it('gates CSP reporting behind the native-platform check (web-only)', () => {
+    // The native Capacitor build serves no Vercel CSP header, so no violations
+    // can fire there — keep the listener web-only like the analytics gating.
+    expect(mainSrc).toMatch(/createCspReporter/)
+    // The call site is the last `createCspReporter` reference (the first is the
+    // import). It must sit after an `if (!isNative)` gate.
+    const callSite = mainSrc.lastIndexOf('createCspReporter')
+    const nativeGate = mainSrc.lastIndexOf('if (!isNative)', callSite)
+    expect(nativeGate).toBeGreaterThan(-1)
+  })
+
+  it('routes violations through logError so they reach Sentry', () => {
+    expect(mainSrc).toMatch(/logError\([^)]*cspViolation/)
+  })
+})

--- a/src/lib/cspReporting.ts
+++ b/src/lib/cspReporting.ts
@@ -1,0 +1,111 @@
+/**
+ * Client-side Content-Security-Policy violation reporting (LIFT-810).
+ *
+ * Why not `report-uri` / `report-to` in vercel.json?
+ * Those directives need a *static* endpoint URL baked into the HTTP header at
+ * build time. Our Sentry ingest endpoint is derived from `VITE_SENTRY_DSN`, a
+ * runtime env var — hardcoding (or worse, fabricating) the Sentry security URL
+ * into the static `vercel.json` header would violate the SEV1 no-fabricate rule
+ * and leak/duplicate the DSN. Instead we listen for the browser's
+ * `securitypolicyviolation` event, which carries the same fields a CSP report
+ * would, and forward it through the already-initialized Sentry transport. This
+ * keeps the single source of truth for the DSN in one place (main.ts) and works
+ * in any browser that enforces the CSP header Vercel serves.
+ *
+ * The reporter dedupes by directive+resource and caps total forwards per page
+ * load so a misconfiguration (or a hostile injection loop) can never flood
+ * Sentry from a single session.
+ */
+
+/** Normalized subset of `SecurityPolicyViolationEvent` we forward. */
+export interface CspViolationReport {
+  documentURI: string
+  violatedDirective: string
+  effectiveDirective: string
+  blockedURI: string
+  sourceFile: string
+  lineNumber: number
+  columnNumber: number
+  disposition: string
+}
+
+/** Pull the reportable fields off a `securitypolicyviolation` event. */
+export function extractViolation(event: SecurityPolicyViolationEvent): CspViolationReport {
+  return {
+    documentURI: event.documentURI ?? '',
+    // `effectiveDirective` is the modern field; `violatedDirective` is the
+    // legacy alias some engines still emit, so fall back between them.
+    violatedDirective: event.violatedDirective || event.effectiveDirective || '',
+    effectiveDirective: event.effectiveDirective || event.violatedDirective || '',
+    blockedURI: event.blockedURI ?? '',
+    sourceFile: event.sourceFile ?? '',
+    lineNumber: event.lineNumber ?? 0,
+    columnNumber: event.columnNumber ?? 0,
+    disposition: event.disposition ?? '',
+  }
+}
+
+/** Stable dedupe key — one report per (directive, blocked resource) pair. */
+export function violationKey(report: CspViolationReport): string {
+  return `${report.effectiveDirective}|${report.blockedURI}`
+}
+
+/** Human-readable one-line summary used as the Sentry issue title. */
+export function violationSummary(report: CspViolationReport): string {
+  const directive = report.effectiveDirective || 'unknown-directive'
+  const resource = report.blockedURI || 'inline'
+  return `CSP violation: ${directive} blocked ${resource}`
+}
+
+export interface CspReporter {
+  /** Process a single violation event (exposed for testing). */
+  handleViolation: (event: SecurityPolicyViolationEvent) => void
+  /** Begin listening for violations on the given target (defaults to document). */
+  start: (target?: EventTarget) => void
+  /** Stop listening. */
+  stop: () => void
+}
+
+export interface CspReporterOptions {
+  /** Max number of violations forwarded per page load (default 20). */
+  maxReports?: number
+}
+
+/**
+ * Create a CSP reporter that forwards deduped, rate-capped violations to the
+ * supplied sink. The sink is where Sentry wiring lives (see main.ts) — the
+ * module itself has no Sentry dependency, which keeps it trivially testable.
+ */
+export function createCspReporter(
+  forward: (report: CspViolationReport) => void,
+  options: CspReporterOptions = {},
+): CspReporter {
+  const maxReports = options.maxReports ?? 20
+  const seen = new Set<string>()
+  let count = 0
+  let listener: ((event: Event) => void) | null = null
+
+  function handleViolation(event: SecurityPolicyViolationEvent): void {
+    if (count >= maxReports) return
+    const report = extractViolation(event)
+    const key = violationKey(report)
+    if (seen.has(key)) return
+    seen.add(key)
+    count += 1
+    forward(report)
+  }
+
+  function start(target: EventTarget = document): void {
+    if (listener) return
+    listener = (event: Event): void => handleViolation(event as SecurityPolicyViolationEvent)
+    target.addEventListener('securitypolicyviolation', listener)
+  }
+
+  function stop(target: EventTarget = document): void {
+    if (!listener) return
+    target.removeEventListener('securitypolicyviolation', listener)
+    listener = null
+  }
+
+  return { handleViolation, start, stop }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { injectSpeedInsights } from '@vercel/speed-insights'
 import { initNativePlugins } from './lib/native'
 import { initTheme } from './composables/useTheme'
 import { setSentryCaptureException, logError } from './lib/logger'
+import { createCspReporter, violationSummary } from './lib/cspReporting'
 import { isNative } from './lib/platform'
 import App from './App.vue'
 import './index.css'
@@ -69,6 +70,20 @@ if (sentryDsn && import.meta.env.PROD) {
     })
     setSentryCaptureException((err, ctx) => Sentry.captureException(err, { extra: ctx }))
   })
+}
+
+// ── CSP violation reporting (LIFT-810) ────────────────────────
+// Forward Content-Security-Policy violations to Sentry so a blocked resource —
+// whether a real injection attempt or a self-inflicted policy misconfiguration
+// — surfaces in telemetry instead of failing silently. Web-only: the native
+// Capacitor build serves no Vercel CSP header, so no violations can fire there.
+if (!isNative) {
+  const cspReporter = createCspReporter((report) => {
+    const violation = new Error(violationSummary(report))
+    violation.name = 'CspViolation'
+    logError(violation, { cspViolation: report })
+  })
+  cspReporter.start()
 }
 
 app.config.errorHandler = (err, _instance, info) => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-810](https://github.com/aschung212/Lift/issues/810)

Implement **LIFT-810** (priority 3-medium, Security): surface CSP violations in telemetry instead of failing silently. The literal `report-uri`/`report-to` approach would require baking the Sentry security endpoint (derived from `VITE_SENTRY_DSN`, a runtime env var) into the static `vercel.json` header — a no-fabricate SEV1 risk and DSN duplication, and impossible without a serverless relay (this is a pure SPA). I deviated to a client-side `securitypolicyviolation` listener that forwards the same fields a CSP report carries through the already-initialized Sentry transport.

## Changes
- **`src/lib/cspReporting.ts`** (new) — `createCspReporter(forward)` registers a `securitypolicyviolation` listener, normalizes the event (`extractViolation`), dedupes per directive+resource, and caps total forwards per page load (default 20) so a misconfig/hostile loop can't flood Sentry. Pure, Sentry-agnostic, trivially testable.
- **`src/main.ts`** — wires the reporter web-only (`if (!isNative)`, matching analytics gating; native serves no Vercel CSP), routing violations through `logError` so they reach Sentry with a `cspViolation` context blob and a `CspViolation`-named error for clean grouping.
- **`src/lib/__tests__/cspReporting.test.ts`** (new) — 15 tests covering field extraction, legacy-directive fallback, dedupe, distinct-pair reporting, rate cap, start/stop listener binding, idempotent start, and main.ts wiring assertions.

## Verification
- `npm run lint` — clean
- `npm run build` — succeeds
- `npx vitest run` — 2284 passed | 1 skipped (was 2269; +15 new)
- Pre-push Gemini review gate down (`IneligibleTierError: UNSUPPORTED_CLIENT`) — see discovery below.

## Screenshots
N/A — telemetry/wiring change with no user-facing UI.

## Commits
- [`42035da`](https://github.com/aschung212/Lift/commit/42035da) feat(LIFT-810): forward CSP violations to Sentry via a client-side listener

## Test Results
- Before: 2269 passing
- After: 2284 passing (15 delta)

---
_Automated by overnight pipeline — Tue Jun 23 23:37:11 PDT 2026_

## Preview
Test on your phone: https://lift-3kwl3qg0y-aschung212-1101s-projects.vercel.app