### PR TITLE
feat(coach): surface real per-set timestamp (created_at) for time-of-day + order (#846)

### DIFF
--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -118,8 +118,11 @@ in `src/lib/aiCoach.ts`):
 > server `sets.created_at` column for synced/historical sets and stamped at log time in `logSet` for
 > new/offline sets. The builder reads it for `timeOfDay` ("HH:MM" local) and orders within a day by
 > real timestamp. **Accuracy caveat:** `created_at` is insert/sync time — ≈ training time for live
-> online logging, but skewed for log-offline-then-sync-later or backfilled sets, so time-of-day is
-> indicative, not exact. `sessions` (split + rest-day cadence) works for all data regardless.
+> online logging, but skewed for log-offline-then-sync-later or backfilled sets. It also stores only
+> a UTC instant (no captured offset), and `timeOfDay` is rendered in the timezone of the device that
+> *builds* the digest — so a set trained while traveling reads in the digesting device's local time,
+> not the training-location time. Treat time-of-day as indicative, not exact. `sessions` (split +
+> rest-day cadence) works for all data regardless.
 
 **Never sent:** exercise/session/set UUIDs, user_id, email, auth tokens, XP log, preferences.
 Identifiers are used for quota/consent only and never forwarded to the model. Exercise names are

--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -113,10 +113,13 @@ in `src/lib/aiCoach.ts`):
 - **focus** — overload suggestions: `{ exerciseName, type, suggestedWeight, suggestedReps, reason }`
 - **bodyweight** (opt-out) — `{ trendDirection, deltaLbs }`
 
-> **`timeOfDay` and within-workout order are dormant until the set-time capture work lands.**
-> `set.date` is stamped end-of-day (no time), so the builder emits `timeOfDay`/real ordering only
-> once a real per-set timestamp (`WorkoutSet.createdAt`, currently unpopulated) is captured —
-> tracked as its own issue. `sessions` (split + rest-day cadence) works today.
+> **`timeOfDay` and within-workout order are now live (#846).** `set.date` stays end-of-day (no
+> time, per #746); a separate `WorkoutSet.createdAt` carries the real log time — surfaced from the
+> server `sets.created_at` column for synced/historical sets and stamped at log time in `logSet` for
+> new/offline sets. The builder reads it for `timeOfDay` ("HH:MM" local) and orders within a day by
+> real timestamp. **Accuracy caveat:** `created_at` is insert/sync time — ≈ training time for live
+> online logging, but skewed for log-offline-then-sync-later or backfilled sets, so time-of-day is
+> indicative, not exact. `sessions` (split + rest-day cadence) works for all data regardless.
 
 **Never sent:** exercise/session/set UUIDs, user_id, email, auth tokens, XP log, preferences.
 Identifiers are used for quota/consent only and never forwarded to the model. Exercise names are

--- a/src/lib/__tests__/coachDigest.test.ts
+++ b/src/lib/__tests__/coachDigest.test.ts
@@ -167,6 +167,21 @@ describe('buildCoachPayload — time of day (forward-ready)', () => {
     expect(bench[1].timeOfDay).toMatch(/^\d{2}:\d{2}$/)
     expect(bench[0].timeOfDay).not.toBe(bench[1].timeOfDay)
   })
+
+  it('orders untimestamped (legacy) sets after timestamped ones within the same day', () => {
+    // A day that mixes a pre-#846 set (no createdAt) with a freshly timestamped
+    // one: the timestamped set must not land behind the unknown-time set just
+    // because '' sorts before any real ISO string.
+    const sets = [
+      { id: 'u1', date: '2026-06-25T12:00:00.000Z', weight: 200, reps: 5, estimated1RM: 233 }, // legacy: no createdAt
+      { id: 't1', date: '2026-06-25T12:00:00.000Z', weight: 100, reps: 5, estimated1RM: 116, createdAt: '2026-06-25T08:00:00Z' },
+    ]
+    const p = build({ exercises: [ex('e1', 'Bench Press', ['Chest'], sets)] })
+    const bench = p.sets.filter((s) => s.exerciseName === 'Bench Press')
+    expect(bench.map((s) => s.weight)).toEqual([100, 200]) // timestamped first, legacy last
+    expect(bench[0].timeOfDay).toMatch(/^\d{2}:\d{2}$/)
+    expect(bench[1].timeOfDay).toBeUndefined()
+  })
 })
 
 describe('buildCoachPayload — unit conversion', () => {

--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -267,6 +267,20 @@ describe('replay allowlist (LIFT-785)', () => {
       })).toBe(true)
     })
 
