### PR TITLE
feat(LIFT-849): versioned AI Coach consent gate + LegalSheet/privacy disclosure

### DIFF
--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -152,9 +152,26 @@ disclosure work must ship in the **same PR as the UI** (CLAUDE.md Documentation 
   intensities, volume, consistency, and bodyweight), and state the **actual** retention posture —
   do not write "zero data retention" until verified in writing (SEV1 fabrication trap).
 - A hosted `/privacy` route (`public/privacy.html` + a `vercel.json` rewrite exception) for the
-  App Store listing.
+  App Store listing. The reachable URL is `https://spa-rho-sandy.vercel.app/privacy` (the catch-all
+  `/(.*) → /index.html` rewrite is preceded by `/privacy → /privacy.html` so the static page wins;
+  pinned by `vercelHeadersRegression.test.ts`).
 - App Store nutrition label: Health & Fitness → **Data Linked to You = Yes**,
   **Used for Tracking = No**, **Third-Party Sharing = Yes**.
+
+### App Store nutrition-label answers (documented for the listing)
+
+| Question | Answer | Rationale |
+|---|---|---|
+| Data Linked to You | **Yes** | Workout/health data is tied to an authenticated account (email). |
+| Used for Tracking | **No** | No cross-app/cross-site tracking; analytics are anonymous + aggregated. |
+| Third-Party Sharing | **Yes** | Training data (and bodyweight unless opted out) is sent to Anthropic when the user opts into the AI Coach. |
+| Data types — Health & Fitness | Collected, linked | Sets/reps/weights, PRs, bodyweight trend. |
+| Data types — Contact Info | Collected, linked | Email (auth only); **never** forwarded to Anthropic. |
+
+> **Retention posture (SEV1 fabrication guard):** the LegalSheet + `/privacy` deliberately do NOT
+> assert "zero data retention" / "not trained on" for Anthropic. State only that Anthropic processes
+> the data as a sub-processor under its own published terms until a written DPA/retention commitment
+> is on file. `privacyPolicy.test.ts` fails the build if those unverified phrases appear.
 
 ## UX (Phase 1, after backend)
 
