### PR TITLE
refactor(LIFT-881): stop useTheme re-exporting useWeightUnit and useRestTimer

### DIFF
--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -691,6 +691,8 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick, type ComponentPublicInstance } from 'vue'
 import { useTheme } from '../composables/useTheme'
+import { useWeightUnit } from '../composables/useWeightUnit'
+import { useRestTimer } from '../composables/useRestTimer'
 import type { ThemeId } from '../lib/themes'
 import { usePRBaseline } from '../composables/usePRBaseline'
 import { useProgressionStore, UNLOCK_TIERS, showXPToast } from '../stores/progression'
@@ -727,7 +729,9 @@ const emit = defineEmits<{
   'sign-out': []
 }>()
 
-const { currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode, restTimerEnabled, restTimerAutoStart, weightUnit, displayWeight, toLbs, selectTheme: themeSelectFn, previewTheme, revertPreview, isThemeUnlocked } = useTheme()
+const { currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode, selectTheme: themeSelectFn, previewTheme, revertPreview, isThemeUnlocked } = useTheme()
+const { restTimerEnabled, restTimerAutoStart } = useRestTimer()
+const { weightUnit, displayWeight, toLbs } = useWeightUnit()
 const { prBaselineDate, setPRBaseline, startNewTrainingBlock, clearPRBaseline } = usePRBaseline()
 const progressionStore = useProgressionStore()
 const { celebrateUnlocks } = useXPCeremony()

--- a/src/composables/__tests__/useTheme.test.ts
+++ b/src/composables/__tests__/useTheme.test.ts
@@ -29,8 +29,8 @@ describe('useTheme', () => {
     localStorageMock.clear()
     localStorageMock.setItem.mockClear()
     localStorageMock.getItem.mockClear()
-    // useTheme() delegates weightUnit/restTimer to the preferences store
-    // (LIFT-821), so a Pinia instance must be active before it is called.
+    // The progression store (connected via connectProgressionStore) reads from
+    // Pinia, so a Pinia instance must be active before useTheme() is called.
     setActivePinia(createPinia())
     // initTheme() is guarded against double-init in production, but tests need
     // fresh state. We call it here so watchers and DOM attributes are set up.
@@ -108,38 +108,18 @@ describe('useTheme', () => {
     })
   })
 