+    it('accepts a set upsert carrying created_at (#846) so offline log-time survives replay', () => {
+      // _enqueueSetUpsert now sends the real log-time `created_at` so an offline
+      // set keeps its training time. The descriptor it journals must be
+      // replayable — otherwise rehydrate() drops the entry and the offline set
+      // is never synced (the exact failure #846 exists to prevent).
+      expect(isReplayableDescriptor({
+        op: 'upsert', table: 'sets',
+        row: {
+          id: 's1', user_id: 'u1', exercise_id: 'e1', date: '2026-06-20T23:59:30.000Z',
+          weight: 185, reps: 5, estimated_1rm: 216, created_at: '2026-06-20T18:45:00.000Z',
+        },
+      })).toBe(true)
+    })
+
     it('tolerates retired-but-dormant DB columns so legacy offline writes still replay', () => {
       // warmup_scheme was retired in #770 but the column still exists in the DB.
       // An offline write journaled by a pre-#770 client must not be dropped.

--- a/src/lib/coachDigest.ts
+++ b/src/lib/coachDigest.ts
@@ -199,11 +199,19 @@ export function buildCoachPayload(input: CoachDigestInput): CoachPayload {
     }
   }
 
-  // Order by day, then by real log time within the day when available (stable
-  // — preserving per-exercise logged order — when timestamps aren't captured yet).
+  // Order by day, then by real log time within the day when available. A naive
+  // localeCompare would sort the empty sortTime ('' = legacy/never-synced set,
+  // no captured time) BEFORE any real ISO timestamp — inverting order on a day
+  // that mixes a pre-#846 set with a freshly timestamped one. Instead, untimestamped
+  // sets sort AFTER timestamped ones (a known time never lands behind an unknown
+  // one); a stable sort preserves per-exercise logged order among equally-(un)timestamped sets.
   setItems.sort((a, b) => {
     const d = (a.rec.date ?? '').localeCompare(b.rec.date ?? '')
-    return d !== 0 ? d : a.sortTime.localeCompare(b.sortTime)
+    if (d !== 0) return d
+    if (a.sortTime && b.sortTime) return a.sortTime.localeCompare(b.sortTime)
+    if (a.sortTime) return -1
+    if (b.sortTime) return 1
+    return 0
   })
   const orderedSets = setItems.map((it) => it.rec)
   const cappedSets = orderedSets.length > MAX_SETS ? orderedSets.slice(orderedSets.length - MAX_SETS) : orderedSets

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -63,6 +63,12 @@ const REPLAYABLE_COLUMNS: Record<string, ReadonlySet<string>> = {
   sets: new Set([
     'id', 'user_id', 'exercise_id', 'date', 'weight', 'reps',
     'estimated_1rm', 'deleted_at',
+    // Real log-time timestamp sent by _enqueueSetUpsert (#846) so an offline set
+    // logged at 6pm keeps its training time when replayed after a reload rather
+    // than inheriting the later sync time. Must be allowlisted or the journaled
+    // descriptor is dropped on rehydrate() — defeating the durable queue for the
+    // exact offline-then-sync case it exists for.
+    'created_at',
   ]),
 }
 

--- a/src/stores/__tests__/workoutSetTimestamp.test.ts
+++ b/src/stores/__tests__/workoutSetTimestamp.test.ts
@@ -102,14 +102,20 @@ describe('#846 per-set createdAt timestamp', () => {
     expect(set.createdAt).not.toBe(set.date)
   })
 
-  it('persists createdAt through localStorage', () => {
+  it('persists createdAt through localStorage and round-trips via load()', () => {
     const store = useWorkoutStore()
     const id = store.addExercise('Bench')!
-    store.logSet(id, 185, 5)
+    store.logSet(id, 185, 5) // no-date path: createdAt is still stamped
 
-    const raw = localStorageMock.getItem('workout-exercises')!
-    const parsed = JSON.parse(raw)
+    // Written to storage…
+    const parsed = JSON.parse(localStorageMock.getItem('workout-exercises')!)
     expect(parsed[0].sets[0].createdAt).toBe(NOW)
+    expect(parsed[0].sets[0].createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/) // a real ISO instant
+
+    // …and survives a reload through the store's load() path (not just the raw write).
+    setActivePinia(createPinia())
+    const reloaded = useWorkoutStore()
+    expect(reloaded.exercises[0].sets[0].createdAt).toBe(NOW)
   })
 
   it('does not reset createdAt when a set is edited', () => {
@@ -140,6 +146,24 @@ describe('#846 per-set createdAt timestamp', () => {
     const row = setUpsertRow(setId)
     expect(row).toBeDefined()
     expect(row!.created_at).toBe(NOW)
+  })
+
+  it('re-sends created_at in the upsert row when editing a set that has one', async () => {
+    const store = useWorkoutStore()
+    await store.init('user-1')
+    const exId = store.addExercise('Row')!
+    store.logSet(exId, 135, 8)
+    const setId = store.exercises[0].sets[0].id
+
+    // Edit weight/reps after time passes — createdAt must still ride along
+    // (setUpsertRow returns the most recent enqueue, i.e. this edit's).
+    vi.setSystemTime(new Date('2026-06-29T09:00:00.000Z'))
+    store.updateSet(exId, setId, 145, 6)
+
+    const row = setUpsertRow(setId)
+    expect(row).toBeDefined()
+    expect(row!.weight).toBe(145)
+    expect(row!.created_at).toBe(NOW) // original log time, not the edit time
   })
 
   it('omits created_at from the upsert row for a legacy set with no local createdAt', async () => {

--- a/src/stores/__tests__/workoutSetTimestamp.test.ts
+++ b/src/stores/__tests__/workoutSetTimestamp.test.ts
@@ -1,0 +1,201 @@
+/**
+ * #846 — real per-set timestamp (`createdAt`).
+ *
+ * `WorkoutSet.date` is stamped end-of-day (`…T23:59:<jitter>Z`, no time-of-day,
+ * per #746). A separate `createdAt` carries the real wall-clock log time so the
+ * AI Coach payload (coachDigest) can derive time-of-day + within-workout order.
+ * This suite pins that contract at the store boundary:
+ *   - logSet stamps a real createdAt distinct from the end-of-day date
+ *   - createdAt round-trips through localStorage
+ *   - editing a set never resets createdAt
+ *   - the upsert row carries created_at (so offline sets keep their log time),
+ *     and omits it for legacy sets with no local createdAt (leaving the
+ *     server's insert-time value untouched on conflict)
+ *   - the fetch mapping surfaces sets.created_at → WorkoutSet.createdAt
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+// Configurable remote dataset for the fetch-mapping test.
+let mockExercises: Record<string, unknown>[] = []
+let mockSets: Record<string, unknown>[] = []
+
+// Resolving supabase mock: fetch returns the configured rows; upsert is a no-op
+// (the durable thunk never runs because syncQueue is mocked — we assert on the
+// descriptor row instead).
+vi.mock('../../lib/supabase', () => {
+  function resolvingChain(getData: () => Record<string, unknown>[]): Record<string, unknown> {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      is: () => chain,
+      order: () => chain,
+      upsert: () => Promise.resolve({ error: null }),
+      then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: getData(), error: null }).then(resolve, reject),
+    }
+    return chain
+  }
+  return {
+    supabase: {
+      from: (table: string) =>
+        resolvingChain(() => (table === 'sets' ? mockSets : mockExercises)),
+    },
+    isPreviewMode: { value: false },
+  }
+})
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn(), rehydrate: vi.fn() },
+}))
+
+vi.mock('../../lib/logger', () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+import { useWorkoutStore } from '../workout'
+import { syncQueue } from '../../lib/syncQueue'
+
+const NOW = '2026-06-28T14:30:00.000Z'
+
+/** The most recent journaled set-upsert descriptor row for a given set id. */
+function setUpsertRow(setId: string): Record<string, unknown> | undefined {
+  const enqueue = syncQueue.enqueue as unknown as { mock: { calls: unknown[][] } }
+  let row: Record<string, unknown> | undefined
+  for (const call of enqueue.mock.calls) {
+    const descriptor = call[2] as { table?: string; row?: Record<string, unknown> } | undefined
+    if (descriptor?.table === 'sets' && descriptor.row?.id === setId) row = descriptor.row
+  }
+  return row
+}
+
+describe('#846 per-set createdAt timestamp', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    mockExercises = []
+    mockSets = []
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(NOW))
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stamps a real createdAt distinct from the end-of-day date', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Squat')!
+    // Backdate the calendar day — date becomes end-of-day for that day, but the
+    // log moment (createdAt) is still the real "now".
+    store.logSet(id, 225, 5, '2026-06-20')
+
+    const set = store.exercises[0].sets[0]
+    expect(set.date).toMatch(/^2026-06-20T23:59:/)
+    expect(set.createdAt).toBe(NOW)
+    expect(set.createdAt).not.toBe(set.date)
+  })
+
+  it('persists createdAt through localStorage', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Bench')!
+    store.logSet(id, 185, 5)
+
+    const raw = localStorageMock.getItem('workout-exercises')!
+    const parsed = JSON.parse(raw)
+    expect(parsed[0].sets[0].createdAt).toBe(NOW)
+  })
+
+  it('does not reset createdAt when a set is edited', () => {
+    const store = useWorkoutStore()
+    const exId = store.addExercise('Bench')!
+    store.logSet(exId, 135, 10)
+    const setId = store.exercises[0].sets[0].id
+    const original = store.exercises[0].sets[0].createdAt
+    expect(original).toBe(NOW)
+
+    // Time passes, then the user fixes the weight/reps and even the day.
+    vi.setSystemTime(new Date('2026-06-29T09:00:00.000Z'))
+    store.updateSet(exId, setId, 185, 5, '2026-06-25')
+
+    const set = store.exercises[0].sets[0]
+    expect(set.weight).toBe(185)
+    expect(set.date).toMatch(/^2026-06-25T23:59:/)
+    expect(set.createdAt).toBe(original) // unchanged by the edit
+  })
+
+  it('enqueues an upsert row carrying created_at for a freshly logged set', async () => {
+    const store = useWorkoutStore()
+    await store.init('user-1') // sets _userId so the sync branch fires
+    const exId = store.addExercise('Deadlift')!
+    store.logSet(exId, 315, 3)
+    const setId = store.exercises[0].sets[0].id
+
+    const row = setUpsertRow(setId)
+    expect(row).toBeDefined()
+    expect(row!.created_at).toBe(NOW)
+  })
+
+  it('omits created_at from the upsert row for a legacy set with no local createdAt', async () => {
+    // Seed a pre-#846 set (no createdAt) directly into localStorage.
+    localStorageMock.setItem('workout-exercises', JSON.stringify([
+      {
+        id: 'ex-legacy',
+        name: 'OHP',
+        tags: ['Push'],
+        updated_at: '2026-05-01T00:00:00.000Z',
+        sets: [{ id: 'set-legacy', date: '2026-05-01T23:59:30.000Z', weight: 95, reps: 5, estimated1RM: 111 }],
+      },
+    ]))
+    setActivePinia(createPinia())
+    const store = useWorkoutStore()
+    await store.init('user-1')
+
+    // Edit it — must not invent a created_at (would clobber the server's
+    // insert-time value on conflict).
+    store.updateSet('ex-legacy', 'set-legacy', 100, 5)
+
+    const row = setUpsertRow('set-legacy')
+    expect(row).toBeDefined()
+    expect(row!.weight).toBe(100)
+    expect('created_at' in row!).toBe(false)
+  })
+
+  it('surfaces sets.created_at from the fetch as WorkoutSet.createdAt', async () => {
+    mockExercises = [
+      {
+        id: 'ex-1',
+        name: 'Bench Press',
+        tags: ['Push'],
+        created_at: '2026-06-20T00:00:00.000Z',
+        updated_at: '2026-06-20T00:00:00.000Z',
+        deleted_at: null,
+      },
+    ]
+    mockSets = [
+      {
+        id: 's-1',
+        exercise_id: 'ex-1',
+        date: '2026-06-20T23:59:30.000Z',
+        weight: 185,
+        reps: 5,
+        estimated_1rm: 216,
+        created_at: '2026-06-20T18:45:00.000Z',
+        deleted_at: null,
+      },
+    ]
+
+    const store = useWorkoutStore()
+    await store.init('user-1')
+
+    const ex = store.exercises.find(e => e.id === 'ex-1')
+    expect(ex).toBeDefined()
+    expect(ex!.sets[0].createdAt).toBe('2026-06-20T18:45:00.000Z')
+  })
+})

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -283,7 +283,7 @@ export const useWorkoutStore = defineStore('workout', () => {
 
   /** Durable set upsert with a journaled descriptor (LIFT-706). */
   function _enqueueSetUpsert(
-    set: { id: string; date: string; weight: number; reps: number; estimated1RM: number },
+    set: { id: string; date: string; weight: number; reps: number; estimated1RM: number; createdAt?: string },
     exerciseId: string,
     userId: string,
   ) {
@@ -291,6 +291,11 @@ export const useWorkoutStore = defineStore('workout', () => {
       id: set.id, user_id: userId, exercise_id: exerciseId,
       date: set.date, weight: set.weight, reps: set.reps,
       estimated_1rm: set.estimated1RM,
+      // Persist the real log-time timestamp so an offline set logged at 6pm but
+      // synced hours later keeps its training time instead of the DB insert-time
+      // default (#846). Omitted when absent so editing a legacy set (no local
+      // createdAt) leaves the server's created_at untouched on upsert.
+      ...(set.createdAt ? { created_at: set.createdAt } : {}),
     }
     syncQueue.enqueue(
       `set:${set.id}`,
@@ -406,7 +411,10 @@ export const useWorkoutStore = defineStore('workout', () => {
         date: s.date,
         weight: s.weight,
         reps: s.reps,
-        estimated1RM: s.estimated_1rm
+        estimated1RM: s.estimated_1rm,
+        // Surface the server insert timestamp so historical/synced sets carry a
+        // real time-of-day + within-workout order for the AI Coach payload (#846).
+        createdAt: s.created_at,
       })
     }
     remoteExercises.forEach(ex => {
@@ -656,13 +664,19 @@ export const useWorkoutStore = defineStore('workout', () => {
       : new Date().toISOString()
     const id = uuid()
     const estimated1RM = epley(weight, reps)
-    exercise.sets.push({ id, date, weight, reps, estimated1RM })
+    // Real wall-clock log time, distinct from `date` (stamped end-of-day for the
+    // chosen calendar day, no time-of-day, per #746). Drives time-of-day +
+    // within-workout ordering in the AI Coach payload (#846): ≈ training time for
+    // live logging, and for an offline set it preserves the log moment rather
+    // than the later sync time.
+    const createdAt = new Date().toISOString()
+    exercise.sets.push({ id, date, weight, reps, estimated1RM, createdAt })
     exercise.updated_at = new Date().toISOString()
     triggerRef(exercises)
     _persist()
 
     if (sync && supabase && !isPreviewMode.value && _userId) {
-      _enqueueSetUpsert({ id, date, weight, reps, estimated1RM }, exerciseId, _userId)
+      _enqueueSetUpsert({ id, date, weight, reps, estimated1RM, createdAt }, exerciseId, _userId)
     }
   }
 


### PR DESCRIPTION
Closes #846. Part of the AI Coach epic #842.

## What & why
A real per-set timestamp **already existed server-side** — `sets.created_at` (DB insert default) is what `.order('created_at')` uses on fetch to restore logged order across reloads/devices. It was simply **never surfaced into the client model**, so the AI Coach payload's `timeOfDay` + within-workout ordering sat dormant. This surfaces it (mostly plumbing, not capture-from-scratch).

## Changes (`src/stores/workout.ts`)
- **Fetch mapping** — map `s.created_at` → `WorkoutSet.createdAt`, so all synced/historical sets carry a real timestamp immediately.
- **`logSet`** — stamp a real `createdAt = new Date().toISOString()` at log time, **distinct from `date`** (which keeps its end-of-day `setDayKey` bucketing, #746). Include it in the set object + upsert row so new/offline/pre-sync sets keep their log moment instead of inheriting the DB insert-time default.
- **`_enqueueSetUpsert`** — send `created_at` when present; **omit it when absent** so editing a legacy (pre-#846) set never clobbers the server's insert-time value on conflict.
- **`updateSet`** — leaves `createdAt` untouched, so edits preserve the original log time.

`coachDigest` already consumes `createdAt` → `timeOfDay` ("HH:MM" local) + real intra-day ordering (existing tests cover the consumer).

## Accuracy caveat (documented, not over-claimed)
`created_at` is insert/sync time: ≈ training time for live online logging, but skewed for log-offline-then-sync-later or backfilled sets. Surfaced as indicative, not exact.

## Tests
New `src/stores/__tests__/workoutSetTimestamp.test.ts` pins the producer side:
- `logSet` stamps a real `createdAt` distinct from the end-of-day `date`
- `createdAt` round-trips through localStorage
- editing a set never resets `createdAt`
- upsert row **carries** `created_at` for fresh sets and **omits** it for legacy sets (conflict-safety)
- fetch maps `sets.created_at` → `WorkoutSet.createdAt`

## Acceptance criteria
- [x] `WorkoutSet.createdAt` populated for synced data (fetch) and new sets (logSet); preserved across edits
- [x] coachDigest emits `timeOfDay` + real intra-day ordering (existing tests)
- [x] No regression to `setDayKey` bucketing, dedup/merge, or sync idempotency

## Gates
typecheck ✓ · lint ✓ · 2332 tests ✓ · build ✓

## Notes
Dormant `sets.session_id` column remains unused — ordering by `created_at` within a day already yields within-workout sequence, so explicit session grouping stays optional (not blocked on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)