@@ -181,11 +198,27 @@ disclosure work must ship in the **same PR as the UI** (CLAUDE.md Documentation 
   trend, weights unit-converted, identifiers stripped — + 13 tests (validate round-trip +
   no-identifiers assertion).
 
+**Landed (consent/governance PR, LIFT-849):**
+- Consent contract in `src/lib/aiCoach.ts`: `AiCoachConsent` + `sanitizeAiCoachConsent`
+  (fail-closed: only `accepted === true` with a positive version consents) + `coachConsentIsCurrent`
+  / `needsCoachConsent` (a stale older version → re-prompt). The synced preferences blob is a client
+  *mirror*; the server's `coach_consent` record stays authoritative.
+- `preferences` store: `aiCoachConsent` + the granular `aiCoachBodyweightOptOut`, sanitized at all
+  three load sites (localStorage init, Supabase hydrate, cross-tab reload), with
+  `recordAiCoachConsent` / `revokeAiCoachConsent` / `setAiCoachBodyweightOptOut` and the
+  `needsAiCoachConsent` getter.
+- `AiCoachConsentModal.vue` — the centered (`repMaxModal`) opt-in: one screen of what's sent / to
+  whom / how to revoke, with the bodyweight opt-out toggle inline. Prop-driven (emits
+  `accept(bodyweightOptOut)` / `decline` / `view-privacy`); wired by `CoachSheet` (#848).
+- `LegalSheet.vue` AI Coach disclosure + hosted `public/privacy.html` (served at `/privacy` via the
+  ordered rewrite) + nutrition-label answers above. No fabricated retention claims (test-guarded).
+
 **Remaining Phase 1:**
 - `CoachSheet` + the Workouts-tab entry card; render output via text interpolation. The view
   wires `buildCoachPayload` to the stores (passes `getOverloadSuggestion` results as `overloads`,
-  `streakWeeks`/`weeklyTarget`, and `toDisplayUnits`).
-- Versioned consent modal + `LegalSheet` update + hosted `/privacy` + nutrition-label answers.
+  `streakWeeks`/`weeklyTarget`, and `toDisplayUnits`), shows `AiCoachConsentModal` when
+  `needsAiCoachConsent`, calls `record_coach_consent(version)` on accept (server is authoritative),
+  and excludes bodyweight from the payload when `aiCoachBodyweightOptOut`.
 - **Wire `deleteAccount()` to call `delete_coach_data`** and fix the verified resolved-error
   bug at `src/composables/useAuth.ts:225` (`Promise.allSettled` then `filter(status === 'rejected')`
   — supabase-js *resolves* `{ error }` on a failed delete, so a failed delete passes silently

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="robots" content="index, follow" />
+  <title>Privacy Policy — Lift</title>
+  <link rel="canonical" href="https://spa-rho-sandy.vercel.app/privacy" />
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      margin: 0;
+      padding: 2rem 1.25rem 4rem;
+      max-width: 720px;
+      margin-inline: auto;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+      color: #1c1c1e;
+      background: #ffffff;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { color: #e5e5e7; background: #000000; }
+      a { color: #0a84ff; }
+    }
+    h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+    h2 { font-size: 1.15rem; margin-top: 2rem; }
+    .updated { color: #8e8e93; font-size: 0.9rem; margin-top: 0; }
+    ul { padding-left: 1.25rem; }
+    li { margin-bottom: 0.35rem; }
+    a { color: #007aff; }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p class="updated">Lift — last updated June 30, 2026</p>
+
+  <p>Lift is a workout tracking app. This policy explains what data we collect, how it is
+  stored, and the third parties that process it.</p>
+
+  <h2>What We Collect</h2>
+  <p>Lift collects only the data you explicitly enter: exercises, sets, reps, weights, and
+  bodyweight entries. If you create an account, we store your email address for
+  authentication.</p>
+
+  <h2>How Data Is Stored</h2>
+  <p>Your workout data is stored locally on your device using browser storage. If you sign in,
+  data is synced to Supabase (our cloud database) so you can access it across devices. Data is
+  transmitted over HTTPS.</p>
+
+  <h2>Analytics</h2>
+  <p>We use Vercel Analytics to collect anonymous, aggregated usage data (page views, feature
+  usage). No personally identifiable information is included in analytics events.</p>
+
+  <h2>Third-Party Services</h2>
+  <ul>
+    <li><strong>Supabase</strong> — authentication and cloud data sync</li>
+    <li><strong>Vercel</strong> — hosting and anonymous analytics</li>
+    <li><strong>Anthropic</strong> — processes your training data to generate AI Coach reviews,
+    only when you opt in</li>
+  </ul>
+
+  <h2>AI Coach (opt-in)</h2>
+  <p>The AI Coach is off by default. The first time you use it, we ask for your explicit consent
+  before any data leaves your device. When you generate a weekly review, the following training
+  data is sent to <strong>Anthropic</strong> (the provider of the Claude AI model) so it can be
+  analyzed:</p>
+  <ul>
+    <li>Your per-set log — exercise names, weights, reps, and dates</li>
+    <li>Your personal records and each set's relative intensity</li>
+    <li>Your training sessions and consistency (how often you train)</li>
+    <li>Your bodyweight trend — unless you opt out of sharing it (a separate toggle)</li>
+  </ul>
+  <p>Your name, email address, account identifier, and any other account data are
+  <strong>never</strong> sent to Anthropic — only the training data above. Anthropic processes
+  this data under its own terms and privacy policy as a sub-processor. We do not control
+  Anthropic's retention of API data; refer to Anthropic's published policies for their current
+  practices. You can withdraw consent and disable the AI Coach at any time in Settings, which
+  stops any further sharing.</p>
+
+  <h2>Data Deletion</h2>
+  <p>You can export or delete your data at any time. Use the Export feature in Settings to
+  download your data as CSV or JSON. To delete your account and all associated data, including
+  any AI Coach records, use the delete option in Settings or contact us at the email below.</p>
+
+  <h2>Contact</h2>
+  <p>For privacy questions, email <a href="mailto:aaronschung@gmail.com">aaronschung@gmail.com</a>.</p>
+</body>
+</html>

--- a/src/components/AiCoachConsentModal.vue
+++ b/src/components/AiCoachConsentModal.vue
@@ -1,0 +1,140 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="repMaxOverlay"
+      @click.self="emit('decline')"
+      @keydown.escape="emit('decline')"
+    >
+      <div class="repMaxModal aiConsentModal" role="dialog" aria-modal="true" aria-labelledby="ai-consent-title">
+        <h2 id="ai-consent-title">Before your first review</h2>
+        <p class="aiConsentLede">
+          The AI Coach sends your recent training to <strong>Anthropic</strong> (the Claude AI
+          provider) to generate a weekly review. Here's exactly what leaves your device:
+        </p>
+        <ul class="aiConsentList">
+          <li>Your set log — exercises, weights, reps and dates</li>
+          <li>Personal records and how hard each set was (relative intensity)</li>
+          <li>How often and consistently you train</li>
+          <li v-if="!bodyweightOptOut">Your bodyweight trend</li>
+        </ul>
+        <p class="aiConsentFine">
+          Your name, email and account ID are <strong>never</strong> sent. You can turn the
+          Coach off and revoke this consent any time in Settings.
+        </p>
+
+        <div class="settingsRow aiConsentToggleRow">
+          <div class="settingsLabelGroup">
+            <span class="settingsLabel">Share bodyweight trend</span>
+            <span class="settingsHint">Your most sensitive data — optional</span>
+          </div>
+          <button
+            :class="['glassToggle', { on: !bodyweightOptOut }]"
+            @click="bodyweightOptOut = !bodyweightOptOut"
+            type="button"
+            role="switch"
+            :aria-checked="!bodyweightOptOut"
+            :aria-label="bodyweightOptOut ? 'Share bodyweight trend' : 'Do not share bodyweight trend'"
+          >
+            <span class="glassToggleThumb"></span>
+          </button>
+        </div>
+
+        <button class="aiConsentLink" type="button" @click="emit('view-privacy')">
+          Read the full privacy policy
+        </button>
+
+        <div class="repMaxActions">
+          <button class="repMaxBtn repMaxBtnClose" type="button" @click="emit('decline')">Not now</button>
+          <button class="repMaxBtn repMaxBtnCalc" type="button" @click="accept">Agree &amp; continue</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue'
+import { useFocusTrap } from '../composables/useFocusTrap'
+
+const props = defineProps<{
+  open: boolean
+  /** Current granular bodyweight opt-out (true = do NOT share). Seeds the toggle. */
+  bodyweightOptOut?: boolean
+}>()
+
+const emit = defineEmits<{
+  /** User affirmatively consented; payload carries the chosen bodyweight opt-out. */
+  (e: 'accept', bodyweightOptOut: boolean): void
+  /** User dismissed without consenting. */
+  (e: 'decline'): void
+  /** User asked to read the full privacy policy. */
+  (e: 'view-privacy'): void
+}>()
+
+const bodyweightOptOut = ref(props.bodyweightOptOut ?? false)
+const focusTrap = useFocusTrap()
+
+watch(
+  () => props.open,
+  async (open) => {
+    if (open) {
+      // Re-seed the toggle from the latest stored preference on every open.
+      bodyweightOptOut.value = props.bodyweightOptOut ?? false
+      await nextTick()
+      const el = document.querySelector<HTMLElement>('[aria-labelledby="ai-consent-title"]')
+      if (el) focusTrap.activate(el)
+    } else {
+      focusTrap.deactivate()
+    }
+  }
+)
+
+function accept() {
+  emit('accept', bodyweightOptOut.value)
+}
+</script>
+
+<style scoped>
+.aiConsentModal {
+  max-width: 360px;
+  text-align: left;
+}
+.aiConsentLede {
+  margin: 0 0 var(--space-3);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+.aiConsentList {
+  margin: 0 0 var(--space-3);
+  padding-left: var(--space-5);
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+.aiConsentList li {
+  margin-bottom: var(--space-1);
+}
+.aiConsentFine {
+  margin: 0 0 var(--space-4);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+.aiConsentToggleRow {
+  margin-bottom: var(--space-2);
+}
+.aiConsentLink {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  margin-bottom: var(--space-2);
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+}
+</style>

--- a/src/components/LegalSheet.vue
+++ b/src/components/LegalSheet.vue
@@ -20,7 +20,17 @@
               <ul class="legalList">
                 <li><strong>Supabase</strong> — authentication and cloud data sync</li>
                 <li><strong>Vercel</strong> — hosting and anonymous analytics</li>
+                <li><strong>Anthropic</strong> — processes your training data to generate AI Coach reviews (only when you opt in)</li>
               </ul>
+              <h4 class="legalH4">AI Coach (opt-in)</h4>
+              <p>The AI Coach is off by default. The first time you use it, we ask for your explicit consent before any data leaves your device. When you generate a weekly review, the following training data is sent to <strong>Anthropic</strong> (the provider of the Claude AI model) so it can be analyzed:</p>
+              <ul class="legalList">
+                <li>Your per-set log — exercise names, weights, reps, and dates</li>
+                <li>Your personal records and each set's relative intensity</li>
+                <li>Your training sessions and consistency (how often you train)</li>
+                <li>Your bodyweight trend — unless you opt out of sharing it (a separate toggle)</li>
+              </ul>
+              <p>Your name, email address, account identifier, and any other account data are <strong>never</strong> sent to Anthropic — only the training data above. Anthropic processes this data under its own terms and privacy policy as a sub-processor. We do not control Anthropic's retention of API data; refer to Anthropic's published policies for their current practices. You can withdraw consent and disable the AI Coach at any time in Settings, which stops any further sharing.</p>
               <h4 class="legalH4">Data Deletion</h4>
               <p>You can export or delete your data at any time. Use the Export feature in Settings to download your data as CSV or JSON. To delete your account and all associated data, contact us at the email below.</p>
               <h4 class="legalH4">Contact</h4>

--- a/src/components/__tests__/AiCoachConsentModal.test.ts
+++ b/src/components/__tests__/AiCoachConsentModal.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AiCoachConsentModal from '../AiCoachConsentModal.vue'
+
+function mountOpen(props: Record<string, unknown> = {}) {
+  return mount(AiCoachConsentModal, {
+    props: { open: true, ...props },
+    global: { stubs: { Teleport: true } },
+  })
+}
+
+describe('AiCoachConsentModal (LIFT-849)', () => {
+  it('renders nothing when closed', () => {
+    const wrapper = mount(AiCoachConsentModal, {
+      props: { open: false },
+      global: { stubs: { Teleport: true } },
+    })
+    expect(wrapper.find('[aria-labelledby="ai-consent-title"]').exists()).toBe(false)
+  })
+
+  it('names Anthropic and lists what is sent', () => {
+    const wrapper = mountOpen()
+    const text = wrapper.text()
+    expect(text).toContain('Anthropic')
+    expect(text.toLowerCase()).toContain('set log')
+  })
+
+  it('emits accept with bodyweightOptOut=false by default (bodyweight included)', async () => {
+    const wrapper = mountOpen()
+    await wrapper.get('.repMaxBtnCalc').trigger('click')
+    expect(wrapper.emitted('accept')).toBeTruthy()
+    expect(wrapper.emitted('accept')![0]).toEqual([false])
+  })
+
+  it('toggling the bodyweight switch sends opt-out=true on accept', async () => {
+    const wrapper = mountOpen()
+    await wrapper.get('[role="switch"]').trigger('click')
+    await wrapper.get('.repMaxBtnCalc').trigger('click')
+    expect(wrapper.emitted('accept')![0]).toEqual([true])
+  })
+
+  it('seeds the bodyweight toggle from the stored opt-out preference', async () => {
+    const wrapper = mountOpen({ bodyweightOptOut: true })
+    // toggle starts in the opted-out (off) state → switch aria-checked is false
+    expect(wrapper.get('[role="switch"]').attributes('aria-checked')).toBe('false')
+    // hides the "Your bodyweight trend" bullet when already opted out
+    expect(wrapper.text()).not.toContain('Your bodyweight trend')
+  })
+
+  it('emits decline on "Not now"', async () => {
+    const wrapper = mountOpen()
+    await wrapper.get('.repMaxBtnClose').trigger('click')
+    expect(wrapper.emitted('decline')).toBeTruthy()
+  })
+
+  it('emits view-privacy when the policy link is tapped', async () => {
+    const wrapper = mountOpen()
+    await wrapper.get('.aiConsentLink').trigger('click')
+    expect(wrapper.emitted('view-privacy')).toBeTruthy()
+  })
+})

--- a/src/lib/__tests__/aiCoach.test.ts
+++ b/src/lib/__tests__/aiCoach.test.ts
@@ -5,6 +5,11 @@ import {
   costCents,
   estimateMaxCostCents,
   containsUrl,
+  sanitizeAiCoachConsent,
+  coachConsentIsCurrent,
+  needsCoachConsent,
+  CURRENT_CONSENT_VERSION,
+  NO_AI_COACH_CONSENT,
   MAX_OUTPUT_TOKENS,
   MAX_SETS,
   MIN_SETS_FOR_REVIEW,
@@ -209,5 +214,69 @@ describe('containsUrl', () => {
     expect(containsUrl('go to spam.io now')).toBe(true)
     expect(containsUrl('[click](https://a.dev)')).toBe(true)
     expect(containsUrl('a clean coaching sentence with no links')).toBe(false)
+  })
+})
+
+describe('AI Coach consent (LIFT-849)', () => {
+  it('accepts a strictly-true current-version record', () => {
+    const c = sanitizeAiCoachConsent({
+      accepted: true,
+      acceptedAt: '2026-06-30T00:00:00.000Z',
+      version: CURRENT_CONSENT_VERSION,
+    })
+    expect(c.accepted).toBe(true)
+    expect(c.version).toBe(CURRENT_CONSENT_VERSION)
+    expect(c.acceptedAt).toBe('2026-06-30T00:00:00.000Z')
+    expect(coachConsentIsCurrent(c)).toBe(true)
+    expect(needsCoachConsent(c)).toBe(false)
+  })
+
+  it('fails closed on anything not strictly accepted', () => {
+    // truthy-but-not-true, missing fields, wrong types, adversarial input
+    for (const raw of [
+      undefined,
+      null,
+      {},
+      'true',
+      1,
+      [],
+      { accepted: 'true', version: 1 },
+      { accepted: 1, version: 1 },
+      { accepted: true }, // no positive version
+      { accepted: true, version: 0 },
+      { accepted: true, version: -3 },
+      { accepted: true, version: 'two' },
+      { accepted: false, version: 5, acceptedAt: 'x' },
+    ]) {
+      const c = sanitizeAiCoachConsent(raw)
+      expect(c).toEqual(NO_AI_COACH_CONSENT)
+      expect(coachConsentIsCurrent(c)).toBe(false)
+      expect(needsCoachConsent(c)).toBe(true)
+    }
+  })
+
+  it('floors a fractional version and drops a non-string acceptedAt', () => {
+    const c = sanitizeAiCoachConsent({ accepted: true, version: 2.9, acceptedAt: 42 })
+    expect(c.version).toBe(2)
+    expect(c.acceptedAt).toBeNull()
+  })
+
+  it('treats a stale (older) accepted version as needing re-consent', () => {
+    const stale = sanitizeAiCoachConsent({ accepted: true, version: CURRENT_CONSENT_VERSION - 1, acceptedAt: 'x' })
+    // version 0 here would collapse; use a representative bump scenario instead
+    const olderButValid = { accepted: true as const, acceptedAt: 'x', version: CURRENT_CONSENT_VERSION - 1 }
+    expect(coachConsentIsCurrent(olderButValid)).toBe(CURRENT_CONSENT_VERSION - 1 >= CURRENT_CONSENT_VERSION)
+    expect(coachConsentIsCurrent(olderButValid)).toBe(false)
+    expect(needsCoachConsent(olderButValid)).toBe(true)
+    // sanitize keeps a positive older version (so the UI can detect it's stale)
+    if (CURRENT_CONSENT_VERSION - 1 > 0) {
+      expect(stale.version).toBe(CURRENT_CONSENT_VERSION - 1)
+    }
+  })
+
+  it('does not mutate the frozen NO_AI_COACH_CONSENT baseline', () => {
+    const a = sanitizeAiCoachConsent(null)
+    a.accepted = true
+    expect(NO_AI_COACH_CONSENT.accepted).toBe(false)
   })
 })

--- a/src/lib/__tests__/privacyPolicy.test.ts
+++ b/src/lib/__tests__/privacyPolicy.test.ts
@@ -1,0 +1,76 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Regression tests for the hosted privacy page (LIFT-849) — the App Store listing
+ * requires a reachable privacy URL, and the AI Coach ships a new third-party
+ * sub-processor (Anthropic) whose disclosure must be accurate.
+ *
+ * Two failure classes are guarded here:
+ *  1. SEV1 fabrication — never claim a retention posture ("zero data retention",
+ *     "not trained on", etc.) we have not verified in writing.
+ *  2. Domain hallucination — the only deployment domain is spa-rho-sandy.vercel.app
+ *     (same rule as metaRegression.test.ts).
+ */
+
+const DEPLOYMENT_DOMAIN = 'spa-rho-sandy.vercel.app'
+const privacyHtml = readFileSync(resolve(__dirname, '../../../public/privacy.html'), 'utf-8')
+const legalSheet = readFileSync(resolve(__dirname, '../../components/LegalSheet.vue'), 'utf-8')
+
+describe('hosted /privacy page (public/privacy.html)', () => {
+  it('exists and is a complete HTML document', () => {
+    expect(privacyHtml).toMatch(/<!DOCTYPE html>/i)
+    expect(privacyHtml).toContain('Privacy Policy')
+  })
+
+  it('canonical link uses only the real deployment domain', () => {
+    const match = privacyHtml.match(/<link rel="canonical" href="([^"]+)"/)
+    expect(match).not.toBeNull()
+    expect(match![1]).toContain(DEPLOYMENT_DOMAIN)
+  })
+
+  it('discloses Anthropic as the AI Coach processor', () => {
+    expect(privacyHtml).toContain('Anthropic')
+    expect(privacyHtml.toLowerCase()).toContain('ai coach')
+  })
+
+  it('states bodyweight is shared unless opted out', () => {
+    expect(privacyHtml.toLowerCase()).toContain('bodyweight')
+    expect(privacyHtml.toLowerCase()).toContain('opt out')
+  })
+
+  it('provides a contact email', () => {
+    expect(privacyHtml).toContain('aaronschung@gmail.com')
+  })
+
+  it('does NOT fabricate an unverified retention/training posture (SEV1 trap)', () => {
+    const lower = privacyHtml.toLowerCase()
+    expect(lower).not.toContain('zero data retention')
+    expect(lower).not.toContain('not trained on')
+    expect(lower).not.toContain('does not train')
+    expect(lower).not.toContain('will not be used to train')
+  })
+
+  it('references no domain other than the real deployment domain', () => {
+    const domains = privacyHtml.match(/[a-z0-9-]+\.(app|com|net|io|co|dev|ai)\b/gi) || []
+    const offenders = domains.filter(
+      d => !d.endsWith('vercel.app') && !d.includes('gmail.com'),
+    )
+    expect(offenders).toEqual([])
+  })
+})
+
+describe('LegalSheet AI Coach disclosure', () => {
+  it('names Anthropic and lists the AI Coach fields sent', () => {
+    expect(legalSheet).toContain('Anthropic')
+    expect(legalSheet).toContain('AI Coach')
+  })
+
+  it('does NOT fabricate an unverified retention/training posture (SEV1 trap)', () => {
+    const lower = legalSheet.toLowerCase()
+    expect(lower).not.toContain('zero data retention')
+    expect(lower).not.toContain('not trained on')
+  })
+})

--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -21,9 +21,15 @@ interface RedirectRule {
   statusCode?: number
 }
 
+interface RewriteRule {
+  source: string
+  destination: string
+}
+
 interface VercelConfig {
   headers?: HeaderRule[]
   redirects?: RedirectRule[]
+  rewrites?: RewriteRule[]
 }
 
 function loadVercelConfig(): VercelConfig {
@@ -121,6 +127,29 @@ describe('vercel.json security headers', () => {
       expect(csp).toMatch(/img-src\s+[^;]*'self'/)
       expect(csp).toMatch(/img-src\s+[^;]*data:/)
       expect(csp).toMatch(/img-src\s+[^;]*blob:/)
+    })
+  })
+
+  describe('rewrites — hosted /privacy exception (LIFT-849)', () => {
+    const rewrites = config.rewrites || []
+
+    it('serves /privacy from the static privacy.html before the SPA catch-all', () => {
+      const privacy = rewrites.find(r => r.source === '/privacy')
+      expect(privacy).toBeDefined()
+      expect(privacy?.destination).toBe('/privacy.html')
+    })
+
+    it('orders the /privacy rewrite before the /(.*) catch-all (first match wins)', () => {
+      const privacyIdx = rewrites.findIndex(r => r.source === '/privacy')
+      const catchAllIdx = rewrites.findIndex(r => r.source === '/(.*)')
+      expect(privacyIdx).toBeGreaterThanOrEqual(0)
+      expect(catchAllIdx).toBeGreaterThanOrEqual(0)
+      expect(privacyIdx).toBeLessThan(catchAllIdx)
+    })
+
+    it('still routes everything else to the SPA shell', () => {
+      const catchAll = rewrites.find(r => r.source === '/(.*)')
+      expect(catchAll?.destination).toBe('/index.html')
     })
   })
 

--- a/src/lib/aiCoach.ts
+++ b/src/lib/aiCoach.ts
@@ -27,6 +27,67 @@
 /** Bump only when the set of fields that leave the device expands or the provider changes. */
 export const CURRENT_CONSENT_VERSION = 1
 
+// ---- Consent (client mirror of the server-authoritative coach_consent record) ----
+
+/**
+ * The device-local mirror of a user's AI Coach consent. The SERVER is
+ * authoritative (the `coach_consent` table, written via `record_coach_consent`);
+ * this synced copy only gates the client so it never even attempts an egress call
+ * without a current opt-in. Because the synced preferences blob is remote-wins, a
+ * stale older-device copy must never re-enable egress — so consent is always
+ * re-verified against {@link CURRENT_CONSENT_VERSION} at call time, and the server
+ * 403s `consent_required` independently when its record is absent or stale.
+ */
+export interface AiCoachConsent {
+  /** Strictly true only when the user has affirmatively accepted. */
+  accepted: boolean
+  /** ISO timestamp of acceptance, or null when not (yet) accepted. */
+  acceptedAt: string | null
+  /** The consent version accepted; 0 means "never accepted". */
+  version: number
+}
+
+/** The not-consented baseline (and the value any malformed/declined input collapses to). */
+export const NO_AI_COACH_CONSENT: AiCoachConsent = Object.freeze({
+  accepted: false,
+  acceptedAt: null,
+  version: 0,
+})
+
+/**
+ * Coerce any stored/synced value into a trustworthy {@link AiCoachConsent}. Anything
+ * that is not *strictly* an accepted record collapses to {@link NO_AI_COACH_CONSENT}
+ * — i.e. the only way to be consented is for `accepted === true` with a positive
+ * version. This is fail-closed by construction: corrupt, partial, truthy-but-not-true,
+ * or adversarial input can never grant consent. Mirrors `sanitizeIntensityPresets` and
+ * runs at the same load sites (localStorage init, Supabase hydrate, cross-tab reload).
+ */
+export function sanitizeAiCoachConsent(raw: unknown): AiCoachConsent {
+  if (!isObject(raw)) return { ...NO_AI_COACH_CONSENT }
+  if (raw.accepted !== true) return { ...NO_AI_COACH_CONSENT }
+  const version =
+    typeof raw.version === 'number' && Number.isFinite(raw.version) && raw.version > 0
+      ? Math.floor(raw.version)
+      : 0
+  if (version <= 0) return { ...NO_AI_COACH_CONSENT }
+  const acceptedAt = typeof raw.acceptedAt === 'string' ? raw.acceptedAt : null
+  return { accepted: true, acceptedAt, version }
+}
+
+/**
+ * True only when consent is affirmatively accepted AND at least the current version.
+ * An older accepted version is treated as NOT current → the UI must re-prompt and the
+ * server will 403 until the user re-accepts.
+ */
+export function coachConsentIsCurrent(consent: AiCoachConsent | null | undefined): boolean {
+  return !!consent && consent.accepted === true && consent.version >= CURRENT_CONSENT_VERSION
+}
+
+/** Convenience inverse of {@link coachConsentIsCurrent} — the UI needs the consent gate. */
+export function needsCoachConsent(consent: AiCoachConsent | null | undefined): boolean {
+  return !coachConsentIsCurrent(consent)
+}
+
 /** Per-user reviews per rolling 7-day window (overridable per user via coach_usage.limit_override). */
 export const DEFAULT_WEEKLY_LIMIT = 3
 

--- a/src/stores/__tests__/preferences.test.ts
+++ b/src/stores/__tests__/preferences.test.ts
@@ -773,4 +773,91 @@ describe('usePreferencesStore', () => {
       expect(store.intensityPresets).toEqual([40, 60, 80])
     })
   })
+
+  describe('AI Coach consent (LIFT-849)', () => {
+    it('defaults to not-consented and needs the consent gate', () => {
+      expect(store.aiCoachConsent.accepted).toBe(false)
+      expect(store.aiCoachConsent.version).toBe(0)
+      expect(store.aiCoachBodyweightOptOut).toBe(false)
+      expect(store.needsAiCoachConsent).toBe(true)
+    })
+
+    it('recordAiCoachConsent stamps the current version + clears the gate and persists', () => {
+      store.recordAiCoachConsent()
+      expect(store.aiCoachConsent.accepted).toBe(true)
+      expect(store.aiCoachConsent.version).toBe(1)
+      expect(typeof store.aiCoachConsent.acceptedAt).toBe('string')
+      expect(store.needsAiCoachConsent).toBe(false)
+
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.aiCoachConsent.accepted).toBe(true)
+      expect(stored.aiCoachConsent.version).toBe(1)
+    })
+
+    it('revokeAiCoachConsent flips back to not-consented and persists', () => {
+      store.recordAiCoachConsent()
+      store.revokeAiCoachConsent()
+      expect(store.aiCoachConsent.accepted).toBe(false)
+      expect(store.needsAiCoachConsent).toBe(true)
+
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.aiCoachConsent.accepted).toBe(false)
+    })
+
+    it('setAiCoachBodyweightOptOut coerces to a strict boolean and persists', () => {
+      store.setAiCoachBodyweightOptOut(true)
+      expect(store.aiCoachBodyweightOptOut).toBe(true)
+      // @ts-expect-error — guard against a truthy non-boolean being stored verbatim
+      store.setAiCoachBodyweightOptOut('yes')
+      expect(store.aiCoachBodyweightOptOut).toBe(false)
+
+      const stored = JSON.parse(localStorageMock.getItem('user-preferences')!)
+      expect(stored.aiCoachBodyweightOptOut).toBe(false)
+    })
+
+    it('init sanitizes a stored consent blob fail-closed (truthy, not strictly true)', async () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        aiCoachConsent: { accepted: 'true', version: 9, acceptedAt: 'x' },
+        aiCoachBodyweightOptOut: true,
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.aiCoachConsent.accepted).toBe(false)
+      expect(freshStore.needsAiCoachConsent).toBe(true)
+      expect(freshStore.aiCoachBodyweightOptOut).toBe(true)
+    })
+
+    it('init loads a valid current-version consent record', async () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        aiCoachConsent: { accepted: true, version: 1, acceptedAt: '2026-06-30T00:00:00.000Z' },
+      }))
+
+      const pinia = createPinia()
+      setActivePinia(pinia)
+      const freshStore = usePreferencesStore()
+      await freshStore.init('test-user')
+
+      expect(freshStore.aiCoachConsent.accepted).toBe(true)
+      expect(freshStore.needsAiCoachConsent).toBe(false)
+    })
+
+    it('_reloadFromStorage picks up a consent change from another tab', () => {
+      localStorageMock.setItem('user-preferences', JSON.stringify({
+        features: { workouts: true, calendar: true, weight: true },
+        aiCoachConsent: { accepted: true, version: 1, acceptedAt: 'x' },
+        aiCoachBodyweightOptOut: true,
+      }))
+
+      store._reloadFromStorage()
+
+      expect(store.aiCoachConsent.accepted).toBe(true)
+      expect(store.aiCoachBodyweightOptOut).toBe(true)
+    })
+  })
 })

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -5,6 +5,13 @@ import { logError } from '../lib/logger'
 import { backupToIDB } from '../lib/durableStorage'
 import { broadcastStoreUpdate } from '../lib/crossTabSync'
 import { sanitizeIntensityPresets, DEFAULT_INTENSITY_PRESETS } from '../lib/intensityTable'
