### PR TITLE
feat(LIFT-906): instrument supporter conversion funnel (impression → tap)

### DIFF
--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -530,14 +530,14 @@
           <div v-if="appShareFeedback" class="settingsImportResult" role="status">
             <span class="settingsImportSuccess">{{ appShareFeedback }}</span>
           </div>
-          <a class="settingsRow settingsRowBtn settingsLink" href="https://github.com/sponsors/aschung212" target="_blank" rel="noopener">
+          <a class="settingsRow settingsRowBtn settingsLink" href="https://github.com/sponsors/aschung212" target="_blank" rel="noopener" @click="onSupportTap('github_sponsors')">
             <span class="settingsLabel">
               <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" style="vertical-align: -2px; margin-right: 6px; color: var(--accent)"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
               Sponsor on GitHub
             </span>
             <svg class="settingsChevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
           </a>
-          <a class="settingsRow settingsRowBtn settingsLink" href="https://buymeacoffee.com/aschung212" target="_blank" rel="noopener">
+          <a class="settingsRow settingsRowBtn settingsLink" href="https://buymeacoffee.com/aschung212" target="_blank" rel="noopener" @click="onSupportTap('buymeacoffee')">
             <span class="settingsLabel">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" style="vertical-align: -2px; margin-right: 6px; color: var(--accent)"><path d="M18 8h1a4 4 0 0 1 0 8h-1"/><path d="M2 8h16v9a4 4 0 0 1-4 4H6a4 4 0 0 1-4-4V8z"/><line x1="6" y1="1" x2="6" y2="4"/><line x1="10" y1="1" x2="10" y2="4"/><line x1="14" y1="1" x2="14" y2="4"/></svg>
               Buy Me a Coffee
@@ -732,7 +732,7 @@ const { prBaselineDate, setPRBaseline, startNewTrainingBlock, clearPRBaseline } 
 const progressionStore = useProgressionStore()
 const { celebrateUnlocks } = useXPCeremony()
 const { user } = useAuth()
-const { logEvent } = useAnalytics()
+const { logEvent, supportFunnel } = useAnalytics()
 const prefs = usePreferencesStore()
 const workoutStore = useWorkoutStore()
 const bodyweightStore = useBodyweightStore()
@@ -777,6 +777,15 @@ async function shareLift() {
     if (appShareFeedbackTimer) clearTimeout(appShareFeedbackTimer)
     appShareFeedbackTimer = setTimeout(() => { appShareFeedback.value = null }, 3000)
   }
+}
+
+// ── Supporter conversion funnel (LIFT-906) ─────────────────────
+// Instrument the Support-group CTAs so tip-jar vs. subscription can be a
+// data-driven decision before any IAP is wired. Impression fires once per
+// settings-open (proxy for "the Support group was reachable"); taps fire on
+// each external CTA. The default navigation is left untouched.
+function onSupportTap(cta: 'github_sponsors' | 'buymeacoffee') {
+  supportFunnel('tap', { cta })
 }
 
 // ── App icon picker (native iOS only) ──────────────────────────