-  describe('weight unit conversion', () => {
-    it('returns lbs values unchanged when unit is lbs', () => {
-      theme.weightUnit.value = 'lbs'
-      expect(theme.displayWeight(225)).toBe(225)
-    })
-
-    it('converts lbs to kg when unit is kg', () => {
-      theme.weightUnit.value = 'kg'
-      // 225 lbs * 0.453592 = 102.1
-      expect(theme.displayWeight(225)).toBeCloseTo(102.1, 1)
-    })
-
-    it('converts kg input back to lbs with toLbs', () => {
-      theme.weightUnit.value = 'kg'
-      // 100 kg / 0.453592 ≈ 220.5
-      expect(theme.toLbs(100)).toBeCloseTo(220.5, 0)
-    })
-
-    it('toLbs returns value unchanged when unit is lbs', () => {
-      theme.weightUnit.value = 'lbs'
-      expect(theme.toLbs(225)).toBe(225)
-    })
-  })
-
-  describe('rest timer', () => {
-    it('persists rest timer preference to localStorage', async () => {
-      theme.restTimerEnabled.value = false
-      await nextTick()
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('rest-timer', 'off')
-      theme.restTimerEnabled.value = true
-      await nextTick()
-      expect(localStorageMock.setItem).toHaveBeenCalledWith('rest-timer', 'on')
+  // Weight-unit conversion and rest-timer persistence are no longer reachable
+  // through useTheme (LIFT-881 removed the re-exports); they are covered by
+  // useWeightUnit.test.ts and useRestTimer.test.ts respectively.
+  describe('does not re-export focused composables (LIFT-881)', () => {
+    it('no longer exposes weight-unit or rest-timer state', () => {
+      const surface = theme as unknown as Record<string, unknown>
+      expect(surface.weightUnit).toBeUndefined()
+      expect(surface.displayWeight).toBeUndefined()
+      expect(surface.toLbs).toBeUndefined()
+      expect(surface.restTimerEnabled).toBeUndefined()
+      expect(surface.restTimerAutoStart).toBeUndefined()
+      expect(surface.setRestTimerEnabled).toBeUndefined()
     })
   })
 

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -4,9 +4,6 @@ import {
   THEMES, THEME_PREVIEWS, THEME_META_COLORS, THEME_MIGRATION,
   type ThemeId, type ColorMode, type ThemeOption,
 } from '../lib/themes'
-import { useWeightUnit, type UseWeightUnitReturn } from './useWeightUnit'
-import { useRestTimer, type UseRestTimerReturn } from './useRestTimer'
-
 // Re-export types and constants so existing `import { … } from 'useTheme'` still works.
 // New code should import from the specific module instead.
 export { THEMES, THEME_PREVIEWS }
@@ -161,7 +158,7 @@ function isThemeUnlocked(id: ThemeId): boolean {
   return store.unlockedThemes.some(t => t.id === id)
 }
 
-export interface UseThemeReturn extends UseWeightUnitReturn, UseRestTimerReturn {
+export interface UseThemeReturn {
   currentTheme: Ref<string>
   THEMES: typeof THEMES
   THEME_PREVIEWS: typeof THEME_PREVIEWS
@@ -175,10 +172,6 @@ export interface UseThemeReturn extends UseWeightUnitReturn, UseRestTimerReturn 
 }
 
 export function useTheme(): UseThemeReturn {
-  // Delegate to focused composables
-  const { weightUnit, displayWeight, toLbs } = useWeightUnit()
-  const { restTimerEnabled, restTimerAutoStart, setRestTimerEnabled } = useRestTimer()
-
   /**
    * Select a theme — persists only if unlocked.
    * Returns true if the theme was applied and persisted.
@@ -209,8 +202,5 @@ export function useTheme(): UseThemeReturn {
     // Theme selection + color mode
     currentTheme, THEMES, THEME_PREVIEWS, colorMode, resolvedMode,
     selectTheme, previewTheme, revertPreview, isThemeUnlocked, preloadThemeCSS,
-    // Re-exported from focused composables (backward compat)
-    restTimerEnabled, restTimerAutoStart, setRestTimerEnabled,
-    weightUnit, displayWeight, toLbs,
   }
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-881](https://github.com/aschung212/Lift/issues/881)

Implemented **LIFT-881** — `useTheme` composed and re-exported `useWeightUnit` (`weightUnit`/`displayWeight`/`toLbs`) and `useRestTimer` (`restTimerEnabled`/`restTimerAutoStart`/`setRestTimerEnabled`) through its own return object, making two independent single-purpose utilities reachable via an unrelated composable and obscuring the real dependency graph. Removed the pass-through so the dependency edges are explicit — sequencing groundwork for the later `useRestTimer`/`useRestTimerController` split (LIFT-879).

## Changes
- `src/composables/useTheme.ts` — dropped the `useWeightUnit`/`useRestTimer` imports, the `UseWeightUnitReturn`/`UseRestTimerReturn` interface extension, the in-function delegation, and the six re-exported members. `useTheme` now returns only theme/color-mode surface.
- `src/components/SettingsSheet.vue` — the only caller pulling weight-unit/rest-timer state off `useTheme`; now imports `useWeightUnit` and `useRestTimer` directly (matching `WorkoutTracker.vue` and `BodyweightTracker.vue`, which already did). No template changes — the writable computeds behave identically.
- `src/composables/__tests__/useTheme.test.ts` — replaced the redundant "weight unit conversion" and "rest timer" describe blocks (behavior is already fully covered by `useWeightUnit.test.ts` / `useRestTimer.test.ts`) with a regression guard asserting the `useTheme` surface no longer leaks those members; corrected a stale beforeEach comment.

## Verification
- `npm run lint` — clean
- `npm run typecheck` (vue-tsc) — clean
- Targeted tests (useTheme/useWeightUnit/useRestTimer) — 35 passed
- `npm test` — 122 files, 2337 passed (was 2341: removed 5 redundant re-export tests, added 1 guard). One intermittent unhandled error surfaced on one run only — the pre-existing `TagVolumeSparkline`/`CalendarView` teardown race already flagged as a discovery in run4; unrelated to these theme/settings changes and absent on re-run.
- `npm run build` — succeeded (PWA precache generated)

## Screenshots
None — no visual/UI change; `SettingsSheet` bindings and template are byte-for-byte equivalent (same writable computeds, just imported from their own composables).

## Discovery
ISSUE_DISCOVER:test: The `TagVolumeSparkline.vue:53` unhandled error under the full parallel `npm test` run remains intermittent (surfaced on 1 of 3 runs this iteration, reported as "1 error" with all tests still passing). Confirms run4's finding — worth a deterministic `onScopeDispose`/unmount teardown fix so CI doesn't log a spurious error.

## Commits
- [`ed19d5e`](https://github.com/aschung212/Lift/commit/ed19d5e) refactor(LIFT-881): stop useTheme re-exporting useWeightUnit and useRestTimer

## Test Results
- Before: 2341 passing
- After: 2337 passing (-4 delta)

---
_Automated by overnight pipeline — Wed Jul  1 23:51:50 PDT 2026_

## Preview
Test on your phone: https://lift-5oa8rke7x-aschung212-1101s-projects.vercel.app