### PR TITLE
feat(LIFT-904): anchor Supporter tier on AI Coach weekly review frequency

### DIFF
--- a/api/coach.ts
+++ b/api/coach.ts
@@ -28,7 +28,7 @@
 import { createClient } from '@supabase/supabase-js'
 import {
   CURRENT_CONSENT_VERSION,
-  DEFAULT_WEEKLY_LIMIT,
+  FREE_WEEKLY_LIMIT,
   MAX_INPUT_PAYLOAD_BYTES,
   MAX_INPUT_TOKENS,
   MAX_OUTPUT_TOKENS,
@@ -224,10 +224,15 @@ export default async function handler(req: Request): Promise<Response> {
   const maxCostCents = estimateMaxCostCents(model, inputTokens)
   const ceilingCents = intEnv('COACH_DAILY_CEILING_CENTS', 200)
 
+  // Always pass the FREE baseline as the default — NEVER a client-claimed limit
+  // (LIFT-904). A supporter's higher allowance (SUPPORTER_WEEKLY_LIMIT) is applied
+  // server-side via the trusted coach_usage.limit_override, set from a validated
+  // entitlement, so it overrides this default inside the RPC without the client
+  // ever dictating its own cap.
   const { data: claimData, error: claimError } = await supabase.rpc('claim_coach_request', {
     p_max_cost_cents: maxCostCents,
     p_daily_ceiling_cents: ceilingCents,
-    p_default_limit: DEFAULT_WEEKLY_LIMIT,
+    p_default_limit: FREE_WEEKLY_LIMIT,
   })
   if (claimError) return json(500, { error: 'quota_error' }, cors)
   const decision = Array.isArray(claimData) ? claimData[0] : claimData

--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -35,10 +35,10 @@ counter is cosmetic — the server is the only real cap.
 |---|---|---|
 | Provider/model | **Claude Opus 4.8** (`claude-opus-4-8`), read from `COACH_MODEL` env | Sonnet 4.6 is a 1-line swap; Haiku 4.5 also priced. Never hardcoded (SEV1). |
 | Billing | **Anthropic Console API key**, usage-billed | A Claude **Max subscription is NOT API access** and cannot power an app backend. Separate account/bill. |
-| Monetization | **Free forever, premium seam built in** | `coach_usage.limit_override` column lets a future premium tier be a config change, not a rewrite. |
+| Monetization | **Free baseline, Supporter anchors on frequency** (LIFT-904) | Tracking + a baseline weekly digest stay free forever; the Supporter tier buys a higher weekly review allowance (`SUPPORTER_WEEKLY_LIMIT`) so recurring API cost is cost-recovered, never the core loop. Applied via the `coach_usage.limit_override` seam. |
 | Bodyweight | **Included in v1**, behind its own opt-out | Most sensitive field; named explicitly in consent + App Store label. |
 | Data sent | **Full per-set log** (client windows to ~16 wks) + lifetime PRs + per-set relative intensities + derived volume/consistency/overload | Ground truth, not just aggregates — thin aggregates produce thin coaching. Identifiers (user_id/email/UUIDs) are never sent. |
-| Per-user quota | **3 reviews / rolling 7-day window** (`DEFAULT_WEEKLY_LIMIT`) | Rolling, not fixed Mon–Sun. UI copy: "Resets in N days" from server `resetsAt`. |
+| Per-user quota | **Free `FREE_WEEKLY_LIMIT` (3) / Supporter `SUPPORTER_WEEKLY_LIMIT` (10)** per rolling 7-day window | Rolling, not fixed Mon–Sun. UI copy: "Resets in N days" from server `resetsAt`. |
 | Cadence | **Weekly only** | No daily flag/tier in v1. |
 | Global spend ceiling | **$2/day** (`COACH_DAILY_CEILING_CENTS=200`) | Abuse brake, not a growth limiter. Provider-side monthly cap ≈ $62. |
 | Output cap | `max_tokens` 2500 (`MAX_OUTPUT_TOKENS`) | Leaves room for adaptive thinking + the digest; single-shot (non-streaming). |
@@ -62,6 +62,31 @@ cost far less, so the practical mix is higher). It throttles organically around 
 users — earlier than the aggregate-only design, which is the deliberate trade for usefulness. The
 two levers when you grow: raise the ceiling (and the provider monthly cap), or shorten the window.
 Hard backstops: `MAX_SETS` (1500), `MAX_INPUT_TOKENS` (80K → 413), `MAX_INPUT_PAYLOAD_BYTES` (512KB).
+
+## Monetization anchor — Supporter tier (LIFT-904)
+
+The AI Coach is the one feature with a real, recurring **per-user API cost** (Opus 4.8
+through the server proxy), which makes it the only place a paid tier is philosophically
+defensible: freemium best practice is to gate the feature with a marginal cost, never the
+core loop. So the whole tracking app + a baseline weekly digest stay **free forever**, and
+the `isSupporter` entitlement is anchored on **more-frequent** coach runs — supporter
+revenue funds the API bill instead of taxing core UX.
+
+The per-tier allowance lives in one tiny pure module, `src/lib/coachTier.ts`
+(`FREE_WEEKLY_LIMIT` = 3, `SUPPORTER_WEEKLY_LIMIT` = 10, `weeklyReviewLimit(isSupporter)`),
+re-exported from `aiCoach.ts` so the server shares the same source of truth. Consumers:
+- **Server (`api/coach.ts`)** — passes `FREE_WEEKLY_LIMIT` as `claim_coach_request`'s
+  `p_default_limit`. **It never trusts a client-claimed limit.** A supporter's higher
+  allowance is applied server-side through the trusted `coach_usage.limit_override` column,
+  set from a validated entitlement (RevenueCat / StoreKit IAP — LIFT-598), which overrides
+  the default *inside* the RPC. This closes the obvious attack (a free client sending
+  `p_default_limit: 10`): the client input for the cap is ignored entirely.
+- **Client (`useSupporter().coachWeeklyLimit`)** — cosmetic "N reviews left this week"
+  display; the server counter is authoritative.
+
+Remaining to make it live: LIFT-598 wires the IAP entitlement and the server path that
+writes `coach_usage.limit_override` from a validated receipt (the `limit_override` column
+and the resolver seam already exist; only the trusted writer is missing).
 
 ## Architecture & request flow
 

--- a/src/composables/__tests__/useSupporter.test.ts
+++ b/src/composables/__tests__/useSupporter.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { useSupporter } from '../useSupporter'
+import { FREE_WEEKLY_LIMIT } from '../../lib/coachTier'
+
+describe('useSupporter', () => {
+  it('defaults to the free tier (stub until IAP wiring, LIFT-598)', () => {
+    const { isSupporter, coachWeeklyLimit } = useSupporter()
+    expect(isSupporter.value).toBe(false)
+    // Coach allowance follows the entitlement — free by default (LIFT-904).
+    expect(coachWeeklyLimit.value).toBe(FREE_WEEKLY_LIMIT)
+  })
+
+  it('exposes isSupporter as a read-only ref', () => {
+    const { isSupporter } = useSupporter()
+    // readonly() refs warn and no-op on write in dev; the type is Readonly<Ref>.
+    expect(isSupporter.value).toBe(false)
+  })
+})

--- a/src/composables/useSupporter.ts
+++ b/src/composables/useSupporter.ts
@@ -1,14 +1,16 @@
 /**
  * Supporter (paid tier) entitlement — single source of truth (issue #601).
  *
- * Read this anywhere the free vs. paid experience diverges. Today the only
- * consumer is the share-card "Made with Lift" watermark: free users get the
- * watermark, supporters get clean cards.
+ * Read this anywhere the free vs. paid experience diverges. Consumers today:
+ *  - the share-card "Made with Lift" watermark (free users get it, supporters don't);
+ *  - the AI Coach weekly-review allowance (`coachWeeklyLimit`, LIFT-904) — supporters
+ *    get more-frequent coach runs so their revenue funds the recurring API cost.
  *
  * Module-level singleton ref so the value is global, not per-component.
  */
 
-import { readonly, ref, type Ref } from 'vue'
+import { computed, readonly, ref, type ComputedRef, type Ref } from 'vue'
+import { weeklyReviewLimit } from '../lib/coachTier'
 
 // TODO(LIFT-598): wire this to the RevenueCat / Capacitor IAP entitlement
 // (or the Supabase profile flag synced from it) once App Store purchases
@@ -19,8 +21,16 @@ const _isSupporter = ref(false)
 export interface UseSupporterReturn {
   /** True when the user has an active supporter entitlement. */
   isSupporter: Readonly<Ref<boolean>>
+  /**
+   * AI Coach reviews allowed per rolling 7-day window for the current entitlement
+   * (LIFT-904). Cosmetic on the client — the server is the real cap (it applies the
+   * supporter allowance via the trusted `coach_usage.limit_override`, never a
+   * client-sent value) — but it drives the "N reviews left this week" copy.
+   */
+  coachWeeklyLimit: ComputedRef<number>
 }
 
 export function useSupporter(): UseSupporterReturn {
-  return { isSupporter: readonly(_isSupporter) }
+  const coachWeeklyLimit = computed(() => weeklyReviewLimit(_isSupporter.value))
+  return { isSupporter: readonly(_isSupporter), coachWeeklyLimit }
 }

--- a/src/lib/__tests__/coachTier.test.ts
+++ b/src/lib/__tests__/coachTier.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import {
+  FREE_WEEKLY_LIMIT,
+  SUPPORTER_WEEKLY_LIMIT,
+  weeklyReviewLimit,
+} from '../coachTier'
+
+describe('coach tier model (LIFT-904)', () => {
+  it('the supporter allowance is strictly greater than the free baseline', () => {
+    // The whole value prop: supporters get *more-frequent* coach runs. If these were
+    // equal the paid tier would anchor on nothing.
+    expect(SUPPORTER_WEEKLY_LIMIT).toBeGreaterThan(FREE_WEEKLY_LIMIT)
+  })
+
+  it('keeps a non-trivial free baseline so the core loop is never paywalled', () => {
+    expect(FREE_WEEKLY_LIMIT).toBeGreaterThanOrEqual(1)
+  })
+
+  it('weeklyReviewLimit resolves the free baseline for non-supporters', () => {
+    expect(weeklyReviewLimit(false)).toBe(FREE_WEEKLY_LIMIT)
+  })
+
+  it('weeklyReviewLimit resolves the supporter allowance for supporters', () => {
+    expect(weeklyReviewLimit(true)).toBe(SUPPORTER_WEEKLY_LIMIT)
+  })
+
+  it('re-exports the same tier symbols from the aiCoach contract module', async () => {
+    // The server proxy imports these from aiCoach; assert they are the identical values
+    // so the server's p_default_limit and the client display can never drift.
+    const aiCoach = await import('../aiCoach')
+    expect(aiCoach.FREE_WEEKLY_LIMIT).toBe(FREE_WEEKLY_LIMIT)
+    expect(aiCoach.SUPPORTER_WEEKLY_LIMIT).toBe(SUPPORTER_WEEKLY_LIMIT)
+    expect(aiCoach.weeklyReviewLimit(true)).toBe(SUPPORTER_WEEKLY_LIMIT)
+  })
+})

--- a/src/lib/aiCoach.ts
+++ b/src/lib/aiCoach.ts
@@ -24,11 +24,18 @@
 
 // ---- Tunable constants (defaults; the function may override cost ceiling via env) ----
 
+// Per-tier weekly review allowance lives in the tiny pure `coachTier` module so the
+// client entitlement and this server-shared contract share one source of truth. The
+// server passes FREE_WEEKLY_LIMIT as claim_coach_request's p_default_limit; supporters
+// get SUPPORTER_WEEKLY_LIMIT server-side via coach_usage.limit_override (LIFT-904).
+export {
+  FREE_WEEKLY_LIMIT,
+  SUPPORTER_WEEKLY_LIMIT,
+  weeklyReviewLimit,
+} from './coachTier'
+
 /** Bump only when the set of fields that leave the device expands or the provider changes. */
 export const CURRENT_CONSENT_VERSION = 1
-
-/** Per-user reviews per rolling 7-day window (overridable per user via coach_usage.limit_override). */
-export const DEFAULT_WEEKLY_LIMIT = 3
 
 /** Hard output ceiling sent to the model. Leaves room for adaptive thinking + the digest. */
 export const MAX_OUTPUT_TOKENS = 2500

--- a/src/lib/coachTier.ts
+++ b/src/lib/coachTier.ts
@@ -1,0 +1,39 @@
+/**
+ * AI Coach — Supporter tier model (LIFT-904).
+ *
+ * The AI Coach is the ONE Lift feature with a real, recurring per-user API cost
+ * (Claude Opus 4.8 through the server proxy in `api/coach.ts`). That makes it the
+ * one place a paid tier is philosophically defensible: keep all tracking + a
+ * baseline weekly digest FREE, and anchor the Supporter entitlement on
+ * *more-frequent* coach runs so supporter revenue funds the API bill instead of
+ * taxing the core tracking loop (CLAUDE.md Principle 2 / freemium best practice —
+ * gate the feature with a marginal cost, never the core loop).
+ *
+ * This is a tiny, pure module (no browser/network/store deps) so it is the single
+ * source of truth shared by both the client entitlement (`useSupporter`) and the
+ * server proxy (`api/coach.ts`, via a re-export from `aiCoach.ts`) for the per-tier
+ * weekly review allowance.
+ *
+ * TRUST NOTE (load-bearing): the server NEVER trusts a client-claimed limit. It
+ * passes the FREE baseline as `claim_coach_request`'s `p_default_limit`; a
+ * supporter's higher allowance is applied server-side through the trusted
+ * `coach_usage.limit_override` column, set from a validated entitlement
+ * (RevenueCat / StoreKit IAP — LIFT-598), never from a value the client sends for
+ * itself. `weeklyReviewLimit()` here is the source of truth for that override value
+ * AND for the client's cosmetic "N reviews left this week" display.
+ */
+
+/** Free tier: reviews per rolling 7-day window — the baseline weekly digest, free forever. */
+export const FREE_WEEKLY_LIMIT = 3
+
+/**
+ * Supporter tier: a higher rolling-7-day allowance — the cost-recovery value prop.
+ * Sized so a supporter can run the coach roughly on demand within a week while
+ * staying comfortably under the global `$2/day` spend ceiling (docs/ai-coach.md).
+ */
+export const SUPPORTER_WEEKLY_LIMIT = 10
+
+/** Effective rolling-7-day review allowance for a given entitlement. */
+export function weeklyReviewLimit(isSupporter: boolean): number {
+  return isSupporter ? SUPPORTER_WEEKLY_LIMIT : FREE_WEEKLY_LIMIT
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-904](https://github.com/aschung212/Lift/issues/904)

Implement LIFT-904 by making the abstract `isSupporter` stub a concrete recurring-revenue value prop: keep all tracking + a baseline weekly AI-Coach digest free, and anchor the Supporter tier on a *higher weekly review allowance* so supporter revenue funds the one feature with real per-user API cost (Opus 4.8 via the server proxy). Build the tier model purely and safely without touching the blocked IAP infra (LIFT-598) or the in-progress CoachSheet UI (LIFT-848).

## Changes
- **`src/lib/coachTier.ts` (new)** — pure single source of truth for the per-tier allowance: `FREE_WEEKLY_LIMIT=3`, `SUPPORTER_WEEKLY_LIMIT=10`, `weeklyReviewLimit(isSupporter)`. Tiny module (no browser/store deps) shared by client + server.
- **`src/lib/aiCoach.ts`** — replaced the standalone `DEFAULT_WEEKLY_LIMIT` with a re-export of the tier symbols from `coachTier`, so the server-shared contract and the client display can't drift.
- **`api/coach.ts`** — passes `FREE_WEEKLY_LIMIT` as `claim_coach_request`'s `p_default_limit` with a load-bearing trust comment: the server NEVER trusts a client-claimed limit; supporters exceed the baseline only via the trusted `coach_usage.limit_override` seam (closes the "free client sends `p_default_limit:10`" attack).
- **`src/composables/useSupporter.ts`** — exposes `coachWeeklyLimit` computed, giving the `isSupporter` entitlement a concrete second consumer beyond the watermark (cosmetic "N reviews left" display; server stays authoritative).
- **Tests** — `coachTier.test.ts` (resolver, supporter>free invariant, re-export parity) + `useSupporter.test.ts` (free default). +7 tests.
- **`docs/ai-coach.md`** — new "Monetization anchor (LIFT-904)" section + updated quota/monetization rows documenting the trust model and the remaining LIFT-598 dependency.

## Verification
- Lint: clean (0 errors)
- Tests: 124 files / 2348 passed (was 2341; +7 new)
- Build: succeeds
- Pushed `enhance/run3-2026-07-07` to origin (foreground). Note: the Gemini pre/post-commit review failed on an environmental auth error (`IneligibleTierError` — the Gemini CLI tier is deprecated, unrelated to this diff); same known issue hit in run1.

## Discovery
ISSUE_DISCOVER:test: `api/coach.ts` — the entire server-side gate chain (kill switch, production-only, config presence, JWT/email-confirmed, versioned consent, payload byte/token caps, atomic quota claim, two-phase pre-charge/true-up, upstream-failure refund) has NO test file. It is Lift's only server component and its whole trust boundary, yet only the pure helpers in `src/lib/aiCoach.ts` are tested — the handler's branch logic (gate ordering, refund-on-failure, `p_default_limit` never trusting client input) is entirely uncovered. A handler test with mocked `createClient`/`fetch` would lock the security-critical control flow.

## Commits
- [`d299ddb`](https://github.com/aschung212/Lift/commit/d299ddb) feat(LIFT-904): anchor Supporter tier on AI Coach weekly review frequency

## Test Results
- Before: 2341 passing
- After: 2348 passing (7 delta)

---
_Automated by overnight pipeline — Tue Jul  7 23:23:12 PDT 2026_

## Preview
Test on your phone: https://lift-404lelyk3-aschung212-1101s-projects.vercel.app