### PR TITLE
ci(LIFT-868): reuse build-and-test coverage artifact in ratchet-baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,16 @@ jobs:
           path: coverage/coverage-summary.json
           key: coverage-summary-master-${{ github.sha }}
 
+      # Hand the freshly-computed summary to ratchet-baseline as a same-run
+      # artifact so it never has to re-run the full suite just to regenerate it.
+      - name: Upload coverage summary artifact (master)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: coverage-summary
+          path: coverage/coverage-summary.json
+          retention-days: 1
+
       - name: Post coverage delta comment
         if: always() && github.event_name == 'pull_request' && hashFiles('coverage/coverage-summary.json') != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -367,16 +377,16 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
-          cache: npm
 
-      - name: Restore node_modules
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      # Reuse the coverage-summary.json that build-and-test already produced
+      # instead of re-running the full suite. The ratchet script reads only
+      # coverage/coverage-summary.json and Node builtins — no node_modules
+      # or test run is needed on this job (LIFT-868).
+      - name: Download coverage summary artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          path: node_modules
-          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Run tests with coverage
-        run: npx vitest run --coverage
+          name: coverage-summary
+          path: coverage
 
       - name: Ratchet baseline
         run: node scripts/check-coverage-ratchet.js --update


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-868](https://github.com/aschung212/Lift/issues/868)

Implement **LIFT-868**: stop `ratchet-baseline` from re-running the full `npx vitest run --coverage` suite on every master push. `build-and-test` already computes coverage, so hand its `coverage-summary.json` to `ratchet-baseline` as a same-run artifact and drop the second full suite run.

## Changes
- `.github/workflows/ci.yml`:
  - **`build-and-test`** — added an `Upload coverage summary artifact (master)` step (upload-artifact@v7, `retention-days: 1`, master-push only) that uploads `coverage/coverage-summary.json` right after it's produced.
  - **`ratchet-baseline`** — replaced the `Restore node_modules` + `Run tests with coverage` steps with a single `Download coverage summary artifact` step (download-artifact@v7, SHA `37930b1c…` resolved from GitHub, not fabricated). Also dropped `cache: npm` from setup-node since no npm install/test runs there. The ratchet script reads only `coverage/coverage-summary.json` + Node builtins, so `node scripts/check-coverage-ratchet.js --update` runs directly against the downloaded file.

Net effect: coverage suite runs once (in `build-and-test`) instead of twice on the merge-to-deploy path; the ratchet floor semantics are unchanged.

## Verification
- YAML edits are structurally consistent with surrounding steps (indentation, pinned-SHA convention, master-push `if` guards preserved).
- download-artifact v7.0.0 SHA verified via `gh api repos/actions/download-artifact/git/refs/tags`.
- No app code touched — the local `npm test`/build suite is unaffected (workflow-only change). The change is exercised on the next master push, where `ratchet-baseline` consumes the artifact.

## Screenshots
N/A — CI workflow change, no UI.

## Issue updates
ISSUE_DONE:LIFT-868:build-and-test now uploads coverage/coverage-summary.json as a same-run artifact (master push only); ratchet-baseline downloads it via download-artifact@v7 instead of re-running `npx vitest run --coverage`, and drops the node_modules restore + test run. Eliminates the duplicate full coverage suite on the merge-to-deploy path while preserving the ratchet floor semantics.

ISSUE_DISCOVER: ci: The Gemini pre-push/post-commit adversarial review hook still fails with `IneligibleTierError` (Gemini Code Assist free tier no longer supported for gemini-cli 0.35.3) — every commit/push runs the hook, it errors, and no automated review happens. Migrate to a supported client/model (Antigravity) or swap reviewers so branch diffs regain pre-PR review. (Recurring across runs 2/3/4/5 tonight — this is now blocking all automated review and should be prioritized.)

## Commits
- [`41c2d8d`](https://github.com/aschung212/Lift/commit/41c2d8d) ci(LIFT-868): reuse build-and-test coverage artifact in ratchet-baseline

## Test Results
- Before: 2341 passing
- After: 2341 passing (0 delta)

---
_Automated by overnight pipeline — Tue Jun 30 23:43:10 PDT 2026_