### PR TITLE
fix(LIFT-909): hide external support links on native for App Store 3.1.1 compliance

### DIFF
--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -530,14 +530,14 @@
           <div v-if="appShareFeedback" class="settingsImportResult" role="status">
             <span class="settingsImportSuccess">{{ appShareFeedback }}</span>
           </div>
-          <a class="settingsRow settingsRowBtn settingsLink" href="https://github.com/sponsors/aschung212" target="_blank" rel="noopener">
+          <a v-if="!isNative" class="settingsRow settingsRowBtn settingsLink" href="https://github.com/sponsors/aschung212" target="_blank" rel="noopener">
             <span class="settingsLabel">
               <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" style="vertical-align: -2px; margin-right: 6px; color: var(--accent)"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
               Sponsor on GitHub
             </span>
             <svg class="settingsChevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
           </a>
-          <a class="settingsRow settingsRowBtn settingsLink" href="https://buymeacoffee.com/aschung212" target="_blank" rel="noopener">
+          <a v-if="!isNative" class="settingsRow settingsRowBtn settingsLink" href="https://buymeacoffee.com/aschung212" target="_blank" rel="noopener">
             <span class="settingsLabel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" style="vertical-align: -2px; margin-right: 6px; color: var(--accent)"><path d="M18 8h1a4 4 0 0 1 0 8h-1"/><path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/><line x1="6" y1="1" x2="6" y2="4"/><line x1="10" y1="1" x2="10" y2="4"/><line x1="14" y1="1" x2="14" y2="4"/></svg>
               Buy Me a Coffee

--- a/src/lib/__tests__/settingsSupportLinksNativeGuard.test.ts
+++ b/src/lib/__tests__/settingsSupportLinksNativeGuard.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Regression test for LIFT-909.
+ *
+ * App Store guideline 3.1.1 prohibits steering users to external payment
+ * mechanisms on the native (Capacitor) build. Both external support links
+ * (GitHub Sponsors, Buy Me a Coffee) in the Settings "Support" group MUST be
+ * guarded by `v-if="!isNative"` so they never render inside the iOS shell.
+ *
+ * This is a structural source check (not a full mount) to keep it cheap and
+ * to pin the exact guard that keeps us compliant.
+ */
+const source = readFileSync(
+  resolve(__dirname, '../../components/SettingsSheet.vue'),
+  'utf-8',
+)
+
+// Grab the opening <a ...> tag for a given external URL.
+function anchorTagFor(url: string): string {
+  const idx = source.indexOf(url)
+  expect(idx, `expected to find external support link ${url}`).toBeGreaterThan(-1)
+  const open = source.lastIndexOf('<a', idx)
+  const close = source.indexOf('>', idx)
+  expect(open).toBeGreaterThan(-1)
+  expect(close).toBeGreaterThan(open)
+  return source.slice(open, close + 1)
+}
+
+describe('LIFT-909: external support links hidden on native', () => {
+  const externalSupportUrls = [
+    'https://github.com/sponsors/aschung212',
+    'https://buymeacoffee.com/aschung212',
+  ]
+
+  it.each(externalSupportUrls)(
+    'guards %s with v-if="!isNative"',
+    (url) => {
+      expect(anchorTagFor(url)).toContain('v-if="!isNative"')
+    },
+  )
+
+  it('imports isNative from the platform helper', () => {
+    expect(source).toMatch(/import\s*\{[^}]*\bisNative\b[^}]*\}\s*from\s*['"]\.\.\/lib\/platform['"]/)
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-909](https://github.com/aschung212/Lift/issues/909)

Implement LIFT-909: hide the two external support links (GitHub Sponsors, Buy Me a Coffee) on the native Capacitor build to satisfy App Store guideline 3.1.1 (no external payment steering). Minimal fix — no IAP infra needed.

## Changes
- `src/components/SettingsSheet.vue` — added `v-if="!isNative"` to both external `<a>` support links in the Settings "Support" group. `isNative` was already imported from `../lib/platform`. The "Share Lift" button in the same group is unaffected.
- `src/lib/__tests__/settingsSupportLinksNativeGuard.test.ts` — new structural regression test (matching the repo's metaRegression/cssRegression source-check pattern) pinning the `!isNative` guard on both external URLs and verifying the `isNative` import.

## Verification
- `npm run lint` — clean, zero errors
- `npm run build` — succeeds
- `npx vitest run` — 123 files / 2344 tests pass (3 new)

## Screenshots
N/A — the change removes DOM only on the native (Capacitor) build, which is not visible in web/desktop rendering; behavior is verified structurally via the regression test.

## Commits
- [`4c0e5fe`](https://github.com/aschung212/Lift/commit/4c0e5fe) fix(LIFT-909): hide external support links on native for App Store 3.1.1 compliance

## Test Results
- Before: 2341 passing
- After: 2344 passing (3 delta)

---
_Automated by overnight pipeline — Tue Jul  7 23:05:16 PDT 2026_

## Preview
Test on your phone: https://lift-jw256pigf-aschung212-1101s-projects.vercel.app