### PR TITLE
test(LIFT-891): run Playwright E2E on WebKit for the iOS-first PWA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,15 +433,17 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          # Include the Playwright config in the key so changing the browser
+          # set (e.g. adding webkit) busts the cache and reinstalls binaries.
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json', 'playwright.config.ts') }}
 
-      - name: Install Playwright Chromium
+      - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Install Playwright system deps (cache hit)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
+        run: npx playwright install-deps chromium webkit
 
       - name: Build app
         run: npm run build

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 const isCI = !!process.env.CI
 
@@ -9,7 +9,6 @@ export default defineConfig({
   use: {
     baseURL: isCI ? 'http://localhost:4173' : 'http://localhost:5173',
     headless: true,
-    viewport: { width: 390, height: 844 }, // iPhone 14 Pro
     actionTimeout: 10000,
   },
   webServer: {
@@ -19,9 +18,20 @@ export default defineConfig({
     timeout: isCI ? 30000 : 15000,
   },
   projects: [
+    // WebKit is the primary target: Lift is an iOS-first PWA shipping in
+    // WKWebView via Capacitor, and Safari-only behaviors (container scroll-lock,
+    // backdrop-filter glass, viewport keyboard, safe-area insets) don't repro on
+    // Blink. The iPhone 14 Pro descriptor supplies an accurate mobile-Safari
+    // UA + touch/mobile emulation instead of a bare 390x844 viewport.
+    {
+      name: 'webkit',
+      use: { ...devices['iPhone 14 Pro'] },
+    },
+    // Chromium is kept for broad cross-engine coverage, at the original
+    // iPhone-14-Pro viewport so its existing behavior is unchanged.
     {
       name: 'chromium',
-      use: { browserName: 'chromium' },
+      use: { browserName: 'chromium', viewport: { width: 390, height: 844 } },
     },
   ],
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-891](https://github.com/aschung212/Lift/issues/891)

LIFT-891 asked to run the Playwright E2E suite on WebKit (the engine users actually ship on via WKWebView/Capacitor), not just Chromium. The config defined a single `chromium` project at a bare `390x844` viewport, so none of the Safari-only behaviors CLAUDE.md documents (container scroll-lock, backdrop-filter glass, viewport keyboard, safe-area insets) were ever exercised by CI. I added a `webkit` project using the `iPhone 14 Pro` device descriptor for an accurate mobile-Safari UA + touch/mobile emulation, kept `chromium` for cross-engine coverage, and wired the browser install + cache into CI.

## Changes
- **`playwright.config.ts`** — Imported `devices`; added a `webkit` project (`...devices['iPhone 14 Pro']`) as the primary iOS target; kept `chromium` at its original `390x844` viewport so existing behavior is unchanged. Removed the now-redundant global `use.viewport` (each project sets its own).
- **`.github/workflows/ci.yml`** — Install both browsers (`playwright install --with-deps chromium webkit` and the cache-hit `install-deps` variant). Keyed the Playwright browser cache on `playwright.config.ts` in addition to `package-lock.json` so adding a browser busts the cache and reinstalls binaries — otherwise a cache hit (package-lock unchanged) would skip the install step and leave the WebKit binary missing, failing the run.

## Verification
- `npm run typecheck` — clean.
- `npm run build` — succeeds (built in 3.63s, PWA generated).
- Verified `devices['iPhone 14 Pro']` exists in the installed `@playwright/test` version (deviceDescriptorsSource.json:1248).
- Could NOT run the WebKit suite locally: `npx playwright install webkit` is permission-blocked in this loop and the binary isn't cached. CI will install and run it. This is the main residual risk — if a spec genuinely fails on WebKit, it likely reveals a real iOS-specific bug (which is the point of the issue) and should be triaged as a follow-up, not masked by reverting.

## Screenshots
None (test-infra/CI change only — no UI change).

## Commits
- [`4c9b8e0`](https://github.com/aschung212/Lift/commit/4c9b8e0) test(LIFT-891): run Playwright E2E on WebKit for the iOS-first PWA

## Test Results
- Before: 2341 passing
- After: 2341 passing (0 delta)

---
_Automated by overnight pipeline — Mon Jul  6 23:40:27 PDT 2026_