### PR TITLE
test(LIFT-822): pin guarded hydration of workout store secondary state

### DIFF
--- a/src/stores/__tests__/workoutStorageHydration.test.ts
+++ b/src/stores/__tests__/workoutStorageHydration.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration test: the workout store hydrates its secondary state
+ * defensively, on a real Pinia instance.
+ *
+ * Regression for #822: customTags, tagRecoveryDays, and tagRecoveryExcluded
+ * are hydrated inline in the store's setup-function body. If any of those keys
+ * holds corrupt JSON (truncated write, quota eviction mid-write, manual
+ * tampering), a raw JSON.parse would throw DURING store construction — which,
+ * because it happens in the setup body, fails to construct the store at all and
+ * takes down the entire workout feature rather than degrading to defaults.
+ *
+ * These tests pin the guarded-hydration contract (loadJSON: try/catch parse +
+ * shape validation) so a future persistence refactor (#819) cannot silently
+ * regress it back to an unguarded parse.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: null,
+  isPreviewMode: { value: false },
+}))
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },
+}))
+vi.mock('../../lib/durableStorage', () => ({
+  backupToIDB: vi.fn(),
+}))
+
+describe('workout store secondary-state hydration (real Pinia)', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('constructs with empty defaults when lift-custom-tags is unparseable', async () => {
+    localStorageMock.setItem('lift-custom-tags', '{not json')
+
+    const { useWorkoutStore } = await import('../workout')
+    let store!: ReturnType<typeof useWorkoutStore>
+    expect(() => { store = useWorkoutStore() }).not.toThrow()
+    expect(store.customTags).toEqual([])
+  })
+
+  it('constructs with empty defaults when all three secondary keys are corrupt', async () => {
+    localStorageMock.setItem('lift-custom-tags', '{not json')
+    localStorageMock.setItem('lift-tag-recovery-days', 'undefined')
+    localStorageMock.setItem('lift-tag-recovery-excluded', '[1, 2,')
+
+    const { useWorkoutStore } = await import('../workout')
+    let store!: ReturnType<typeof useWorkoutStore>
+    expect(() => { store = useWorkoutStore() }).not.toThrow()
+    expect(store.customTags).toEqual([])
+    expect(store.tagRecoveryDays).toEqual({})
+    expect(store.tagRecoveryExcluded).toEqual([])
+  })
+
+  it('falls back to defaults when a key parses but has the wrong shape', async () => {
+    // Valid JSON, but the wrong type — validators must reject these.
+    localStorageMock.setItem('lift-custom-tags', JSON.stringify('Push')) // string, not array
+    localStorageMock.setItem('lift-tag-recovery-days', JSON.stringify(['Push'])) // array, not object
+    localStorageMock.setItem('lift-tag-recovery-excluded', JSON.stringify({ Push: true })) // object, not array
+
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+    expect(store.customTags).toEqual([])
+    expect(store.tagRecoveryDays).toEqual({})
+    expect(store.tagRecoveryExcluded).toEqual([])
+  })
+
+  it('hydrates valid secondary state without dropping it', async () => {
+    localStorageMock.setItem('lift-custom-tags', JSON.stringify(['Push', 'Pull']))
+    localStorageMock.setItem('lift-tag-recovery-days', JSON.stringify({ Push: 3 }))
+    localStorageMock.setItem('lift-tag-recovery-excluded', JSON.stringify(['Legs']))
+
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+    expect(store.customTags).toEqual(['Push', 'Pull'])
+    expect(store.tagRecoveryDays).toEqual({ Push: 3 })
+    expect(store.tagRecoveryExcluded).toEqual(['Legs'])
+  })
+
+  it('_reloadFromStorage keeps current in-memory value on a corrupt key', async () => {
+    localStorageMock.setItem('lift-custom-tags', JSON.stringify(['Push']))
+
+    const { useWorkoutStore } = await import('../workout')
+    const store = useWorkoutStore()
+    expect(store.customTags).toEqual(['Push'])
+
+    // Simulate a corrupt write landing after construction (e.g. a quota-evicted
+    // partial write seen by the cross-tab reload listener).
+    localStorageMock.setItem('lift-custom-tags', '{not json')
+    expect(() => store._reloadFromStorage()).not.toThrow()
+    // Degrades by keeping the last-good in-memory value, not resetting to [].
+    expect(store.customTags).toEqual(['Push'])
+  })
+})

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -189,6 +189,11 @@ export const useWorkoutStore = defineStore('workout', () => {
   // This avoids wrapping thousands of set objects in Proxy (5,000+ for heavy users).
   // Trade-off: every mutation must call triggerRef(exercises) to notify watchers.
   const exercises = shallowRef<Exercise[]>(load())
+  // Secondary state MUST hydrate through loadJSON (guarded parse + shape
+  // validation), never a raw JSON.parse. A corrupt key (truncated write,
+  // quota eviction mid-write, manual tampering) would otherwise throw in this
+  // setup-function body and the store would fail to construct at all — taking
+  // down the whole workout feature instead of degrading to defaults (#822).
   const customTags = shallowRef<string[]>(loadJSON('lift-custom-tags', [], Array.isArray))
   const tagRecoveryDays = shallowRef<Record<string, number>>(loadJSON('lift-tag-recovery-days', {}, isPlainObject))
   const tagRecoveryExcluded = shallowRef<string[]>(loadJSON('lift-tag-recovery-excluded', [], Array.isArray))


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-822](https://github.com/aschung212/Lift/issues/822)

LIFT-822 flagged that the workout store's secondary state (`customTags`, `tagRecoveryDays`, `tagRecoveryExcluded`) was hydrated in the setup-function body with unguarded `JSON.parse`, so a corrupt key would throw during construction and take down the whole workout feature. On reading the code, that production vulnerability was **already fixed** in #747 — all three keys now hydrate through the guarded `loadJSON` helper (try/catch parse + shape validation). The remaining gap was the store-level regression test the issue's proposed approach explicitly asks for, to lock the contract in against a future persistence refactor (#819).

## Changes
- `src/stores/workout.ts` — added an inline contract comment documenting why secondary state MUST hydrate through `loadJSON` (guarded parse) rather than a raw `JSON.parse`, referencing #822.
- `src/stores/__tests__/workoutStorageHydration.test.ts` (new) — 5 real-Pinia regression tests: store constructs with empty defaults on unparseable keys, on all-three-corrupt keys, and on valid-but-wrong-shape keys; hydrates valid state intact; and `_reloadFromStorage` keeps the last-good in-memory value on a corrupt key.

## Verification
- New test file: 5 passed
- Full suite: 2274 passed | 1 skipped (was 2269 — +5 new)
- `npm run lint`: clean
- `npm run build`: success
- Pre-push Gemini review: failed to run due to a Gemini Code Assist tier/auth error on the host (infra, unrelated to this diff)

## Screenshots
None — test-only + a code comment, no UI surface changed.

## Commits
- [`ac3333b`](https://github.com/aschung212/Lift/commit/ac3333b) test(LIFT-822): pin guarded hydration of workout store secondary state

## Test Results
- Before: 2269 passing
- After: 2274 passing (5 delta)

---
_Automated by overnight pipeline — Wed Jun 24 23:16:08 PDT 2026_

## Preview
Test on your phone: https://lift-lug1gfst4-aschung212-1101s-projects.vercel.app