### PR TITLE
a11y(LIFT-856): give each top-level view a single consistent <h1> page heading

### DIFF
--- a/src/components/__tests__/BodyweightTracker.test.ts
+++ b/src/components/__tests__/BodyweightTracker.test.ts
@@ -743,6 +743,17 @@ describe('BodyweightTracker', () => {
       const hero = wrapper.find('.bwHero')
       expect(hero.find('.wtLogBtn').exists()).toBe(true)
     })
+
+    // LIFT-856: the hero shows the current weight value, not a title — so the view
+    // had no page-level <h1>, breaking heading navigation across tab switches. A
+    // single visually-hidden h1 gives assistive tech a consistent landmark.
+    it('provides a single visually-hidden h1 page heading for assistive tech', () => {
+      const wrapper = mountTracker()
+      const h1s = wrapper.findAll('h1')
+      expect(h1s.length).toBe(1)
+      expect(h1s[0].text()).toBe('Weight')
+      expect(h1s[0].classes()).toContain('srOnly')
+    })
   })
 
   describe('a11y: sentiment indicators (WCAG 1.4.1 — not color alone)', () => {

--- a/src/components/__tests__/CalendarView.test.ts
+++ b/src/components/__tests__/CalendarView.test.ts
@@ -93,6 +93,16 @@ describe('CalendarView', () => {
       expect(wrapper.find('.calTitle').text()).toBe('Training Calendar')
     })
 
+    // LIFT-856: each top-level view needs a single page-level <h1> so screen-reader
+    // users get a consistent landmark and the hierarchy doesn't skip from h1 to h2.
+    it('exposes the calendar title as the single h1 (no skipped heading level)', () => {
+      const wrapper = mountCalendar()
+      const h1s = wrapper.findAll('h1')
+      expect(h1s.length).toBe(1)
+      expect(h1s[0].classes()).toContain('calTitle')
+      expect(h1s[0].text()).toBe('Training Calendar')
+    })
+
     it('shows Month and Week view toggle buttons', () => {
       const wrapper = mountCalendar()
       const btns = wrapper.findAll('.calToggleBtn')

--- a/src/views/BodyweightTracker.vue
+++ b/src/views/BodyweightTracker.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="wtCard bwCard">
+    <!-- Page-level heading for assistive tech (the hero shows the value, not a title) -->
+    <h1 class="srOnly">Weight</h1>
     <!-- Hero header: current weight + goal hint + log button -->
     <div class="bwHero">
       <span class="bwCurrentValue">{{ store.latestWeight ? `${displayWeight(store.latestWeight)} ${weightUnit}` : 'No entries' }}</span>

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -2,7 +2,7 @@
   <div class="calCard">
     <!-- Header -->
     <div class="calCardHeader">
-      <h2 class="calTitle">Training Calendar</h2>
+      <h1 class="calTitle">Training Calendar</h1>
       <div class="calViewToggle">
         <button :class="['calToggleBtn', { active: view === 'month' }]" :aria-pressed="view === 'month'" @click="setView('month')">Month</button>
         <button :class="['calToggleBtn', { active: view === 'week' }]" :aria-pressed="view === 'week'" @click="setView('week')">Week</button>


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-856](https://github.com/aschung212/Lift/issues/856)

Fix LIFT-856: each top-level view should have a single, consistent page-level `<h1>`. CalendarView jumped to `<h2 class="calTitle">` (skipping h1) and BodyweightTracker had no page heading at all — breaking heading-based screen-reader navigation when switching tabs.

## Changes
- `src/views/CalendarView.vue` — promoted `<h2 class="calTitle">Training Calendar</h2>` to `<h1>`. CSS is class-based, so visuals are unchanged.
- `src/views/BodyweightTracker.vue` — added a single visually-hidden `<h1 class="srOnly">Weight</h1>` (the hero shows the weight value, not a title, so the settled hero design is preserved). "Weight" matches the tab label and the run2 view-change announcement.
- `src/components/__tests__/CalendarView.test.ts` — regression test: exactly one `<h1>` (`.calTitle`, "Training Calendar").
- `src/components/__tests__/BodyweightTracker.test.ts` — regression test: exactly one visually-hidden `<h1>` ("Weight", `.srOnly`).

WorkoutTracker already had its `<h1 class="wtPageTitle">Workouts</h1>`, so all three views now expose exactly one consistent top-level heading. WCAG 1.3.1 / 2.4.6 / 2.4.10.

## Verification
- `npx vitest run` — 122 files, 2343 tests passing (2 new)
- `npm run lint` — clean
- `npm run build` — succeeds
- Note: the pre-push Gemini 3.1 Pro reviewer failed with an `IneligibleTierError` (Gemini Code Assist free-tier client deprecated) — an infrastructure/auth issue affecting the review tooling itself, not this diff. Worth flagging for human follow-up.

## Screenshots
None — no visible UI change (Calendar title unchanged via class-based CSS; Weight h1 is visually hidden).

## Commits
- [`92f83c9`](https://github.com/aschung212/Lift/commit/92f83c9) a11y(LIFT-856): give each top-level view a single consistent <h1> page heading

## Test Results
- Before: 2341 passing
- After: 2343 passing (2 delta)

---
_Automated by overnight pipeline — Mon Jun 29 23:22:21 PDT 2026_

## Preview
Test on your phone: https://lift-m6l90rqkq-aschung212-1101s-projects.vercel.app