@@ -839,7 +848,11 @@ const settingsFocus = useFocusTrap()
 const confirmFocus = useFocusTrap()
 
 watch(() => props.modelValue, (open) => {
-  if (!open) {
+  if (open) {
+    // Top of the supporter funnel (LIFT-906): the Support group renders with
+    // the sheet, so an open is one impression opportunity for its CTAs.
+    supportFunnel('impression')
+  } else {
     settingsSwipe.detach()
     settingsFocus.deactivate()
   }

--- a/src/composables/__tests__/useAnalytics.test.ts
+++ b/src/composables/__tests__/useAnalytics.test.ts
@@ -21,11 +21,12 @@ describe('useAnalytics', () => {
     vi.useRealTimers()
   })
 
-  it('returns logEvent, tabSwitch, and flushEngagement', () => {
+  it('returns logEvent, tabSwitch, flushEngagement, and supportFunnel', () => {
     const analytics = useAnalytics()
     expect(typeof analytics.logEvent).toBe('function')
     expect(typeof analytics.tabSwitch).toBe('function')
     expect(typeof analytics.flushEngagement).toBe('function')
+    expect(typeof analytics.supportFunnel).toBe('function')
   })
 
   it('logEvent calls track with name and props', () => {
@@ -98,6 +99,24 @@ describe('useAnalytics', () => {
       ([name]) => name === 'tab_engagement'
     )
     expect(engagementCalls).toHaveLength(0)
+  })
+
+  it('supportFunnel logs support_funnel with the stage', () => {
+    const { supportFunnel } = useAnalytics()
+    supportFunnel('impression')
+    expect(mockTrack).toHaveBeenCalledWith('support_funnel', { stage: 'impression' })
+  })
+
+  it('supportFunnel merges extra props alongside the stage', () => {
+    const { supportFunnel } = useAnalytics()
+    supportFunnel('tap', { cta: 'github_sponsors' })
+    expect(mockTrack).toHaveBeenCalledWith('support_funnel', { stage: 'tap', cta: 'github_sponsors' })
+  })
+
+  it('supportFunnel does not throw when track fails', () => {
+    mockTrack.mockImplementation(() => { throw new Error('offline') })
+    const { supportFunnel } = useAnalytics()
+    expect(() => supportFunnel('tap', { cta: 'buymeacoffee' })).not.toThrow()
   })
 
   it('supports multiple consecutive tab switches', () => {

--- a/src/composables/useAnalytics.ts
+++ b/src/composables/useAnalytics.ts
@@ -6,10 +6,20 @@ type AllowedPropertyValues = string | number | boolean | null | undefined
 let _currentTab = 'workouts'
 let _tabStart = Date.now()
 
+/**
+ * Supporter conversion funnel (LIFT-906). One event name (`support_funnel`)
+ * with a `stage` discriminator so impression → tap → purchase → restore can be
+ * grouped as a single funnel in the analytics dashboard, mirroring the existing
+ * share funnel. `purchase`/`restore` are reserved for the native IAP wiring
+ * (LIFT-598 / LIFT-910); only `impression` and `tap` fire today.
+ */
+export type SupportFunnelStage = 'impression' | 'tap' | 'purchase' | 'restore'
+
 export interface UseAnalyticsReturn {
   logEvent: (name: string, props?: Record<string, AllowedPropertyValues>) => void
   tabSwitch: (fromTab: string, toTab: string) => void
   flushEngagement: () => void
+  supportFunnel: (stage: SupportFunnelStage, props?: Record<string, AllowedPropertyValues>) => void
 }
 
 export function useAnalytics(): UseAnalyticsReturn {
@@ -34,5 +44,9 @@ export function useAnalytics(): UseAnalyticsReturn {
     }
   }
 
-  return { logEvent, tabSwitch, flushEngagement }
+  function supportFunnel(stage: SupportFunnelStage, props: Record<string, AllowedPropertyValues> = {}): void {
+    logEvent('support_funnel', { stage, ...props })
+  }
+
+  return { logEvent, tabSwitch, flushEngagement, supportFunnel }
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-906](https://github.com/aschung212/Lift/issues/906)

Implement LIFT-906: instrument the supporter conversion funnel (impression → tap → purchase → restore) before any IAP is wired, so the tip-jar vs. subscription decision is data-driven. Mirror the existing share-funnel analytics pattern.

## Changes
- `src/composables/useAnalytics.ts` — added a first-class `supportFunnel(stage, props)` helper emitting a single `support_funnel` event with a `stage` discriminator, plus an exported `SupportFunnelStage` type (`impression | tap | purchase | restore`). `purchase`/`restore` are reserved for the future native IAP wiring (LIFT-598 / LIFT-910) and do not fire yet.
- `src/components/SettingsSheet.vue` — fire `impression` when the settings sheet opens (the Support group renders with it) and `tap` (with a `cta` prop) on the GitHub Sponsors and Buy Me a Coffee CTAs via `@click` handlers, leaving default navigation untouched.
- `src/composables/__tests__/useAnalytics.test.ts` — 3 new tests covering the funnel API (stage-only, merged props, offline-safe).

Scoped the commit to only these 3 files — left the untracked `duration.*` / migration files (another in-progress issue, LIFT-836) unstaged.

## Verification
- `npm run lint` — clean
- `npm run build` — succeeds (includes typecheck)
- `npx vitest run` — 122 files, 2344 tests pass (was 2341 + 3 new)

## Screenshots
None — change is analytics instrumentation only; no visual/UI change.

## Commits
- [`e30d6a7`](https://github.com/aschung212/Lift/commit/e30d6a7) feat(LIFT-906): instrument supporter conversion funnel (impression → tap)

## Test Results
- Before: 2341 passing
- After: 2344 passing (3 delta)

---
_Automated by overnight pipeline — Tue Jul  7 23:13:15 PDT 2026_

## Preview
Test on your phone: https://lift-ez1vvpzj4-aschung212-1101s-projects.vercel.app