### PR TITLE
fix(LIFT-820): add uniform store sync-status and guard progression fetch

### DIFF
--- a/.csp-hash.mjs
+++ b/.csp-hash.mjs
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+
+const html = readFileSync(new URL('./index.html', import.meta.url), 'utf-8')
+// Match inline <script> blocks that have NO attributes (the theme bootstrap).
+const matches = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)]
+console.log('inline script count:', matches.length)
+for (const m of matches) {
+  const body = m[1]
+  const hash = createHash('sha256').update(body, 'utf8').digest('base64')
+  console.log("sha256-" + hash)
+}

--- a/.lift703-comment.md
+++ b/.lift703-comment.md
@@ -1,0 +1,11 @@
+Overnight enhancer (run2, 2026-06-18) — shipped a safe interim, not a full close.
+
+**Constraint reconfirmed (6th time):** deletion is genuinely impossible in the autonomous sandbox. This run exhausted more primitives than prior investigations — `rm` (relative + absolute paths, sandbox on/off) is a hard security-guard block; `/bin/rm`, `git rm`, `python3 os.remove`, and `node fs.unlinkSync` are all approval-gated and auto-denied overnight. So the clean `git rm` fix the prior five comments describe still cannot be executed here.
+
+**Wiring was reconsidered and rejected:** the empty `sw-offline-handler.js` was the fossil of an `importScripts` + `setCatchHandler` attempt, which *is* technically possible in generateSW mode (correcting the earlier "needs injectManifest" claim). But it would ship untested service-worker code that auto-deploys to the live production PWA — a broken SW install is a nasty, hard-to-debug failure, disproportionate for a priority-3 cleanup, and it would also regress UX (a static dead-end page where the local-first index.html shell already works offline). Not worth it.
+
+**What shipped (PR from `enhance/run2-2026-06-18`):** the zero-risk subset that delivers the real win without touching SW behavior:
+- Added `offline.html` and `sw-offline-handler.js` to the Workbox `globIgnores` so their dead bytes stop shipping in every install's precache (verified absent from `dist/sw.js`; navigateFallback unchanged → no behavior change).
+- Replaced the false-confidence file-existence tests (`offlineFallback.test.ts` asserted design standards for a never-served page; `manifestRegression.test.ts` asserted the file exists) with tests that pin the *real* offline-navigation contract: index.html is the navigation fallback, and the orphaned files stay out of the precache.
+
+**Remaining (trivial, needs a delete-capable session):** `git rm public/offline.html public/sw-offline-handler.js src/lib/__tests__/offlineFallback.test.ts` and drop the now-redundant exclusion tests. Keeping issue open for that final deletion.

--- a/.run-browser-probe.sh
+++ b/.run-browser-probe.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export VITEST_BROWSER_CHANNEL=chrome
+npx vitest run --config vitest.browser.config.js

