### PR TITLE
feat(LIFT-851): add device-local AI Coach insight history (last-12 ring)

### DIFF
--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -180,6 +180,13 @@ disclosure work must ship in the **same PR as the UI** (CLAUDE.md Documentation 
   lifetime PRs, per-set relative intensities, current-week volume, consistency, bodyweight
   trend, weights unit-converted, identifiers stripped — + 13 tests (validate round-trip +
   no-identifiers assertion).
+- `src/lib/coachHistory.ts` (LIFT-851) — device-local insight ring. Persists generated
+  reviews to localStorage (`coach-insights-history`) as a **last-12 ring** (drop oldest);
+  re-opening a cached review is **free** (no quota). `appendCoachInsight` / `loadCoachHistory`
+  (newest-first, corrupt + malformed entries dropped) / `clearCoachHistory`. The key is wired
+  into `deleteAccount`'s `localStorageKeys` clear. NOT synced — cross-device `coach_insights`
+  is a deliberate Phase 2 change. The CoachSheet "Past insights" list consumes this once #848
+  lands.
 
 **Remaining Phase 1:**
 - `CoachSheet` + the Workouts-tab entry card; render output via text interpolation. The view

--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -245,6 +245,7 @@ describe('useAuth', () => {
         'onboarding-complete', 'sample-data', 'active-tab', 'wt-list-view',
         'rest-duration', 'rest-warning-options', 'rest-warnings', 'rest-presets-disabled', 'rest-presets',
         'app-theme', 'app-mode', 'app-glass', 'rest-timer', 'rest-timer-autostart', 'weight-unit',
+        'coach-insights-history',
       ]
       for (const key of allKeys) {
         localStorage.setItem(key, 'test-value')

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -235,6 +235,7 @@ async function deleteAccount(): Promise<void> {
     'onboarding-complete', 'sample-data', 'active-tab', 'wt-list-view',
     'rest-duration', 'rest-warning-options', 'rest-warnings', 'rest-presets-disabled', 'rest-presets',
     'app-theme', 'app-mode', 'app-glass', 'rest-timer', 'rest-timer-autostart', 'weight-unit',
+    'coach-insights-history',
   ]
   for (const key of localStorageKeys) {
     localStorage.removeItem(key)

--- a/src/lib/__tests__/coachHistory.test.ts
+++ b/src/lib/__tests__/coachHistory.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  loadCoachHistory,
+  appendCoachInsight,
+  clearCoachHistory,
+  COACH_HISTORY_KEY,
+  COACH_HISTORY_LIMIT,
+} from '../coachHistory'
+import type { CoachReview } from '../aiCoach'
+
+function review(headline: string): CoachReview {
+  return {
+    headline,
+    sections: [
+      { type: 'progress', title: 'Bench up', body: 'You added 10 lb on bench this week.' },
+    ],
+    focusNext: 'Hit squats twice next week.',
+  }
+}
+
+describe('coach insight history', () => {
+  beforeEach(() => {
+    localStorage.removeItem(COACH_HISTORY_KEY)
+  })
+
+  it('defaults to an empty list', () => {
+    expect(loadCoachHistory()).toEqual([])
+  })
+
+  it('appends and re-reads a review (re-open is free — no quota involved)', () => {
+    appendCoachInsight(review('Strong week'), 1000)
+    const history = loadCoachHistory()
+    expect(history).toHaveLength(1)
+    expect(history[0].review.headline).toBe('Strong week')
+    expect(history[0].createdAt).toBe(1000)
+    expect(history[0].id).toBeTruthy()
+  })
+
+  it('orders newest-first', () => {
+    appendCoachInsight(review('oldest'), 1000)
+    appendCoachInsight(review('middle'), 2000)
+    appendCoachInsight(review('newest'), 3000)
+    expect(loadCoachHistory().map((e) => e.review.headline)).toEqual([
+      'newest',
+      'middle',
+      'oldest',
+    ])
+  })
+
+  it('caps the ring at COACH_HISTORY_LIMIT, dropping the oldest', () => {
+    for (let i = 0; i < COACH_HISTORY_LIMIT + 5; i++) {
+      appendCoachInsight(review(`review-${i}`), 1000 + i)
+    }
+    const history = loadCoachHistory()
+    expect(history).toHaveLength(COACH_HISTORY_LIMIT)
+    // newest is the last appended; the 5 oldest were evicted
+    expect(history[0].review.headline).toBe(`review-${COACH_HISTORY_LIMIT + 4}`)
+    expect(history[history.length - 1].review.headline).toBe('review-5')
+  })
+
+  it('assigns a unique id per insight', () => {
+    appendCoachInsight(review('a'), 1000)
+    appendCoachInsight(review('b'), 1000)
+    const ids = loadCoachHistory().map((e) => e.id)
+    expect(new Set(ids).size).toBe(2)
+  })
+
+  it('clears the whole ring', () => {
+    appendCoachInsight(review('a'), 1000)
+    appendCoachInsight(review('b'), 2000)
+    clearCoachHistory()
+    expect(loadCoachHistory()).toEqual([])
+    expect(localStorage.getItem(COACH_HISTORY_KEY)).toBeNull()
+  })
+
+  it('returns an empty list on corrupt storage', () => {
+    localStorage.setItem(COACH_HISTORY_KEY, '{not json')
+    expect(loadCoachHistory()).toEqual([])
+  })
+
+  it('returns an empty list when the stored value is not an array', () => {
+    localStorage.setItem(COACH_HISTORY_KEY, JSON.stringify({ not: 'an array' }))
+    expect(loadCoachHistory()).toEqual([])
+  })
+
+  it('drops malformed entries but keeps valid ones', () => {
+    localStorage.setItem(
+      COACH_HISTORY_KEY,
+      JSON.stringify([
+        { id: 'ok', createdAt: 1000, review: review('valid') },
+        { id: 'no-review', createdAt: 2000 },
+        { id: 42, createdAt: 3000, review: review('bad id') },
+        { id: 'bad-review-shape', createdAt: 4000, review: { headline: 'x' } },
+        { id: 'bad-section', createdAt: 5000, review: { headline: 'h', focusNext: 'f', sections: [{ type: 'nope', title: 't', body: 'b' }] } },
+      ]),
+    )
+    const history = loadCoachHistory()
+    expect(history).toHaveLength(1)
+    expect(history[0].id).toBe('ok')
+  })
+
+  it('defensively caps an over-long persisted ring on read', () => {
+    const tooMany = Array.from({ length: COACH_HISTORY_LIMIT + 3 }, (_, i) => ({
+      id: `id-${i}`,
+      createdAt: 1000 + i,
+      review: review(`r-${i}`),
+    }))
+    localStorage.setItem(COACH_HISTORY_KEY, JSON.stringify(tooMany))
+    expect(loadCoachHistory()).toHaveLength(COACH_HISTORY_LIMIT)
+  })
+
+  it('persists a metric on a section round-trip', () => {
+    const withMetric: CoachReview = {
+      headline: 'PR week',
+      sections: [
+        {
+          type: 'progress',
+          title: 'Squat PR',
+          body: 'New estimated 1RM.',
+          metric: { label: 'Squat e1RM', value: '315 lb' },
+        },
+      ],
+      focusNext: 'Deload next week.',
+    }
+    appendCoachInsight(withMetric, 1000)
+    expect(loadCoachHistory()[0].review.sections[0].metric).toEqual({
+      label: 'Squat e1RM',
+      value: '315 lb',
+    })
+  })
+})

--- a/src/lib/coachHistory.ts
+++ b/src/lib/coachHistory.ts
@@ -1,0 +1,128 @@
+/**
+ * AI Coach — device-local insight history (LIFT-851, part of #842).
+ *
+ * Each generated Weekly Review costs a quota slot and real money to produce, so
+ * once a review exists it should not evaporate. This module persists generated
+ * reviews to localStorage as a bounded **last-12 ring** (drop oldest), turning the
+ * coach into an accruing coaching journal: re-opening a past insight is FREE — it
+ * reads from this store and never touches the server quota.
+ *
+ * The history is intentionally **device-local** (like the overload nudge and goal
+ * celebration), NOT synced. Cross-device `coach_insights` sync is a deliberate
+ * Phase 2 change because it would re-trigger a consent-version bump, deleteAccount
+ * wiring, and an App Store privacy-label review (see docs/ai-coach.md, History).
+ *
+ * The ring is capped at COACH_HISTORY_LIMIT so a long-lived PWA can never grow this
+ * key without bound and trip storage-quota eviction of more important data.
+ *
+ * Pure + storage-only (no Vue, no network) so it is unit-testable and reusable by
+ * both the CoachSheet UI and any future surface. The persisted review is the
+ * already-sanitized output of `sanitizeCoachOutput`, so reads stay safe to render.
+ */
+
+import { loadJSON, isPlainObject } from './storage'
+import type { CoachReview, CoachSection, CoachSectionType } from './aiCoach'
+
+/** Device-local localStorage key holding the insight ring. Cleared on account deletion. */
+export const COACH_HISTORY_KEY = 'coach-insights-history'
+
+/** Ring capacity. Bounded so the PWA can't grow this key without limit. */
+export const COACH_HISTORY_LIMIT = 12
+
+/** One persisted Weekly Review plus the metadata needed to list and re-open it. */
+export interface StoredCoachInsight {
+  /** Stable unique id (for list keys + dedupe). */
+  id: string
+  /** Epoch milliseconds the review was generated. Drives the "Past insights" ordering + labels. */
+  createdAt: number
+  /** The sanitized review exactly as it was rendered when generated. */
+  review: CoachReview
+}
+
+const SECTION_TYPES: readonly CoachSectionType[] = ['progress', 'volume', 'consistency', 'focus']
+
+function isCoachSection(value: unknown): value is CoachSection {
+  if (!isPlainObject(value)) return false
+  const s = value as Record<string, unknown>
+  if (typeof s.title !== 'string' || typeof s.body !== 'string') return false
+  if (!SECTION_TYPES.includes(s.type as CoachSectionType)) return false
+  if (s.metric !== undefined) {
+    if (!isPlainObject(s.metric)) return false
+    const m = s.metric as Record<string, unknown>
+    if (typeof m.label !== 'string' || typeof m.value !== 'string') return false
+  }
+  return true
+}
+
+function isCoachReview(value: unknown): value is CoachReview {
+  if (!isPlainObject(value)) return false
+  const r = value as Record<string, unknown>
+  if (typeof r.headline !== 'string' || typeof r.focusNext !== 'string') return false
+  if (!Array.isArray(r.sections)) return false
+  return r.sections.every(isCoachSection)
+}
+
+function isStoredInsight(value: unknown): value is StoredCoachInsight {
+  if (!isPlainObject(value)) return false
+  const e = value as Record<string, unknown>
+  return (
+    typeof e.id === 'string' &&
+    e.id.length > 0 &&
+    typeof e.createdAt === 'number' &&
+    Number.isFinite(e.createdAt) &&
+    isCoachReview(e.review)
+  )
+}
+
+/**
+ * Read the persisted insight ring, newest-first. Corrupt storage or malformed
+ * entries are dropped silently (never thrown into a render), and the result is
+ * defensively capped to COACH_HISTORY_LIMIT in case an older build wrote more.
+ */
+export function loadCoachHistory(): StoredCoachInsight[] {
+  const raw = loadJSON<unknown[]>(COACH_HISTORY_KEY, [], Array.isArray)
+  return raw.filter(isStoredInsight).slice(0, COACH_HISTORY_LIMIT)
+}
+
+function persist(history: StoredCoachInsight[]): void {
+  try {
+    localStorage.setItem(COACH_HISTORY_KEY, JSON.stringify(history))
+  } catch {
+    /* quota / private-mode — history is best-effort, never block the UI */
+  }
+}
+
+function makeId(now: number): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID()
+    }
+  } catch {
+    /* fall through to the timestamp id */
+  }
+  return `${now}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Prepend a freshly generated review to the ring, evicting the oldest beyond
+ * COACH_HISTORY_LIMIT, persist, and return the new newest-first list. Pure aside
+ * from the localStorage write; pass `now` for deterministic tests.
+ */
+export function appendCoachInsight(
+  review: CoachReview,
+  now: number = Date.now(),
+): StoredCoachInsight[] {
+  const entry: StoredCoachInsight = { id: makeId(now), createdAt: now, review }
+  const next = [entry, ...loadCoachHistory()].slice(0, COACH_HISTORY_LIMIT)
+  persist(next)
+  return next
+}
+
+/** Drop the entire ring (account deletion / sign-out). */
+export function clearCoachHistory(): void {
+  try {
+    localStorage.removeItem(COACH_HISTORY_KEY)
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-851](https://github.com/aschung212/Lift/issues/851)

Implement **LIFT-851** — device-local "Past insights" history for the AI Coach. CoachSheet (#848) is still an open PR (not on master), so I built the self-contained persistence layer that the UI consumes when it lands — matching this feature's deliberately layered rollout (backend #843 and payload builder #844 both shipped before any UI). Scope: a bounded last-12 ring in localStorage, free (no-quota) re-open semantics, and `deleteAccount` wiring, all with tests.

## Changes
- **`src/lib/coachHistory.ts`** (new) — pure + storage-only insight ring. `COACH_HISTORY_KEY = 'coach-insights-history'`, `COACH_HISTORY_LIMIT = 12`. `appendCoachInsight` (prepend newest, evict oldest, persist), `loadCoachHistory` (newest-first; corrupt + malformed entries dropped via shape guards; defensively re-capped), `clearCoachHistory`. Persists the already-sanitized `CoachReview` so reads stay safe to render. Documented as device-local-only (Phase 2 is the synced path).
- **`src/composables/useAuth.ts`** — added `'coach-insights-history'` to `deleteAccount`'s `localStorageKeys` so health-derived insights are wiped on account deletion.
- **`src/composables/__tests__/useAuth.test.ts`** — added the new key to the existing delete-keys regression test.
- **`src/lib/__tests__/coachHistory.test.ts`** (new) — 12 tests: append/re-read (free), newest-first ordering, ring cap + oldest eviction, unique ids, clear, corrupt/non-array storage, malformed-entry filtering, defensive over-length cap, metric round-trip.
- **`docs/ai-coach.md`** — documented the landed history layer under "Landed".

## Verification
- `npx vitest run` — **123 files, 2352 tests pass** (was 122/2341; +1 file, +11 tests net).
- `npm run lint` — clean.
- `npm run build` — typecheck + build succeed.

## Discoveries
ISSUE_DISCOVER:tooling:The Gemini pre-push adversarial reviewer (Husky hook) is STILL hard-down — `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals` (migrate to Antigravity). Reported by run4 and unfixed; the review gate has been silently no-op'ing on every push since. Swap the reviewer model or re-auth gemini-cli.

## Screenshots
None — no UI surface added this iteration (pure data layer; CoachSheet UI is #848).

## Commits
- [`e02b82a`](https://github.com/aschung212/Lift/commit/e02b82a) feat(LIFT-851): add device-local AI Coach insight history (last-12 ring)

## Test Results
- Before: 2341 passing
- After: 2352 passing (11 delta)

---
_Automated by overnight pipeline — Mon Jun 29 23:55:14 PDT 2026_

## Preview
Test on your phone: https://lift-boqazkm5h-aschung212-1101s-projects.vercel.app