### PR TITLE
perf(LIFT-870): shard the Vitest suite across a 3-way CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,61 @@ jobs:
 
       - run: npm run typecheck
 
-  build-and-test:
+  # Unit/component suite, sharded across a matrix for faster PR feedback.
+  # Each shard runs a disjoint slice of the ~120-file suite in parallel and
+  # writes a Vitest blob report (which carries this shard's coverage data).
+  # The blobs are merged back into a single coverage report in build-and-test,
+  # where the ratchet check and PR comments run against the full total.
+  #
+  # Coverage thresholds are intentionally disabled per shard (a single shard
+  # only exercises a subset of the code, so it can never meet the global
+  # floor). The thresholds are enforced once, on the merged total, by the
+  # `vitest --merge-reports --coverage` step in build-and-test.
+  test:
     runs-on: ubuntu-latest
     needs: [lint, typecheck]
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Restore node_modules
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Run tests (shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+        run: >-
+          npx vitest run --coverage --reporter=blob
+          --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+          --coverage.thresholds.lines=0
+          --coverage.thresholds.statements=0
+          --coverage.thresholds.functions=0
+          --coverage.thresholds.branches=0
+
+      - name: Upload blob report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: .vitest-reports/*
+          include-hidden-files: true
+          retention-days: 1
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
     permissions:
       contents: read
       pull-requests: write
@@ -255,7 +307,19 @@ jobs:
         if: github.event_name == 'pull_request'
         run: if [ -f coverage/coverage-summary.json ]; then mv coverage/coverage-summary.json base-coverage-summary.json; fi
 
-      - run: npx vitest run --coverage
+      - name: Download shard blob reports
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: .vitest-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      # Merge the per-shard blobs into a single coverage report. This does NOT
+      # re-run the tests — it reconstructs the full coverage total from the
+      # blobs and regenerates coverage/coverage-summary.json (+ coverage-final),
+      # enforcing the global thresholds from vitest.config.js on the merged total.
+      - name: Merge coverage from shards
+        run: npx vitest run --merge-reports --coverage
 
       - name: Coverage ratchet check
         run: node scripts/check-coverage-ratchet.js
@@ -491,7 +555,7 @@ jobs:
   # shell). See GitHub docs: "Understanding the risk of script injections".
   notify-deploy:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, build-and-test, e2e, migrate-db, ratchet-baseline]
+    needs: [lint, typecheck, test, build-and-test, e2e, migrate-db, ratchet-baseline]
     if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Notify Slack
@@ -509,7 +573,7 @@ jobs:
   # script-injection guard as `notify-deploy` above.
   notify-failure:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, build-and-test, e2e, migrate-db, ratchet-baseline]
+    needs: [lint, typecheck, test, build-and-test, e2e, migrate-db, ratchet-baseline]
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - name: Notify Slack

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist-ssr/
 # test coverage
 coverage/
 
+# Vitest sharded blob reports (merged in CI)
+.vitest-reports/
+
 # Playwright
 test-results/
 playwright-report/


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-870](https://github.com/aschung212/Lift/issues/870)

Implement **LIFT-870**: shard the single-shard Vitest suite (~120 files / 2341 tests) across a 3-way CI matrix so the slowest PR gate runs in parallel and unblocks `e2e` sooner, while keeping all coverage gating (ratchet + PR comments) computed once from the merged shard total.

## Changes
- **`.github/workflows/ci.yml`**
  - Added a `test` matrix job (`shardIndex: [1,2,3]`, `shardTotal: [3]`, `fail-fast: false`) that runs `vitest run --coverage --reporter=blob --shard=i/3` with per-shard thresholds disabled, then uploads each shard's `.vitest-reports/*` as a `blob-report-N` artifact (`include-hidden-files: true`).
  - `build-and-test` now `needs: [lint, typecheck, test]`; replaced its `npx vitest run --coverage` step with a `download-artifact` (pattern `blob-report-*`, `merge-multiple`) + `vitest run --merge-reports --coverage`. This reconstructs the full coverage total **without re-running tests** and enforces `vitest.config.js` thresholds on the merged total — the ratchet check, coverage comment, and coverage-report action are all unchanged downstream.
  - Added `test` to the `needs` of `notify-deploy`/`notify-failure` so a shard failure on master still fires the Slack failure alert (a failed need *skips* `build-and-test` rather than failing it).
  - Pinned `actions/download-artifact@v7` by verified SHA (`37930b1c…`, resolved via `gh api`).
- **`.gitignore`**: ignore the `.vitest-reports/` blob dir.

## Verification
- Locally reproduced the full CI flow: ran all 3 shards with blob+coverage+disabled-thresholds (each exits 0), then `vitest run --merge-reports --coverage` → merged **122 files / 2341 tests**, coverage total identical to the single-shard run (74.93% stmts / 64.8% branch / 67.68% funcs / 76.91% lines), config thresholds enforced and passing, `coverage/coverage-summary.json` regenerated. Confirmed a lone shard fails the global thresholds (why per-shard checks must be disabled) and that the CLI threshold overrides suppress it.
- No source changes — the test suite itself is untouched.

## Screenshots
N/A — CI-only change.

## Commits
- [`e2dd9c6`](https://github.com/aschung212/Lift/commit/e2dd9c6) perf(LIFT-870): shard the Vitest suite across a 3-way CI matrix

## Test Results
- Before: 2341 passing
- After: 2341 passing (0 delta)

---
_Automated by overnight pipeline — Tue Jun 30 23:35:29 PDT 2026_