### PR TITLE
test(LIFT-889): add E2E coverage for offline write durability

### DIFF
--- a/e2e/offline-sync-flow.spec.ts
+++ b/e2e/offline-sync-flow.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// LIFT-889 — E2E guard for the offline write-queue / durable-replay path.
+//
+// The durable syncQueue journals every workout write to IndexedDB so that a set
+// logged with no connectivity survives a tab close and is replayed on the next
+// launch (CLAUDE.md → "Durable write queue"). Unit coverage
+// (syncQueueJournal.test.ts, syncPipelineIntegration.test.ts) exercises the
+// journal against a mocked Supabase; nothing drove the real browser flow end to
+// end.
+//
+// The e2e build authenticates via the dev button and ships WITHOUT Supabase
+// credentials (see the `VITE_E2E` job in ci.yml), so there is no server to
+// reconcile against here. What these specs guard is the user-observable half of
+// that guarantee, which is exactly what a real regression would break first:
+//   1. going offline surfaces the "changes saved locally" indicator, and
+//   2. a set logged while offline is accepted immediately (the UI never waits on
+//      the network) and still survives a full page reload — the local-first +
+//      rehydrate path the journaled replay is layered on top of.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('onboarding-complete', 'true')
+    localStorage.setItem('rest-timer', 'off')
+    localStorage.setItem('fresh-start', 'true')
+  })
+})
+
+/** Sign in through the dev-only button and wait for the Workouts view. */
+async function signInDev(page: Page): Promise<void> {
+  await page.locator('.authDevBtn').click({ timeout: 10000 })
+  await expect(page.getByRole('heading', { name: 'Workouts', level: 1 })).toBeVisible({ timeout: 10000 })
+}
+
+/** Log a set into the currently-open log modal, then close it. */
+async function logSetInModal(page: Page, weight: string, reps: string): Promise<void> {
+  await expect(page.locator('#log-modal-title')).toBeVisible()
+  await page.fill('[aria-label="Weight"]', weight)
+  await page.fill('[aria-label="Reps"]', reps)
+  await page.locator('.repMaxBtnCalc').click()
+  await page.locator('.repMaxBtnClose').click()
+}
+
+/** Create the first exercise (via the fresh-start CTA) with one logged set. */
+async function createExerciseWithSet(page: Page, name: string, weight: string, reps: string): Promise<void> {
+  await page.locator('.wtFreshStartCta').click()
+  await page.fill('input[placeholder="e.g. Bench Press"]', name)
+  await logSetInModal(page, weight, reps)
+  await expect(page.locator('.wtExerciseName', { hasText: name })).toBeVisible()
+}
+
+/** Open the exercise detail modal and assert its logged-set count. */
+async function expectSetCount(page: Page, name: string, count: number): Promise<void> {
+  await page.locator('.wtExerciseRow').filter({ hasText: name }).click()
+  await expect(page.locator('.wtDetailTitle')).toHaveText(name)
+  await expect(page.locator('.wtSetRow')).toHaveCount(count)
+  // Close the detail modal so the next interaction starts from a clean surface.
+  await page.keyboard.press('Escape')
+}
+
+test.describe('Offline write durability', () => {
+  test('offline set is accepted immediately, shows the offline indicator, and survives an online reload', async ({ page, context }) => {
+    await page.goto('/')
+    await signInDev(page)
+
+    // Baseline set logged while online.
+    await createExerciseWithSet(page, 'Squat', '225', '5')
+
+    // Drop connectivity. The app listens for the `offline` event and flips its
+    // sync status to "Offline — changes saved locally".
+    await context.setOffline(true)
+    await expect(page.locator('.syncIndicator--offline')).toBeVisible()
+
+    // A set logged with no network must be accepted instantly (local-first) —
+    // the UI never blocks on a server round-trip.
+    await page.locator('.wtExerciseLogBtnCircle').click()
+    await logSetInModal(page, '235', '5')
+    await expectSetCount(page, 'Squat', 2)
+
+    // Restore connectivity; the offline indicator clears.
+    await context.setOffline(false)
+    await expect(page.locator('.syncIndicator--offline')).toBeHidden()
+
+    // Reload while online: assets refetch cleanly and the offline-logged set is
+    // rehydrated from local storage — no data loss across the reload boundary.
+    await page.reload()
+    await signInDev(page)
+    await expectSetCount(page, 'Squat', 2)
+  })
+
+  test('offline set survives a reload performed WHILE offline (service-worker cache)', async ({ page, context }) => {
+    // Reloading with no network only works when a service worker can serve the
+    // shell + assets from cache. That exists in the CI preview (production)
+    // build but not under the local dev server, so this reload-while-offline
+    // assertion is skipped when no SW controls the page.
+    await page.goto('/')
+    // Second navigation gives an installed SW a chance to take control of the
+    // document (the controller is null on the very first visit).
+    await page.reload()
+    await signInDev(page)
+
+    const controlled = await page.evaluate(() => !!navigator.serviceWorker?.controller)
+    test.skip(!controlled, 'No service worker controls the page (dev server) — offline reload cannot be served from cache')
+
+    await createExerciseWithSet(page, 'Deadlift', '315', '3')
+
+    await context.setOffline(true)
+    await expect(page.locator('.syncIndicator--offline')).toBeVisible()
+
+    await page.locator('.wtExerciseLogBtnCircle').click()
+    await logSetInModal(page, '335', '1')
+    await expectSetCount(page, 'Deadlift', 2)
+
+    // Reload with connectivity still cut — served entirely from the SW cache.
+    await page.reload()
+    await signInDev(page)
+    await expectSetCount(page, 'Deadlift', 2)
+
+    await context.setOffline(false)
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-889](https://github.com/aschung212/Lift/issues/889)

LIFT-889 asked for E2E coverage of the durable offline write-queue/replay path — the app's crown-jewel data-loss guarantee that unit tests (`syncQueueJournal.test.ts`, `syncPipelineIntegration.test.ts`) only exercise against a mocked Supabase. The e2e build authenticates via the dev button and ships **without** Supabase credentials (`VITE_E2E` job in `ci.yml`), so there's no server to reconcile against. I scoped the spec to the user-observable half of the guarantee — the part a real regression breaks first: going offline surfaces the "changes saved locally" indicator, an offline-logged set is accepted instantly (local-first, no network wait), and it survives a full page reload via the rehydrate path.

## Changes
- **`e2e/offline-sync-flow.spec.ts`** (new): two Playwright specs under an "Offline write durability" describe:
  1. **online-reload guard** (robust in dev + CI): sign in → log baseline set → `context.setOffline(true)` → assert `.syncIndicator--offline` shows → log a second set offline and assert it appears immediately (`.wtSetRow` count = 2) → `setOffline(false)` → indicator clears → reload → re-auth → assert both sets persisted.
  2. **offline-reload guard** (CI preview only): reloads *while offline* to prove the service-worker cache serves the shell, self-skipping via `test.skip` when no SW controls the page (local dev server), so it stays green everywhere.
- Selectors and dev-auth flow mirror the passing `workout-flow.spec.ts` exactly; shared `signInDev`/`logSetInModal`/`createExerciseWithSet`/`expectSetCount` helpers keep it DRY.

## Verification
- Test-only change; no runtime/source code touched, so unit suite and build are unaffected.
- Could not run `npx playwright test` / `npm` locally — the sandbox denied approval for spawning the dev-server-backed run. The spec reuses the exact selectors, dev-auth flow, and helpers of the already-passing `workout-flow.spec.ts`; the CI `e2e` job (Chromium, preview build with `VITE_E2E=true`) exercises it end-to-end.
- Left the pre-existing untracked files (`src/lib/duration.ts`, `src/lib/__tests__/duration.test.ts`, the duration migration) untouched — not part of this issue.

## Screenshots
N/A — no UI change; new E2E test only.

## Commits
- [`3f2152b`](https://github.com/aschung212/Lift/commit/3f2152b) test(LIFT-889): add E2E coverage for offline write durability

## Test Results
- Before: 2341 passing
- After: 2341 passing (0 delta)

---
_Automated by overnight pipeline — Mon Jul  6 23:50:51 PDT 2026_