### PR TITLE
a11y(LIFT-855): expose XP and theme-unlock progress bars to screen readers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -159,7 +159,16 @@
       <div v-if="xpToast.visible" class="xpGlobalToast" role="status" aria-live="polite">
         <div class="xpToastEarned">{{ xpToast.text }}</div>
         <div class="xpToastTotal">{{ xpToast.nextThresholdXP ? `${xpToast.totalXP.toLocaleString()} / ${xpToast.nextThresholdXP.toLocaleString()} XP` : `${xpToast.totalXP.toLocaleString()} XP` }}</div>
-        <div v-if="xpToast.nextThresholdXP" class="xpToastProgress">
+        <div
+          v-if="xpToast.nextThresholdXP"
+          class="xpToastProgress"
+          role="progressbar"
+          aria-label="XP progress to next level"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          :aria-valuenow="xpToast.progressPercent"
+          :aria-valuetext="`${xpToast.totalXP.toLocaleString()} of ${xpToast.nextThresholdXP.toLocaleString()} XP`"
+        >
           <div class="xpToastProgressFill" :style="{ width: xpToast.progressPercent + '%' }"></div>
         </div>
       </div>

--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -66,7 +66,16 @@
             Unlock more themes by enabling <span class="badgeEnableLink">Progression</span> below.
           </p>
           <!-- Progress bar toward next unlock (verbose mode only, active progression, not when all unlocked) -->
-          <div v-if="progressionActive && progressionStore.showProgression && progressionStore.nextUnlockThreshold !== null" class="badgeProgressBar">
+          <div
+            v-if="progressionActive && progressionStore.showProgression && progressionStore.nextUnlockThreshold !== null"
+            class="badgeProgressBar"
+            role="progressbar"
+            aria-label="Progress to next theme unlock"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-valuenow="progressionStore.progressPercent"
+            :aria-valuetext="`${progressionStore.xpToNextUnlock.toLocaleString()} XP to next theme`"
+          >
             <div class="badgeProgressFill" :style="{ width: progressionStore.progressPercent + '%' }"></div>
           </div>
           <div class="settingsRow">