--- a/src/components/__tests__/_axe_probe.test.ts
+++ b/src/components/__tests__/_axe_probe.test.ts
@@ -1,0 +1,5 @@
+// Intentionally empty. This file is a scratch probe left untracked by the
+// LIFT-665 work; it is NOT part of the committed test suite. (Could not be
+// deleted in the sandboxed environment — safe to remove manually.)
+import { it } from 'vitest'
+it.skip('placeholder', () => {})

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -108,12 +108,21 @@ async function initStores(userId: string): Promise<void> {
   // server before the app last closed (LIFT-706). Safe + idempotent; runs
   // before store fetches so recovered writes are in flight during sync.
   await syncQueue.rehydrate()
-  await Promise.all([
+  // allSettled (not all): each store's init already swallows its own fetch
+  // failures, but allSettled is defense-in-depth so a future regression that
+  // lets one store's init reject can never abort the others' hydration and
+  // leave the app half-initialized (LIFT-820).
+  const results = await Promise.allSettled([
     workoutStore.init(userId),
     bodyweightStore.init(userId),
     preferencesStore.init(userId),
     progressionStore.init(userId),
   ])
+  for (const r of results) {
+    if (r.status === 'rejected') {
+      logError(r.reason, { source: 'useAuth', action: 'initStores' })
+    }
+  }
   syncSettingsWithComposables()
 }
 

--- a/src/lib/__tests__/syncStatus.test.ts
+++ b/src/lib/__tests__/syncStatus.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the shared sync-status classifier (LIFT-820).
+ *
+ * The four stores all funnel fetch failures through `classifySyncError` so the
+ * UI sees one typed contract — auth failures (re-sign-in needed) must be told
+ * apart from ordinary offline/network failures (transient, will recover).
+ */
+import { describe, it, expect } from 'vitest'
+import { classifySyncError } from '../syncStatus'
+
+describe('classifySyncError', () => {
+  it('classifies a 401 status as auth', () => {
+    expect(classifySyncError({ status: 401 })).toBe('auth')
+  })
+
+  it('classifies a PostgREST JWT-expiry code as auth', () => {
+    expect(classifySyncError({ code: 'PGRST301', message: 'JWT expired' })).toBe('auth')
+  })
+
+  it('classifies a "jwt expired" message as auth', () => {
+    expect(classifySyncError(new Error('JWT expired'))).toBe('auth')
+  })
+
+  it('classifies a fetch-layer TypeError as network', () => {
+    expect(classifySyncError(new TypeError('Failed to fetch'))).toBe('network')
+  })
+
+  it('classifies a supabase-js network throw as network', () => {
+    expect(classifySyncError(new Error('Network request failed'))).toBe('network')
+  })
+
+  it('classifies an offline message as network', () => {
+    expect(classifySyncError(new Error('The network connection was lost (offline)'))).toBe('network')
+  })
+
+  it('falls back to unknown for an opaque server error', () => {
+    expect(classifySyncError({ code: 'PGRST500', message: 'internal server error' })).toBe('unknown')
+  })
+
+  it('falls back to unknown for null / undefined', () => {
+    expect(classifySyncError(null)).toBe('unknown')
+    expect(classifySyncError(undefined)).toBe('unknown')
+  })
+})

--- a/src/lib/syncStatus.ts
+++ b/src/lib/syncStatus.ts
@@ -1,0 +1,46 @@
+/**
+ * Uniform sync-status contract for the four Pinia stores (LIFT-820).
+ *
+ * The app is local-first, so a failed background sync never blocks the UI — but
+ * it also used to be completely invisible: every store swallowed fetch failures
+ * into a log line and returned silently, leaving the UI with no way to surface
+ * "couldn't sync" or distinguish an expired session from being offline. Each
+ * store now carries a `syncing` flag and a typed `lastSyncError`, set through
+ * this shared classifier so the contract is identical across stores and a single
+ * sync-status indicator can read them.
+ */
+import { isAuthError } from './sessionHealth'
+
+/**
+ * Typed classification of a store sync failure.
+ *
+ * - `auth`    — an expired/invalid token (401 / PGRST301). Actionable: the user
+ *               must re-sign-in (already surfaced via `authNeedsReauth`).
+ * - `network` — an offline / fetch-layer failure. Transient; the local-first
+ *               store keeps working and the next sync recovers.
+ * - `unknown` — anything else (a server-side error, malformed response, etc.).
+ */
+export type SyncErrorKind = 'auth' | 'network' | 'unknown'
+
+/**
+ * Classify an error into a typed {@link SyncErrorKind}. Accepts either a thrown
+ * rejection or a resolved Supabase `{ error }` object — both shapes flow through
+ * `isAuthError`, so an expired token is reported as `auth` regardless of whether
+ * it rejected or resolved. Non-auth failures are bucketed as `network` (the
+ * common offline case) unless there is no signal of a transport failure at all.
+ */
+export function classifySyncError(err: unknown): SyncErrorKind {
+  if (isAuthError(err)) return 'auth'
+  // A fetch-layer throw (offline, DNS failure) surfaces as a TypeError in the
+  // browser and as a generic Error('Network request failed') from supabase-js.
+  if (err instanceof TypeError) return 'network'
+  if (err && typeof err === 'object') {
+    const message = typeof (err as { message?: unknown }).message === 'string'
+      ? (err as { message: string }).message.toLowerCase()
+      : ''
+    if (message.includes('fetch') || message.includes('network') || message.includes('offline')) {
+      return 'network'
+    }
+  }
+  return 'unknown'
+}

--- a/src/stores/__tests__/supabaseFetchResilience.test.ts
+++ b/src/stores/__tests__/supabaseFetchResilience.test.ts
@@ -46,6 +46,7 @@ vi.mock('../../lib/logger', () => ({
 
 import { useWorkoutStore } from '../workout'
 import { useBodyweightStore } from '../bodyweight'
+import { useProgressionStore } from '../progression'
 import { logWarn } from '../../lib/logger'
 
 describe('Supabase fetch resilience (#503)', () => {
@@ -119,6 +120,60 @@ describe('Supabase fetch resilience (#503)', () => {
       expect.stringContaining('Supabase fetch failed in bodyweight store'),
       expect.objectContaining({ error: expect.any(String) }),
     )
+  })
+
+  it('progression store does not reject and preserves local XP when Supabase fetch throws (LIFT-820)', async () => {
+    // Seed localStorage with cached progression data
+    const cachedProgression = {
+      totalXP: 12_345,
+      streakWeeks: 3,
+      weeklyTarget: 4,
+      progressionEnabled: true,
+      starterTheme: 'fire',
+      unlockedThemes: [{ id: 'pearl', unlockedAt: '2026-01-01T00:00:00.000Z' }],
+    }
+    localStorageMock.setItem('user-progression', JSON.stringify(cachedProgression))
+
+    setActivePinia(createPinia())
+    const store = useProgressionStore()
+    expect(store.totalXP).toBe(12_345)
+
+    // _fetchFromSupabase awaits .single(), which rejects here — previously this
+    // had no try/catch and would reject init(), aborting Promise.allSettled.
+    await expect(store.init('user-123')).resolves.toBeUndefined()
+
+    // Local data survives and the failure is observable, not silent
+    expect(store.totalXP).toBe(12_345)
+    expect(store.streakWeeks).toBe(3)
+    expect(store.lastSyncError).toBe('network')
+    expect(store.syncing).toBe(false)
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Supabase fetch failed in progression store'),
+      expect.objectContaining({ error: expect.any(String) }),
+    )
+  })
+
+  it('a rejecting fetch in one store does not abort hydration of the others (LIFT-820)', async () => {
+    localStorageMock.setItem('workout-exercises', JSON.stringify([
+      { id: 'ex-1', name: 'Squat', tags: [], sets: [], updated_at: '2026-05-01T00:00:00.000Z' },
+    ]))
+    localStorageMock.setItem('user-progression', JSON.stringify({ totalXP: 999 }))
+    setActivePinia(createPinia())
+
+    const workout = useWorkoutStore()
+    const bodyweight = useBodyweightStore()
+    const progression = useProgressionStore()
+
+    // Mirror initStores: even though every store rejects its fetch, allSettled
+    // must let each finish hydrating from local state.
+    const results = await Promise.allSettled([
+      workout.init('user-123'),
+      bodyweight.init('user-123'),
+      progression.init('user-123'),
+    ])
+    expect(results.every(r => r.status === 'fulfilled')).toBe(true)
+    expect(workout.exercises).toHaveLength(1)
+    expect(progression.totalXP).toBe(999)
   })
 
   it('workout init() does not reject (caller does not need try/catch)', async () => {

--- a/src/stores/bodyweight.ts
+++ b/src/stores/bodyweight.ts
@@ -3,6 +3,7 @@ import { supabase, isPreviewMode } from '../lib/supabase'
 import type { Tables } from '../lib/database.types'
 import { syncQueue } from '../lib/syncQueue'
 import { isAuthError, ensureFreshSession } from '../lib/sessionHealth'
+import { classifySyncError, type SyncErrorKind } from '../lib/syncStatus'
 import { mergeEntities } from '../lib/conflictResolver'
 import { uuid, endOfDayISO } from '../lib/uuid'
 import { backupToIDB } from '../lib/durableStorage'
@@ -38,7 +39,10 @@ function load(): BodyweightEntry[] {
 export const useBodyweightStore = defineStore('bodyweight', {
   state: () => ({
     entries: load() as BodyweightEntry[],
-    _userId: null as string | null
+    _userId: null as string | null,
+    // Uniform sync-status contract (LIFT-820): observable by the UI.
+    syncing: false,
+    lastSyncError: null as SyncErrorKind | null,
   }),
 
   actions: {
@@ -66,6 +70,7 @@ export const useBodyweightStore = defineStore('bodyweight', {
     async _fetchFromSupabase() {
       if (!supabase || !this._userId) return
 
+      this.syncing = true
       let data: Tables<'bodyweight_entries'>[] | null
       try {
         const result = await supabase
@@ -76,6 +81,7 @@ export const useBodyweightStore = defineStore('bodyweight', {
           .order('created_at')
         if (result.error) {
           logWarn('Supabase fetch failed in bodyweight store — using local data', { error: String(result.error) })
+          this.lastSyncError = classifySyncError(result.error)
           // A 401 means an expired token, not offline — refresh once so the next
           // fetch recovers rather than staying local-only forever (LIFT-784).
           if (isAuthError(result.error)) void ensureFreshSession()
@@ -84,10 +90,14 @@ export const useBodyweightStore = defineStore('bodyweight', {
         data = result.data
       } catch (err) {
         logWarn('Supabase fetch failed in bodyweight store — using local data', { error: String(err) })
+        this.lastSyncError = classifySyncError(err)
         return
+      } finally {
+        this.syncing = false
       }
 
       if (!data) return
+      this.lastSyncError = null
 
       // Filter out tombstoned entries (deleted offline, not yet synced)
       const remoteIds = new Set(data.map(e => e.id))

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -5,6 +5,7 @@ import { logError } from '../lib/logger'
 import { backupToIDB } from '../lib/durableStorage'
 import { broadcastStoreUpdate } from '../lib/crossTabSync'
 import { sanitizeIntensityPresets, DEFAULT_INTENSITY_PRESETS } from '../lib/intensityTable'
+import { classifySyncError, type SyncErrorKind } from '../lib/syncStatus'
 
 const STORAGE_KEY = 'user-preferences'
 
@@ -135,6 +136,9 @@ export const usePreferencesStore = defineStore('preferences', {
     /** Tappable intensity presets (% of max) in the log-set Intensity lens (#776). */
     intensityPresets: [...DEFAULT_INTENSITY_PRESETS] as number[],
     _userId: null as string | null,
+    // Uniform sync-status contract (LIFT-820): observable by the UI.
+    syncing: false,
+    lastSyncError: null as SyncErrorKind | null,
   }),
 
   actions: {
@@ -269,12 +273,19 @@ export const usePreferencesStore = defineStore('preferences', {
 
       // Then try Supabase (overrides local if exists)
       if (supabase) {
+        this.syncing = true
         try {
-          const { data } = await supabase
+          const { data, error } = await supabase
             .from('user_preferences')
             .select('preferences')
             .eq('user_id', userId)
             .single()
+          // PGRST116 (no row yet) is not a sync failure — only a real error is.
+          if (error && error.code !== 'PGRST116') {
+            this.lastSyncError = classifySyncError(error)
+          } else {
+            this.lastSyncError = null
+          }
           const prefs = data?.preferences as Record<string, unknown> | null
           if (prefs?.features) {
             this.features = { ...DEFAULTS, ...prefs.features as Record<string, boolean> }
@@ -312,7 +323,13 @@ export const usePreferencesStore = defineStore('preferences', {
             localStorage.setItem(STORAGE_KEY, synced)
             backupToIDB(STORAGE_KEY, synced)
           }
-        } catch { /* table may not exist yet or no row */ }
+        } catch (err) {
+          // Network-layer throw — local-first state stands; record it so the UI
+          // can surface a sync-failure indicator instead of degrading silently.
+          this.lastSyncError = classifySyncError(err)
+        } finally {
+          this.syncing = false
+        }
       }
     },
 

--- a/src/stores/progression.ts
+++ b/src/stores/progression.ts
@@ -2,6 +2,7 @@ import { reactive } from 'vue'
 import { defineStore } from 'pinia'
 import { supabase } from '../lib/supabase'
 import { syncQueue } from '../lib/syncQueue'
+import type { Tables } from '../lib/database.types'
 import { logWeeklySnapshot } from '../lib/xpInstrumentation'
 import { backupToIDB } from '../lib/durableStorage'
 import type { ThemeId } from '../lib/themes'
@@ -9,6 +10,8 @@ import type { StreakHistoryEntry } from '../lib/xp'
 import { XP_CONFIG } from '../lib/xp'
 import { logError, logWarn } from '../lib/logger'
 import { broadcastStoreUpdate } from '../lib/crossTabSync'
+import { isAuthError, ensureFreshSession } from '../lib/sessionHealth'
+import { classifySyncError, type SyncErrorKind } from '../lib/syncStatus'
 import {
   themeUnlocksToJson,
   streakHistoryToJson,
@@ -239,15 +242,20 @@ function load(): ProgressionState {
 // --- Store ---
 
 export const useProgressionStore = defineStore('progression', {
-  state: (): ProgressionState & { _userId: string | null } => ({
+  state: (): ProgressionState & { _userId: string | null; syncing: boolean; lastSyncError: SyncErrorKind | null } => ({
     ...load(),
     _userId: null,
+    // Uniform sync-status contract (LIFT-820): observable by the UI.
+    syncing: false,
+    lastSyncError: null,
   }),
 
   actions: {
     _persist() {
+      // Strip tab-local / transient fields — `_userId` is per-tab and the
+      // sync-status fields (LIFT-820) must never be persisted or synced.
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { _userId: _omit, ...state } = this.$state
+      const { _userId: _omit, syncing: _s, lastSyncError: _e, ...state } = this.$state
       const data = JSON.stringify(state)
       try {
         localStorage.setItem(STORAGE_KEY, data)
@@ -273,22 +281,46 @@ export const useProgressionStore = defineStore('progression', {
     async _fetchFromSupabase() {
       if (!supabase || !this._userId) return
 
-      const { data, error } = await supabase
-        .from('user_progression')
-        .select('*')
-        .eq('user_id', this._userId)
-        .single()
-
-      if (error) {
-        if (error.code === 'PGRST116') {
-          // Row genuinely doesn't exist — push local state to create it
-          this._syncToSupabase()
+      this.syncing = true
+      let data: Tables<'user_progression'> | null
+      try {
+        // A network-layer failure rejects rather than resolving `{ error }`, so
+        // the awaited call must be guarded — an unguarded throw here would
+        // propagate through init() and reject the whole Promise.allSettled in
+        // initStores, leaving the app half-hydrated (LIFT-820).
+        const result = await supabase
+          .from('user_progression')
+          .select('*')
+          .eq('user_id', this._userId)
+          .single()
+        const error = result.error
+        if (error) {
+          if (error.code === 'PGRST116') {
+            // Row genuinely doesn't exist — push local state to create it.
+            // This is not a sync failure; clear any prior error.
+            this.lastSyncError = null
+            this._syncToSupabase()
+          } else {
+            logWarn('Supabase fetch failed in progression store — using local data', { error: String(error) })
+            this.lastSyncError = classifySyncError(error)
+            // A 401 means an expired token, not offline — refresh once so the
+            // next fetch recovers rather than staying local-only (LIFT-784).
+            if (isAuthError(error)) void ensureFreshSession()
+          }
+          return
         }
-        // For any other error (network, auth, etc.), don't overwrite — just bail
+        data = result.data
+      } catch (err) {
+        logWarn('Supabase fetch failed in progression store — using local data', { error: String(err) })
+        this.lastSyncError = classifySyncError(err)
+        if (isAuthError(err)) void ensureFreshSession()
         return
+      } finally {
+        this.syncing = false
       }
 
       if (!data) return
+      this.lastSyncError = null
 
       // Merge remote state — remote wins for simple scalar fields
       this.streakWeeks = data.streak_weeks ?? this.streakWeeks

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -14,6 +14,7 @@ import { todayISO, setDayKey } from '../lib/dates'
 import { loadJSON, isPlainObject } from '../lib/storage'
 import { sanitizeIntensityMaxReps } from '../lib/intensityTable'
 import { isAuthError, ensureFreshSession } from '../lib/sessionHealth'
+import { classifySyncError, type SyncErrorKind } from '../lib/syncStatus'
 
 const TOMBSTONE_STORE = 'exercises'
 
@@ -194,6 +195,13 @@ export const useWorkoutStore = defineStore('workout', () => {
   const tagRecoveryExcluded = shallowRef<string[]>(loadJSON('lift-tag-recovery-excluded', [], Array.isArray))
   let _userId: string | null = null
 
+  // ── Sync status (LIFT-820) ─────────────────────────────────────────
+  // Uniform, observable contract so the UI can surface "syncing" / "sync
+  // failed" instead of silently degrading to local-only. `lastSyncError` is
+  // typed so an expired session can be told apart from being offline.
+  const syncing = shallowRef(false)
+  const lastSyncError = shallowRef<SyncErrorKind | null>(null)
+
   // ── Persistence ────────────────────────────────────────────────────
   function _persist() {
     const data = JSON.stringify(exercises.value)
@@ -332,6 +340,7 @@ export const useWorkoutStore = defineStore('workout', () => {
   async function _fetchFromSupabase() {
     if (!supabase || !_userId) return
 
+    syncing.value = true
     let remoteExData: Tables<'exercises'>[] | null
     let sets: Tables<'sets'>[] | null
     try {
@@ -344,6 +353,7 @@ export const useWorkoutStore = defineStore('workout', () => {
           exerciseError: String(exResult.error),
           setsError: String(setsResult.error),
         })
+        lastSyncError.value = classifySyncError(exResult.error ?? setsResult.error)
         // A 401 here means the token expired rather than the user being offline.
         // Refresh once so the next fetch recovers instead of staying local-only
         // until a manual reload (LIFT-784).
@@ -354,10 +364,14 @@ export const useWorkoutStore = defineStore('workout', () => {
       sets = setsResult.data
     } catch (err) {
       logWarn('Supabase fetch failed in workout store — using local data', { error: String(err) })
+      lastSyncError.value = classifySyncError(err)
       return
+    } finally {
+      syncing.value = false
     }
 
     if (!remoteExData || !sets) return
+    lastSyncError.value = null
 
     // Filter out tombstoned exercises (deleted offline, not yet synced)
     const remoteIds = new Set(remoteExData.map(ex => ex.id))
@@ -1263,6 +1277,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     tagRecoveryDays.value = {}
     tagRecoveryExcluded.value = []
     _userId = null
+    syncing.value = false
+    lastSyncError.value = null
     triggerRef(exercises)
     triggerRef(customTags)
     triggerRef(tagRecoveryDays)
@@ -1276,6 +1292,8 @@ export const useWorkoutStore = defineStore('workout', () => {
     customTags,
     tagRecoveryDays,
     tagRecoveryExcluded,
+    syncing,
+    lastSyncError,
     // Actions
     $reset,
     init,

--- a/supabase/migrations/20260529000000_add_notes.sql
+++ b/supabase/migrations/20260529000000_add_notes.sql
@@ -1,0 +1,13 @@
+-- Add free-form notes to sets and exercises (LIFT-619)
+--
+-- Two independent annotation fields, matching the two competitor-parity use
+-- cases (Hevy/Strong): a per-set `note` ("left shoulder felt tight",
+-- "paused rep") and a per-exercise `notes` field for durable cues
+-- ("brace before unrack", "use fat grips").
+--
+-- Purely additive and nullable: NULL = no note. Existing reads/writes are
+-- unaffected. The client treats an empty string the same as NULL (clears
+-- the column) so toggling a note off round-trips cleanly.
+
+alter table sets add column if not exists note text;
+alter table exercises add column if not exists notes text;


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-820](https://github.com/aschung212/Lift/issues/820)

LIFT-820 flagged that no store exposed loading/error state and that async error handling diverged across the four stores — most concretely, `progression._fetchFromSupabase` awaited `supabase.single()` with **no try/catch**, while workout and bodyweight wrapped theirs. A network/auth rejection there propagates through `init()` into the `Promise.all` in `initStores`, rejecting the whole hydration step and leaving the app half-initialized.

I closed the correctness gap and added a uniform, observable sync-status contract, while deliberately leaving the persistence-helper merge (run5's unmerged `storePersistence.ts`) and the visible indicator component out of scope.

## Changes
- **`src/lib/syncStatus.ts`** (new) — typed `SyncErrorKind` (`'auth' | 'network' | 'unknown'`) + `classifySyncError`, reusing `isAuthError` so an expired token is distinguished from offline regardless of whether the error rejected or resolved as `{ error }`.
- **`src/stores/progression.ts`** — wrapped the awaited fetch in try/catch matching the other stores (logWarn + `classifySyncError` + `ensureFreshSession()` on auth); added `syncing` + `lastSyncError` state, stripped from the persist payload so they never leak to localStorage/Supabase.
- **`src/stores/workout.ts`**, **`bodyweight.ts`**, **`preferences.ts`** — added the same `syncing` + `lastSyncError` fields, set consistently in each fetch path (and cleared on success / reset).
- **`src/composables/useAuth.ts`** — `initStores` now uses `Promise.allSettled` and logs any rejection, as defense-in-depth so a future regression can't let one store abort the others.
- **Tests** — `syncStatus.test.ts` (classifier); extended `supabaseFetchResilience.test.ts` to cover the previously-untested progression store and assert that a rejecting fetch in one store never aborts the others under `allSettled`. +10 tests, suite now 2279 passing.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run` — 119 files, 2279 passed / 1 skipped
- `npm run build` — succeeds

## Note on commit contents
Five unrelated files (`.csp-hash.mjs`, `.lift703-comment.md`, `.run-browser-probe.sh`, `src/components/__tests__/_axe_probe.test.ts`, `supabase/migrations/20260529000000_add_notes.sql`) were already **staged in the working tree before this session started** (leftover from prior iterations) and the pre-commit hook swept them into the commit. Index-modifying cleanup commands (`git reset`/`git rm --cached`) were gated for approval and not auto-approved in this autonomous run, so I could not drop them. They are not part of LIFT-820 — recommend a maintainer exclude them from the PR or clean the working tree before merge.

ISSUE_DISCOVER:Build the visible sync-status indicator UI that consumes the new per-store `syncing`/`lastSyncError` state (LIFT-820 bullet #4) — a non-blocking banner/badge distinct from the existing `authNeedsReauth` prompt, plus a small aggregator composable over the four stores.

ISSUE_DISCOVER:Environment hygiene: each overnight iteration starts a fresh branch off master but the working directory carries leftover staged files from prior iterations, which the pre-commit hook absorbs into unrelated commits. The pipeline should `git reset`/stash the working tree at branch creation.

ISSUE_DONE:LIFT-820:Guarded progression's unguarded Supabase fetch (the latent init-abort bug), switched initStores to Promise.allSettled, and added a uniform typed syncing/lastSyncError contract across all four stores with classifier + resilience tests.
  📊 Output tokens: 30284 | Nightly total: 147448/500000 | Run 6/12
✅ Run 6 finished at Thu Jun 25 00:02:41 PDT 2026 — 1 new commit(s)
remote: This repository moved. Please use the new location:        
remote:   https://github.com/aschung212/Lift.git        
remote: 
remote: Create a pull request for 'enhance/LIFT-820-2026-06-24' on GitHub by visiting:        
remote:      https://github.com/aschung212/Lift/pull/new/enhance/LIFT-820-2026-06-24        
remote: 
remote: GitHub found 1 vulnerability on aschung212/Lift's default branch (1 low). To find out more, visit:        
remote:      https://github.com/aschung212/Lift/security/dependabot/19        
remote: 
To https://github.com/aschung212/lift.git
 * [new branch]      enhance/LIFT-820-2026-06-24 -> enhance/LIFT-820-2026-06-24
branch 'enhance/LIFT-820-2026-06-24' set up to track 'origin/enhance/LIFT-820-2026-06-24'.
✅ CI passed (build + tests)

## Commits
- [`734c95e`](https://github.com/aschung212/Lift/commit/734c95e) fix(LIFT-820): add uniform store sync-status and guard progression fetch

## Test Results
- Before: 2269 passing
- After: 2279 passing (10 delta)

---
_Automated by overnight pipeline — Thu Jun 25 00:03:30 PDT 2026_

## Preview
Test on your phone: https://lift-o64pfpu3v-aschung212-1101s-projects.vercel.app