### PR TITLE
test(LIFT-893): add tests for xpInstrumentation Supabase payload shape

### DIFF
--- a/src/lib/__tests__/xpInstrumentation.test.ts
+++ b/src/lib/__tests__/xpInstrumentation.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { XPEventData, WeeklySnapshotData } from '../xpInstrumentation'
+
+// Capture the table name and the upserted row for each Supabase call the
+// enqueued operation issues. `from` returns an object whose `upsert` records
+// its argument so we can assert the exact payload shape (column-name drift or a
+// dropped guard would silently stop analytics with zero signal — LIFT-893).
+const upsertSpy = vi.fn(() => Promise.resolve({ error: null }))
+const fromSpy = vi.fn(() => ({ upsert: upsertSpy }))
+
+const { supabaseRef } = vi.hoisted(() => ({
+  supabaseRef: { current: { from: null as unknown } as { from: unknown } | null },
+}))
+
+vi.mock('../supabase', () => ({
+  get supabase() {
+    return supabaseRef.current
+  },
+  isPreviewMode: { value: false },
+}))
+
+// Capture every enqueue call: its idempotency key and the operation closure.
+// The closure is what actually builds the Supabase upsert, so invoking it lets
+// us assert the payload without running the real debounced queue.
+const enqueueSpy = vi.fn()
+vi.mock('../syncQueue', () => ({
+  syncQueue: {
+    enqueue: (key: string, op: () => PromiseLike<unknown>) => enqueueSpy(key, op),
+  },
+}))
+
+import { logXPEvent, logBodyweightXPEvent, logWeeklySnapshot } from '../xpInstrumentation'
+
+/** Run the operation closure captured by the most recent enqueue call. */
+function runEnqueuedOp(): void {
+  const op = enqueueSpy.mock.calls.at(-1)?.[1] as () => PromiseLike<unknown>
+  op()
+}
+
+const baseEvent: XPEventData = {
+  userId: 'user-1',
+  setId: 'set-42',
+  exerciseId: 'ex-bench',
+  setDate: '2026-07-06',
+  baseXP: 100,
+  streakMultiplier: 1.5,
+  finalXP: 150,
+  isPR: true,
+  isTie: false,
+  isRepPR: false,
+  zone: 'working',
+  activeTheme: 'eternal',
+  epoch: 2,
+}
+
+const baseSnapshot: WeeklySnapshotData = {
+  userId: 'user-1',
+  weekStart: '2026-07-06',
+  totalXP: 5000,
+  weekXP: 800,
+  streakWeeks: 3,
+  trainingDays: 4,
+  weeklyTarget: 5,
+  themesUnlocked: 6,
+}
+
+beforeEach(() => {
+  supabaseRef.current = { from: fromSpy }
+  fromSpy.mockClear()
+  upsertSpy.mockClear()
+  enqueueSpy.mockClear()
+})
+
+describe('logXPEvent', () => {
+  it('enqueues an xp_events upsert keyed by set id', () => {
+    logXPEvent(baseEvent)
+
+    expect(enqueueSpy).toHaveBeenCalledOnce()
+    expect(enqueueSpy.mock.calls[0][0]).toBe('xp-event:set-42')
+  })
+
+  it('upserts the full XP-event payload with the correct column names', () => {
+    logXPEvent(baseEvent)
+    runEnqueuedOp()
+
+    expect(fromSpy).toHaveBeenCalledWith('xp_events')
+    expect(upsertSpy).toHaveBeenCalledWith({
+      set_id: 'set-42',
+      user_id: 'user-1',
+      exercise_id: 'ex-bench',
+      set_date: '2026-07-06',
+      base_xp: 100,
+      streak_multiplier: 1.5,
+      final_xp: 150,
+      is_pr: true,
+      is_tie: false,
+      is_rep_pr: false,
+      zone: 'working',
+      active_theme: 'eternal',
+      epoch: 2,
+    })
+  })
+
+  it('no-ops when userId is null', () => {
+    logXPEvent({ ...baseEvent, userId: null })
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when supabase is unavailable', () => {
+    supabaseRef.current = null
+    logXPEvent(baseEvent)
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('logBodyweightXPEvent', () => {
+  it('enqueues a bodyweight xp event keyed by date', () => {
+    logBodyweightXPEvent('user-1', '2026-07-06', 40, 'fire', 1)
+
+    expect(enqueueSpy).toHaveBeenCalledOnce()
+    expect(enqueueSpy.mock.calls[0][0]).toBe('xp-event:bw:2026-07-06')
+  })
+
+  it('upserts a bodyweight payload with the bw-${date} synthetic set id and bodyweight zone', () => {
+    logBodyweightXPEvent('user-1', '2026-07-06', 40, 'fire', 1)
+    runEnqueuedOp()
+
+    expect(fromSpy).toHaveBeenCalledWith('xp_events')
+    expect(upsertSpy).toHaveBeenCalledWith({
+      set_id: 'bw-2026-07-06',
+      user_id: 'user-1',
+      set_date: '2026-07-06',
+      base_xp: 40,
+      streak_multiplier: 1,
+      final_xp: 40,
+      is_pr: false,
+      is_tie: false,
+      is_rep_pr: false,
+      zone: 'bodyweight',
+      active_theme: 'fire',
+      epoch: 1,
+    })
+  })
+
+  it('no-ops when userId is null', () => {
+    logBodyweightXPEvent(null, '2026-07-06', 40, 'fire', 1)
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when supabase is unavailable', () => {
+    supabaseRef.current = null
+    logBodyweightXPEvent('user-1', '2026-07-06', 40, 'fire', 1)
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('logWeeklySnapshot', () => {
+  it('enqueues a progression snapshot keyed by week start', () => {
+    logWeeklySnapshot(baseSnapshot)
+
+    expect(enqueueSpy).toHaveBeenCalledOnce()
+    expect(enqueueSpy.mock.calls[0][0]).toBe('progression-snapshot:2026-07-06')
+  })
+
+  it('upserts the snapshot payload into progression_snapshots with the correct columns', () => {
+    logWeeklySnapshot(baseSnapshot)
+    runEnqueuedOp()
+
+    expect(fromSpy).toHaveBeenCalledWith('progression_snapshots')
+    expect(upsertSpy).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      week_start: '2026-07-06',
+      total_xp: 5000,
+      week_xp: 800,
+      streak_weeks: 3,
+      training_days: 4,
+      weekly_target: 5,
+      themes_unlocked: 6,
+    })
+  })
+
+  it('no-ops when userId is null', () => {
+    logWeeklySnapshot({ ...baseSnapshot, userId: null })
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when supabase is unavailable', () => {
+    supabaseRef.current = null
+    logWeeklySnapshot(baseSnapshot)
+    expect(enqueueSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-893](https://github.com/aschung212/Lift/issues/893)

LIFT-893 asked to pin the Supabase payload shape for `xpInstrumentation.ts`, which enqueues `xp_events` and `progression_snapshots` upserts feeding live threshold-tuning. It had zero test coverage, so column-name drift or a dropped `!supabase || !userId` guard would silently kill analytics with no signal. I added a focused unit test mocking `supabase` and `syncQueue.enqueue` to capture and assert the exact enqueued payloads.

## Changes
- **`src/lib/__tests__/xpInstrumentation.test.ts`** (new) — 12 tests across the three loggers:
  - `logXPEvent` / `logBodyweightXPEvent` / `logWeeklySnapshot`: assert the idempotency key, the target table (`xp_events` / `progression_snapshots`), and the full upsert payload with exact snake_case column names/values (catches column drift).
  - Bodyweight case pins the `bw-${date}` synthetic `set_id` and `zone: 'bodyweight'`.
  - No-op guard tests for both `userId === null` and `supabase` unavailable on all three loggers.
  - Mocks `supabase` via a hoisted mutable getter so the null-guard branch is exercisable, and stubs `syncQueue.enqueue` to capture the operation closure and invoke it directly (no debounced queue / wall-clock waits).

## Verification
- `npx vitest run src/lib/__tests__/xpInstrumentation.test.ts` → 12 passed
- `npm run lint` → clean
- Pre-commit hook (eslint --max-warnings 5) passed. Gemini pre-push review CLI failed to authenticate (`IneligibleTierError` — infra/account issue, not a code finding); push completed.

## Screenshots
N/A — test-only change, no UI impact.

## Commits
- [`b4f5456`](https://github.com/aschung212/Lift/commit/b4f5456) test(LIFT-893): add tests for xpInstrumentation Supabase payload shape

## Test Results
- Before: 2341 passing
- After: 2353 passing (12 delta)

---
_Automated by overnight pipeline — Mon Jul  6 23:23:16 PDT 2026_

## Preview
Test on your phone: https://lift-jyaju53oq-aschung212-1101s-projects.vercel.app