### PR TITLE
test(LIFT-895): drive sync tests with fake timers instead of real setTimeout waits

### DIFF
--- a/src/__tests__/syncPipelineIntegration.test.ts
+++ b/src/__tests__/syncPipelineIntegration.test.ts
@@ -11,7 +11,7 @@
  * through the real enqueue wiring.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { getLocalStorageMock } from './helpers'
 
@@ -102,17 +102,25 @@ import { syncQueue } from '../lib/syncQueue'
 import { isTombstoned, _resetTombstones } from '../lib/tombstones'
 
 const localStorageMock = getLocalStorageMock()
-const tick = () => new Promise(resolve => setTimeout(resolve, 0))
+// Flush pending timers + the microtask chains kicked off by the synchronous
+// syncQueue mock. Driven by fake timers (not a real setTimeout) so tests don't
+// burn wall-clock time or flake under CI load (LIFT-895).
+const tick = () => vi.runAllTimersAsync()
 
 describe('Sync Pipeline Integration (LIFT-654)', () => {
   const TEST_USER = 'user-integration-test'
 
   beforeEach(() => {
+    vi.useFakeTimers()
     localStorageMock.clear()
     fakeSupabase.reset()
     _resetTombstones()
     vi.clearAllMocks()
     setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   // ── logSet → syncQueue.enqueue → Supabase upsert ──────────────

--- a/src/stores/__tests__/syncFuzz.test.ts
+++ b/src/stores/__tests__/syncFuzz.test.ts
@@ -15,7 +15,7 @@
  * (row count dropped / unexpected delete call), not a regex mismatch.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
 // ── Fake Supabase client ─────────────────────────────────────────
@@ -171,16 +171,23 @@ import { useBodyweightStore } from '../bodyweight'
 import { getLocalStorageMock } from '../../__tests__/helpers'
 import { _resetTombstones } from '../../lib/tombstones'
 
-// Helper: flush a microtask tick so any op() chained via syncQueue settles
-const tick = () => new Promise(resolve => setTimeout(resolve, 0))
+// Helper: flush pending timers + the microtask chains kicked off by the
+// synchronous syncQueue mock. Driven by fake timers (not a real setTimeout)
+// so tests don't burn wall-clock time or flake under CI load (LIFT-895).
+const tick = () => vi.runAllTimersAsync()
 
 describe('sync fuzz: SEV1 2026-04-12 regression', () => {
   beforeEach(() => {
+    vi.useFakeTimers()
     setActivePinia(createPinia())
     fakeSupabase.reset()
     getLocalStorageMock().clear()
     // Tombstones cache in-memory — must be reset or they leak between tests
     _resetTombstones()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('workoutStore._fetchFromSupabase — READ path is read-only', () => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-895](https://github.com/aschung212/Lift/issues/895)

Implement LIFT-895: replace the real-time `setTimeout(resolve, 0)` `tick()` helper in the two sync tests with fake timers, matching the pattern the `syncQueue` unit tests already use — eliminating wall-clock waits and CI-load flakiness.

## Changes
- **`src/stores/__tests__/syncFuzz.test.ts`** — added `vi.useFakeTimers()`/`vi.useRealTimers()` in `beforeEach`/`afterEach`; replaced `tick = () => new Promise(r => setTimeout(r, 0))` with `tick = () => vi.runAllTimersAsync()`; imported `afterEach`.
- **`src/__tests__/syncPipelineIntegration.test.ts`** — same conversion.

Both files use a synchronous `syncQueue` mock that fires microtask chains; `vi.runAllTimersAsync()` flushes those without a real macrotask hop. No store paths use real timers, so the conversion is behavior-preserving.

## Verification
- Targeted run: 20 tests pass across both files.
- Full suite: **122 files, 2341 tests pass**.
- `npm run lint`: clean.
- Pre-push Gemini review errored on an external Gemini tier-migration auth issue (`IneligibleTierError`, not a code finding), same as run 1 — no review fixes required.

## Screenshots
N/A — test-only change, no UI impact.

## Commits
- [`5d99ca7`](https://github.com/aschung212/Lift/commit/5d99ca7) test(LIFT-895): drive sync tests with fake timers instead of real setTimeout waits

## Test Results
- Before: 2341 passing
- After: 2341 passing (0 delta)

---
_Automated by overnight pipeline — Mon Jul  6 23:12:38 PDT 2026_

## Preview
Test on your phone: https://lift-cd7fs476m-aschung212-1101s-projects.vercel.app