### PR TITLE
ci: don't fail master run when coverage-baseline push is blocked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,19 @@ jobs:
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add .coverage-baseline.json
             git commit -m "chore: ratchet coverage baseline [skip ci]"
-            git push
+            # master is a protected branch and the default GITHUB_TOKEN cannot push to it
+            # (rejected with GH006). A blocked auto-commit must NOT fail the whole run:
+            # the ratchet's intent (floor only ever rises) is preserved either way —
+            # on success the floor rises, and when the push is blocked the floor simply
+            # holds at its current value (PRs are still gated against it, never falsely).
+            # Long-term fix: push with a PAT / GitHub App token that is in the branch-
+            # protection bypass allowlist — set it as a secret and use it as the
+            # `token:` on the checkout step above, then this fallback never triggers.
+            if git push; then
+              echo "Ratcheted coverage baseline committed to master."
+            else
+              echo "::warning::Coverage baseline could not be pushed to protected master (GH006); floor held. Configure a bypass token to auto-ratchet."
+            fi
           fi
 
   e2e:


### PR DESCRIPTION
## Problem

The `ratchet-baseline` job's **Commit updated baseline** step pushes `.coverage-baseline.json` directly to `master`, but `master` is a protected branch and the default `GITHUB_TOKEN` can't bypass it. The push is rejected with `GH006: Protected branch update failed` and the step exits 1 — turning the **whole master run red** even though build, test, e2e, and migrate-db all pass. It trips on every master merge that changes coverage (e.g. the AI-coach scaffold merge, run [28312395573](https://github.com/aschung212/Lift/actions/runs/28312395573)).

## Fix

Make the blocked push **non-fatal**. On success the ratchet floor rises as before; when the push is blocked the floor simply **holds** at its current value (PRs are still gated against it, never falsely), and the job emits a `::warning::` instead of failing. The ratchet's intent — *floor only ever rises* — is preserved either way.

The proper long-term fix is documented inline: push with a PAT / GitHub App token that's in the branch-protection bypass allowlist (set as a secret, used as the checkout `token:`), at which point this fallback never triggers. I didn't add that here because it requires provisioning a secret — your call whether to set one up.

## Verification

`ratchet-baseline` runs **only on master pushes**, not PRs (`if: github.ref == 'refs/heads/master'`), so it can't run on this PR — it'll be exercised on the next master run after merge. YAML validated locally (`yaml.safe_load`). The change is confined to the one shell step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)