### PR TITLE
refactor(LIFT-882): scope useKeyboardShortcuts help state per-consumer (closes #882)

### DIFF
--- a/src/composables/__tests__/useKeyboardShortcuts.test.ts
+++ b/src/composables/__tests__/useKeyboardShortcuts.test.ts
@@ -101,6 +101,17 @@ describe('useKeyboardShortcuts', () => {
     expect(actions.workouts).not.toHaveBeenCalled()
   })
 
+  it('gives each consumer an independent help state', () => {
+    const a = createWrapper([{ key: '?', label: 'Help', action: actions.help }])
+    const b = createWrapper([{ key: '?', label: 'Help', action: actions.help }])
+    a.vm.toggleHelp()
+    expect(a.vm.helpOpen).toBe(true)
+    // Toggling one consumer's help must not leak into the other (LIFT-882)
+    expect(b.vm.helpOpen).toBe(false)
+    a.unmount()
+    b.unmount()
+  })
+
   it('closes help on Escape when help is open', async () => {
     const wrapper = createWrapper([
       { key: '?', label: 'Help', action: actions.help },

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -8,15 +8,20 @@ export interface Shortcut {
   global?: boolean
 }
 
-const helpOpen = ref(false)
-
 export interface UseKeyboardShortcutsReturn {
   helpOpen: DeepReadonly<Ref<boolean>>
   toggleHelp: () => void
   closeHelp: () => void
 }
 
+// `helpOpen` is per-consumer UI state, NOT an app-global singleton. It lives
+// inside the composable so each caller gets its own shortcut-help boolean —
+// unlike useWakeLock/useServiceWorker, whose module-scoped state deliberately
+// models a single shared system resource. Toggling the help overlay in one
+// component must never affect another (LIFT-882).
 export function useKeyboardShortcuts(shortcuts: () => Shortcut[]): UseKeyboardShortcutsReturn {
+  const helpOpen = ref(false)
+
   function handler(e: KeyboardEvent) {
     // Ignore when modifier keys are held (except Shift for ?)
     if (e.ctrlKey || e.metaKey || e.altKey) return


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-882](https://github.com/aschung212/Lift/issues/882)

Implemented **LIFT-882** — `useKeyboardShortcuts` declared `helpOpen` at module scope, so every caller would share one shortcut-help boolean. This is per-consumer UI state (unlike `useWakeLock`/`useServiceWorker`, whose module state deliberately models a single system resource), so I moved the ref inside the composable function and documented the intent.

## Changes
- `src/composables/useKeyboardShortcuts.ts` — moved `const helpOpen = ref(false)` from module scope into the composable function body; added a header comment explaining why help state is per-consumer, not a global singleton (contrasting the deliberate singletons in `useWakeLock`/`useServiceWorker`).
- `src/composables/__tests__/useKeyboardShortcuts.test.ts` — added a regression test asserting two independent consumers have isolated help state (toggling one does not leak into the other).

## Verification
- `npx vitest run src/composables/__tests__/useKeyboardShortcuts.test.ts` — 11 passed
- `npm run lint` — clean
- `npm run build` — succeeded (PWA generated)

## Screenshots
N/A — internal refactor with no visual/UI change.

## Commits
- [`e4e28b3`](https://github.com/aschung212/Lift/commit/e4e28b3) refactor(LIFT-882): scope useKeyboardShortcuts help state per-consumer (closes #882)

## Test Results
- Before: 2341 passing
- After: 2342 passing (1 delta)

---
_Automated by overnight pipeline — Wed Jul  1 23:42:43 PDT 2026_

## Preview
Test on your phone: https://lift-gokuk381i-aschung212-1101s-projects.vercel.app