+import {
+  sanitizeAiCoachConsent,
+  coachConsentIsCurrent,
+  NO_AI_COACH_CONSENT,
+  CURRENT_CONSENT_VERSION,
+  type AiCoachConsent,
+} from '../lib/aiCoach'
 
 const STORAGE_KEY = 'user-preferences'
 
@@ -134,6 +141,18 @@ export const usePreferencesStore = defineStore('preferences', {
     appIcon: 'default' as string,
     /** Tappable intensity presets (% of max) in the log-set Intensity lens (#776). */
     intensityPresets: [...DEFAULT_INTENSITY_PRESETS] as number[],
+    /**
+     * Device-local mirror of the user's AI Coach consent (the server is
+     * authoritative — see `aiCoach.ts`). Gates the client so it never attempts an
+     * egress call without a current opt-in. Sanitized fail-closed at every load site.
+     */
+    aiCoachConsent: { ...NO_AI_COACH_CONSENT } as AiCoachConsent,
+    /**
+     * Granular opt-out for the most sensitive field: bodyweight trend. Separate from
+     * the blanket coach consent so a user can use the coach without sharing weight.
+     * Default false (bodyweight included); the consent modal lets them flip it.
+     */
+    aiCoachBodyweightOptOut: false,
     _userId: null as string | null,
   }),
 
