### PR TITLE
ci(LIFT-869): set persist-credentials false on read-only checkout steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
@@ -33,6 +35,8 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -57,6 +61,8 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -78,6 +84,8 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -103,6 +111,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -416,6 +426,8 @@ jobs:
       VITE_E2E: 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -465,6 +477,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,8 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-869](https://github.com/aschung212/Lift/issues/869)

Implement LIFT-869: harden the CI supply chain by setting `persist-credentials: false` on every read-only `actions/checkout` step, so the `GITHUB_TOKEN` is no longer written to `.git/config` on jobs that don't push. Leave `ratchet-baseline` untouched since it commits the coverage baseline back to master.

## Changes
- `.github/workflows/ci.yml` — added `persist-credentials: false` to the checkout steps in `dependency-review`, `install`, `lint`, `typecheck`, `build-and-test`, `e2e`, and `migrate-db` (7 jobs). Left `ratchet-baseline`'s checkout as-is (it keeps `ref: master` + `token:` because it pushes).
- `.github/workflows/integration.yml` — added `persist-credentials: false` to the `supabase-integration` checkout.
- `dependabot-auto-merge.yml` has no checkout step — no change needed.

## Verification
- Confirmed via grep that all 8 read-only checkouts now carry `persist-credentials: false` and the only credentialed checkout is `ratchet-baseline` (`ref: master` + `token`), which legitimately pushes.
- Indentation matches the existing `with:` block convention (6-space `- uses`, 8-space `with:`, 10-space keys), mirroring the pre-existing ratchet-baseline block.
- Workflow-only change; no application code touched, so the Vitest/build gates are unaffected. YAML lint validation was attempted but sandbox-blocked; structure was verified against the existing `with:` blocks.
- CI itself will exercise these workflows on the PR.

Note: the pre-push/post-commit Gemini review hook is non-functional (`IneligibleTierError` — Gemini Code Assist free tier deprecated). This is a pre-existing, already-tracked issue and did not block the push.

## Screenshots
N/A — CI configuration change, no UI impact.

## Commits
- [`470473f`](https://github.com/aschung212/Lift/commit/470473f) ci(LIFT-869): set persist-credentials false on read-only checkout steps

## Test Results
- Before: 2341 passing
- After: 2341 passing (0 delta)

---
_Automated by overnight pipeline — Tue Jun 30 23:12:43 PDT 2026_