### PR TITLE
fix(LIFT-832): add interactive-widget=resizes-content to viewport meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,17 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <!--
+    interactive-widget=resizes-content (LIFT-832): when the soft keyboard opens,
+    resize the LAYOUT viewport (not just the visual viewport) so layout and visual
+    viewports stay in sync. The default (resizes-visual) shrinks only the visual
+    viewport, which is the exact desync the #830 scroll-lock fix works around
+    (visual viewport shifts, layout viewport doesn't). It also helps iOS Safari
+    tab mode present the keyboard for inputs under the locked `html,body{overflow:hidden}`
+    app shell, which works in standalone PWA/WKWebView but not always in a Safari tab.
+    On engines that don't yet honor the key it is ignored — a safe no-op.
+  -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
 
   <!-- PWA / iOS -->
   <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/lib/__tests__/metaRegression.test.ts
+++ b/src/lib/__tests__/metaRegression.test.ts
@@ -64,6 +64,23 @@ describe('index.html meta tag regression tests', () => {
     })
   })
 
+  describe('viewport meta keeps iOS-critical keys (LIFT-832)', () => {
+    const viewport =
+      html.match(/<meta name="viewport" content="([^"]+)"/)?.[1] ?? ''
+
+    it('declares a viewport meta tag', () => {
+      expect(viewport.length).toBeGreaterThan(0)
+    })
+
+    it('keeps viewport-fit=cover so safe-area insets resolve under the notch', () => {
+      expect(viewport).toContain('viewport-fit=cover')
+    })
+
+    it('sets interactive-widget=resizes-content so the soft keyboard resizes the layout viewport in step with the visual viewport (iOS Safari tab keyboard / #830 desync)', () => {
+      expect(viewport).toContain('interactive-widget=resizes-content')
+    })
+  })
+
   describe('no references to domains we do not own', () => {
     it('does not reference liftracker.app (competitor domain)', () => {
       expect(html).not.toContain('liftracker.app')


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-832](https://github.com/aschung212/Lift/issues/832)

LIFT-832: in a mobile Safari **browser tab** (pre-install), tapping any input focuses the field (caret + AutoFill bar appear) but the soft keyboard never renders — standalone PWA and Capacitor/WKWebView work fine. The locked `html,body{height:100%;overflow:hidden}` app shell breaks Safari's keyboard/viewport handling in tab mode. I implemented the issue's primary candidate — the viewport-meta `interactive-widget` lever — as the surgical, low-risk first step, deliberately avoiding the settled scroll-model (candidate #2 carries high regression risk per CLAUDE.md's settled-pattern warnings and needs real-device iteration I can't perform).

## Changes
- **`index.html`** — added `interactive-widget=resizes-content` to the viewport meta. This resizes the **layout** viewport in step with the visual viewport when the keyboard opens (the default `resizes-visual` shrinks only the visual viewport — the exact desync the #830 scroll-lock fix works around). On engines that don't honor the key it's a safe no-op, so the settled centered-modal keyboard behavior is preserved. Documented inline.
- **`src/lib/__tests__/metaRegression.test.ts`** — pinned the viewport meta (3 new tests) so `viewport-fit=cover` and the new `interactive-widget=resizes-content` key can't be silently dropped — satisfying the same-commit regression-test mandate.

## Verification
- `npx vitest run` — 119 files / 2294 tests pass. (The 5 failing files in the baseline were a stale `node_modules` missing `modern-screenshot` from the recent LIFT-812 merge; `npm install` resolved them — pre-existing environment drift, unrelated to this change.)
- `npm run build` — succeeds.
- `npm run lint` — clean.
- **Cannot verify on-device**: the actual keyboard behavior requires real-iPhone Safari-tab iteration (the issue explicitly notes it's not reproducible on desktop/simulator). Aaron should validate the keyboard now appears in a Safari tab; if it doesn't, the deeper scroll-model investigation (candidate #2) remains a follow-up.

## Screenshots
N/A — change is a viewport meta attribute + test; no visual UI change.

## Commits
- [`34cc422`](https://github.com/aschung212/Lift/commit/34cc422) fix(LIFT-832): add interactive-widget=resizes-content to viewport meta

## Test Results
- Before: 2216 passing
- After: 2294 passing (78 delta)

---
_Automated by overnight pipeline — Thu Jun 25 23:06:02 PDT 2026_

## Preview
Test on your phone: https://lift-jua6fg9zn-aschung212-1101s-projects.vercel.app