@@ -152,6 +171,8 @@ export const usePreferencesStore = defineStore('preferences', {
         restTimerAutoStart: this.restTimerAutoStart,
         appIcon: this.appIcon,
         intensityPresets: this.intensityPresets,
+        aiCoachConsent: this.aiCoachConsent,
+        aiCoachBodyweightOptOut: this.aiCoachBodyweightOptOut,
       }
       const data = JSON.stringify(payload)
       try {
@@ -198,6 +219,8 @@ export const usePreferencesStore = defineStore('preferences', {
         if (typeof parsed.restTimerAutoStart === 'boolean') this.restTimerAutoStart = parsed.restTimerAutoStart
         if (typeof parsed.appIcon === 'string') this.appIcon = parsed.appIcon
         if (parsed.intensityPresets) this.intensityPresets = sanitizeIntensityPresets(parsed.intensityPresets)
+        if ('aiCoachConsent' in parsed) this.aiCoachConsent = sanitizeAiCoachConsent(parsed.aiCoachConsent)
+        if (typeof parsed.aiCoachBodyweightOptOut === 'boolean') this.aiCoachBodyweightOptOut = parsed.aiCoachBodyweightOptOut
       } catch { /* ignore corrupt data */ }
     },
 
@@ -230,6 +253,8 @@ export const usePreferencesStore = defineStore('preferences', {
           if (typeof parsed.restTimerAutoStart === 'boolean') this.restTimerAutoStart = parsed.restTimerAutoStart
           if (typeof parsed.appIcon === 'string') this.appIcon = parsed.appIcon
           if (parsed.intensityPresets) this.intensityPresets = sanitizeIntensityPresets(parsed.intensityPresets)
+          if ('aiCoachConsent' in parsed) this.aiCoachConsent = sanitizeAiCoachConsent(parsed.aiCoachConsent)
+          if (typeof parsed.aiCoachBodyweightOptOut === 'boolean') this.aiCoachBodyweightOptOut = parsed.aiCoachBodyweightOptOut
         } catch { /* ignore corrupt data */ }
       }
 
@@ -300,6 +325,8 @@ export const usePreferencesStore = defineStore('preferences', {
             if (typeof prefs.restTimerAutoStart === 'boolean') this.restTimerAutoStart = prefs.restTimerAutoStart as boolean
             if (typeof prefs.appIcon === 'string') this.appIcon = prefs.appIcon as string
             if (prefs.intensityPresets) this.intensityPresets = sanitizeIntensityPresets(prefs.intensityPresets)
+            if ('aiCoachConsent' in prefs) this.aiCoachConsent = sanitizeAiCoachConsent(prefs.aiCoachConsent)
+            if (typeof prefs.aiCoachBodyweightOptOut === 'boolean') this.aiCoachBodyweightOptOut = prefs.aiCoachBodyweightOptOut as boolean
             const synced = JSON.stringify({
               features: this.features, weightGoal: this.weightGoal,
               experience: this.experience, filters: this.filters,
@@ -308,6 +335,8 @@ export const usePreferencesStore = defineStore('preferences', {
               weightUnit: this.weightUnit, restTimerEnabled: this.restTimerEnabled,
               restTimerAutoStart: this.restTimerAutoStart, appIcon: this.appIcon,
               intensityPresets: this.intensityPresets,
+              aiCoachConsent: this.aiCoachConsent,
+              aiCoachBodyweightOptOut: this.aiCoachBodyweightOptOut,
             })
             localStorage.setItem(STORAGE_KEY, synced)
             backupToIDB(STORAGE_KEY, synced)
@@ -414,10 +443,38 @@ export const usePreferencesStore = defineStore('preferences', {
       this.intensityPresets = sanitizeIntensityPresets(presets)
       this._persist()
     },
+
+    /**
+     * Record an affirmative AI Coach opt-in at the CURRENT consent version. The
+     * caller is responsible for the server-side `record_coach_consent` RPC (the
+     * server is authoritative); this only updates the synced client mirror.
+     */
+    recordAiCoachConsent() {
+      this.aiCoachConsent = {
+        accepted: true,
+        acceptedAt: new Date().toISOString(),
+        version: CURRENT_CONSENT_VERSION,
+      }
+      this._persist()
+    },
+
+    /** Revoke AI Coach consent locally (flip to not-consented). */
+    revokeAiCoachConsent() {
+      this.aiCoachConsent = { ...NO_AI_COACH_CONSENT }
+      this._persist()
+    },
+
+    /** Toggle the granular bodyweight-trend opt-out (true = do NOT share bodyweight). */
+    setAiCoachBodyweightOptOut(optOut: boolean) {
+      this.aiCoachBodyweightOptOut = optOut === true
+      this._persist()
+    },
   },
 
   getters: {
     enabledCount: (state): number => Object.values(state.features).filter(Boolean).length,
+    /** True when the AI Coach consent gate must be shown (absent or stale version). */
+    needsAiCoachConsent: (state): boolean => !coachConsentIsCurrent(state.aiCoachConsent),
     currentTarget: (state): number | null => {
       const dir = state.weightGoal.direction
       if (dir === 'lose') return state.weightGoal.loseTarget

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,10 @@
   "outputDirectory": "dist",
   "trailingSlash": false,
   "ignoreCommand": "git diff --quiet HEAD^ HEAD -- src/ public/ api/ index.html vite.config.js package.json vercel.json",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "rewrites": [
+    { "source": "/privacy", "destination": "/privacy.html" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
   "headers": [
     {
       "source": "/assets/(.*)",


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-849](https://github.com/aschung212/Lift/issues/849)

Implement **LIFT-849** — the versioned consent gate, disclosure, and hosted privacy page for the opt-in AI Coach (part of #842). Since `CoachSheet` (#848) is still an open PR (not on master), I built the fully-mergeable governance/consent foundation it will consume — the consent contract, store state, opt-in modal, legal disclosure, hosted `/privacy`, and nutrition-label docs — matching this feature's deliberate layered rollout (backend #843 → payload #844 → governance now → UI wiring with #848). The server's `coach_consent` record stays authoritative; the client gets a fail-closed mirror.

## Changes
- **`src/lib/aiCoach.ts`** — `AiCoachConsent` type, `sanitizeAiCoachConsent` (only `accepted===true` + positive version consents; everything else collapses to not-consented), `coachConsentIsCurrent`/`needsCoachConsent` (stale older version → re-prompt), `NO_AI_COACH_CONSENT`.
- **`src/stores/preferences.ts`** — synced `aiCoachConsent` + granular `aiCoachBodyweightOptOut`, sanitized at all three load sites (init/Supabase/cross-tab reload), `recordAiCoachConsent`/`revokeAiCoachConsent`/`setAiCoachBodyweightOptOut` actions, `needsAiCoachConsent` getter.
- **`src/components/AiCoachConsentModal.vue`** — centered `repMaxModal` opt-in (one screen: what's sent / to whom / how to revoke) with the bodyweight opt-out toggle inline; prop-driven (`accept(bodyweightOptOut)`/`decline`/`view-privacy`), wired by #848.
- **`src/components/LegalSheet.vue`** + **`public/privacy.html`** — name Anthropic as a sub-processor, list the exact fields sent; **no fabricated retention claims** (SEV1 guard).
- **`vercel.json`** — ordered `/privacy → /privacy.html` rewrite before the SPA catch-all so the App Store privacy URL is reachable.
- **`docs/ai-coach.md`** — App Store nutrition-label answers + status update.
- **Tests** (+31): consent sanitize/version-reprompt, store persistence/load/fail-closed, modal emits, hosted-page + LegalSheet fabrication guards, `/privacy` rewrite ordering.

## Verification
- `npm run lint` — clean
- `npm run build` — succeeds (includes vue-tsc typecheck); `dist/privacy.html` emitted
- Full suite: **2372 passed (124 files)**, up from 2341 (+31)
- Did not stage the pre-existing untracked `duration.*` / `add_duration_set_type.sql` files (not mine — from another branch)

## Screenshots
N/A — consent modal is unwired pending #848; verified via component mount tests instead.

## Commits
- [`4d4046c`](https://github.com/aschung212/Lift/commit/4d4046c) feat(LIFT-849): versioned AI Coach consent gate + LegalSheet/privacy disclosure

## Test Results
- Before: 2341 passing
- After: 2372 passing (31 delta)

---
_Automated by overnight pipeline — Tue Jun 30 00:08:49 PDT 2026_

## Preview
Test on your phone: https://lift-h6j0wrrfz-aschung212-1101s-projects.vercel.app