--- a/src/components/__tests__/progressbarA11y.test.ts
+++ b/src/components/__tests__/progressbarA11y.test.ts
@@ -1,0 +1,89 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Regression tests for LIFT-855: XP and theme-unlock progress bars must expose
+ * their value to screen readers via role="progressbar" + aria-value* attributes.
+ *
+ * These are source-level assertions (like metaRegression/cssRegression) because
+ * the XP toast lives in App.vue (impractical to mount) and the markup is what
+ * regresses — a future edit dropping the role/value attributes would silently
+ * make the bars opaque to assistive tech again.
+ */
+
+const appSrc = readFileSync(resolve(__dirname, '../../App.vue'), 'utf-8')
+const settingsSrc = readFileSync(resolve(__dirname, '../SettingsSheet.vue'), 'utf-8')
+const starterSrc = readFileSync(resolve(__dirname, '../StarterPickerFlow.vue'), 'utf-8')
+
+/** Extract the opening tag (`<div ... >`) of the element carrying `className`. */
+function openingTagFor(source: string, className: string): string {
+  const classIdx = source.indexOf(`class="${className}"`)
+  expect(classIdx, `class="${className}" should exist in source`).toBeGreaterThan(-1)
+  const tagStart = source.lastIndexOf('<', classIdx)
+  const tagEnd = source.indexOf('>', classIdx)
+  return source.slice(tagStart, tagEnd + 1)
+}
+
+describe('Progress bar accessibility (LIFT-855)', () => {
+  describe('XP toast progress bar (App.vue)', () => {
+    const tag = openingTagFor(appSrc, 'xpToastProgress')
+
+    it('declares role="progressbar"', () => {
+      expect(tag).toContain('role="progressbar"')
+    })
+
+    it('has an aria-label', () => {
+      expect(tag).toMatch(/aria-label="[^"]+"/)
+    })
+
+    it('pins aria-valuemin=0 and aria-valuemax=100', () => {
+      expect(tag).toContain('aria-valuemin="0"')
+      expect(tag).toContain('aria-valuemax="100"')
+    })
+
+    it('binds aria-valuenow to the live progress percent', () => {
+      expect(tag).toContain(':aria-valuenow="xpToast.progressPercent"')
+    })
+
+    it('exposes a human-readable aria-valuetext with the XP totals', () => {
+      expect(tag).toMatch(/:aria-valuetext=/)
+      expect(tag).toContain('xpToast.totalXP')
+      expect(tag).toContain('xpToast.nextThresholdXP')
+    })
+  })
+
+  describe('Theme-unlock progress bar (SettingsSheet.vue)', () => {
+    const tag = openingTagFor(settingsSrc, 'badgeProgressBar')
+
+    it('declares role="progressbar"', () => {
+      expect(tag).toContain('role="progressbar"')
+    })
+
+    it('has an aria-label', () => {
+      expect(tag).toMatch(/aria-label="[^"]+"/)
+    })
+
+    it('pins aria-valuemin=0 and aria-valuemax=100', () => {
+      expect(tag).toContain('aria-valuemin="0"')
+      expect(tag).toContain('aria-valuemax="100"')
+    })
+
+    it('binds aria-valuenow to the store progress percent', () => {
+      expect(tag).toContain(':aria-valuenow="progressionStore.progressPercent"')
+    })
+
+    it('exposes a human-readable aria-valuetext with XP to next unlock', () => {
+      expect(tag).toMatch(/:aria-valuetext=/)
+      expect(tag).toContain('progressionStore.xpToNextUnlock')
+    })
+  })
+
+  describe('Decorative starter-preview bar stays hidden', () => {
+    it('spfProgressTrack remains aria-hidden (purely decorative, no value)', () => {
+      const tag = openingTagFor(starterSrc, 'spfPreview')
+      expect(tag).toContain('aria-hidden="true"')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-855](https://github.com/aschung212/Lift/issues/855)

Fix LIFT-855: the XP toast fill (`.xpToastProgress` in `App.vue`) and the theme-unlock progress bar (`.badgeProgressBar` in `SettingsSheet.vue`) were styled `<div>`s with only an inline width — no `role="progressbar"` or `aria-value*` — so during XP gain and unlock ceremonies a screen-reader user heard the toast text but got no sense of progress toward the next threshold. Add proper progressbar semantics. WCAG 1.3.1.

## Changes
- `src/App.vue:162` — added `role="progressbar"`, `aria-label`, `aria-valuemin="0"`, `aria-valuemax="100"`, `:aria-valuenow="xpToast.progressPercent"`, and `:aria-valuetext` (e.g. "1,200 of 2,000 XP") to the XP toast bar.
- `src/components/SettingsSheet.vue:69` — same treatment on the theme-unlock bar, valuetext bound to `xpToNextUnlock` (e.g. "800 XP to next theme").
- Left the decorative starter-preview bar (`StarterPickerFlow.vue`, `aria-hidden="true"`) and the onboarding step dots (already a labeled progressbar) untouched.
- Added `src/components/__tests__/progressbarA11y.test.ts` — source-level regression test pinning the role + aria-value attributes (App.vue's toast is impractical to mount; the markup is what regresses).

## Verification
- `npm run lint` — clean
- `npm run build` — succeeds
- Full suite: 123 files, 2352 tests passing (11 new)

## Screenshots
None — non-visual a11y attributes only; no visual change.

## Commits
- [`11f74ea`](https://github.com/aschung212/Lift/commit/11f74ea) a11y(LIFT-855): expose XP and theme-unlock progress bars to screen readers

## Test Results
- Before: 2341 passing
- After: 2352 passing (11 delta)

---
_Automated by overnight pipeline — Mon Jun 29 23:29:12 PDT 2026_

## Preview
Test on your phone: https://lift-crw9nhfyt-aschung212-1101s-projects.vercel.app