### PR TITLE
refactor(LIFT-916): move store access out of presentational PRBurst component

### DIFF
--- a/src/components/PRBurst.vue
+++ b/src/components/PRBurst.vue
@@ -51,7 +51,7 @@
         <!-- Peak-moment share affordance (#716): one tap opens the share sheet
              pre-selected to the PR card. Stop propagation so the surrounding
              tap-to-dismiss doesn't fire. -->
-        <button type="button" class="prBurstShare" @click.stop="onShareThisPR">
+        <button v-if="canShare" type="button" class="prBurstShare" @click.stop="onShareThisPR">
           <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7"/><path d="m16 6-4-4-4 4"/><path d="M12 2v13"/></svg>
           Share this PR
         </button>
@@ -75,46 +75,33 @@
 import { computed, watch, nextTick, ref, onMounted, onUnmounted, defineAsyncComponent } from 'vue'
 import { usePRBurst } from '../composables/usePRBurst'
 import { useWeightUnit } from '../composables/useWeightUnit'
-import { useWorkoutStore } from '../stores/workout'
-import { useProgressionStore } from '../stores/progression'
 import { useAnalytics } from '../composables/useAnalytics'
-import { buildSessionSummary, type SessionSummary } from '../lib/sessionSummary'
+import type { SessionSummary } from '../lib/sessionSummary'
 
 const SharePickerSheet = defineAsyncComponent(() => import('./share/SharePickerSheet.vue'))
 
 const { visible, payload, presentPRBurst, dismissPRBurst } = usePRBurst()
 const { weightUnit, displayWeight } = useWeightUnit()
-const workoutStore = useWorkoutStore()
-const progressionStore = useProgressionStore()
 const { logEvent } = useAnalytics()
 
 // ── "Share this PR" peak-moment flow (#716) ───────────────────────────────
 const pickerOpen = ref(false)
 const shareSummary = ref<SessionSummary | null>(null)
 
-/** Local calendar date (YYYY-MM-DD), matching WorkoutTracker.todayISO(). */
-function localTodayKey(): string {
-  const d = new Date()
-  const y = d.getFullYear()
-  const m = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${y}-${m}-${day}`
-}
+/**
+ * True when a shareable summary exists. The caller (WorkoutTracker) builds the
+ * SessionSummary and hands it in via the payload (LIFT-916) — this presentational
+ * component holds no store access, so the button is inert without one.
+ */
+const canShare = computed(() => payload.value?.shareSummary != null)
 
 function onShareThisPR(): void {
   const p = payload.value
-  if (!p) return
-  // Build the session summary for the PR's day so the share sheet (pre-selected
-  // to the PR card) renders the right numbers. The set is already persisted by
-  // the time the burst shows, so the summary reflects it.
-  shareSummary.value = buildSessionSummary({
-    rawDate: p.rawDate ?? localTodayKey(),
-    exercises: workoutStore.exercises,
-    xpPerSet: progressionStore.xpPerSet,
-    streakWeeks: progressionStore.streakWeeks,
-    toDisplayUnits: displayWeight,
-    unitLabel: weightUnit.value,
-  })
+  if (!p || !p.shareSummary) return
+  // The caller already built the session summary for the PR's day (it owns
+  // store access), so the share sheet renders the right numbers with no
+  // store reach-in here.
+  shareSummary.value = p.shareSummary
   logEvent('pr_share_opened', {
     exercise: p.exerciseName,
     firstPr: p.isFirstPR === true,

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2339,6 +2339,11 @@ function saveSet() {
         // Full-bleed PR celebration (respects the PR baseline via oldE1RM,
         // and the prCelebrations opt-out inside presentPRBurst).
         const newE1RM = store.getExercisePR(exerciseId, prBaselineDate.value)
+        // Build the session summary here (WorkoutTracker owns store access) and
+        // hand it to the burst so the presentational PRBurst component can drive
+        // its "Share this PR" flow without reaching into stores (LIFT-916). The
+        // set is already persisted and its XP logged above, so this reflects it.
+        const prRawDate = date.value || todayISO()
         presentPRBurst({
           exerciseName: selectedExerciseName.value,
           oldE1RM,
@@ -2346,7 +2351,14 @@ function saveSet() {
           setWeight: effWeightLbs,
           setReps: effReps,
           isFirstPR: prCountBefore === 0,
-          rawDate: date.value || todayISO(),
+          shareSummary: buildSessionSummary({
+            rawDate: prRawDate,
+            exercises: store.exercises,
+            xpPerSet: progressionStore.xpPerSet,
+            streakWeeks: progressionStore.streakWeeks,
+            toDisplayUnits: displayWeight,
+            unitLabel: weightUnit.value,
+          }),
         })
         if (prCountBefore === 0) {
           logEvent('first_pr', { exercise: selectedExerciseName.value })

--- a/src/composables/__tests__/usePRBurst.test.ts
+++ b/src/composables/__tests__/usePRBurst.test.ts
@@ -163,4 +163,23 @@ describe('usePRBurst', () => {
     dismissPRBurst()
     expect(visible.value).toBe(false)
   })
+
+  // LIFT-916: the caller (WorkoutTracker) owns store access and hands a
+  // pre-built session summary to the burst, so the presentational PRBurst
+  // component drives its "Share this PR" flow without reaching into stores.
+  it('carries a caller-supplied shareSummary through the payload', () => {
+    const { presentPRBurst, payload } = usePRBurst()
+    const summary = { rawDate: '2026-07-08', setsCompleted: 3 } as unknown as NonNullable<
+      typeof payload.value
+    >['shareSummary']
+    presentPRBurst({
+      exerciseName: 'Deadlift',
+      oldE1RM: 400,
+      newE1RM: 420,
+      setWeight: 365,
+      setReps: 5,
+      shareSummary: summary,
+    })
+    expect(payload.value?.shareSummary).toEqual(summary)
+  })
 })

--- a/src/composables/usePRBurst.ts
+++ b/src/composables/usePRBurst.ts
@@ -21,6 +21,7 @@
 import { ref, type Ref } from 'vue'
 import { usePreferencesStore } from '../stores/preferences'
 import { useHaptics } from './useHaptics'
+import type { SessionSummary } from '../lib/sessionSummary'
 
 export interface PRBurstPayload {
   exerciseName: string
@@ -35,11 +36,13 @@ export interface PRBurstPayload {
   /** True when this is the user's very first PR ever. */
   isFirstPR?: boolean
   /**
-   * Local calendar date (YYYY-MM-DD) of the set that triggered the PR. Used by
-   * the "Share this PR" entry point (#716) to build the session summary for the
-   * correct day. Defaults to today when omitted.
+   * Pre-built session summary for the PR's day, supplied by the caller (which
+   * owns store access). Powers the "Share this PR" entry point (#716) so the
+   * presentational PRBurst component never has to reach into stores itself
+   * (LIFT-916). Omitted when the caller cannot build one — the share button is
+   * then inert.
    */
-  rawDate?: string
+  shareSummary?: SessionSummary
 }
 
 const visible: Ref<boolean> = ref(false)


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-916](https://github.com/aschung212/Lift/issues/916)

Implement LIFT-916: move store access out of the presentational `PRBurst.vue` component. `PRBurst` lives in `src/components/` (defined by CLAUDE.md as prop-driven presentational components) but imported `useWorkoutStore` + `useProgressionStore` and rebuilt a full session summary inside its "Share this PR" handler — hidden coupling that made it impossible to reuse/test without a live Pinia instance. Have the caller (WorkoutTracker, which already owns store access) build the summary and pass it via the `usePRBurst` payload.

## Changes
- `src/composables/usePRBurst.ts` — replaced the `rawDate` payload field (which only existed so PRBurst could rebuild the summary) with a `shareSummary?: SessionSummary` field supplied by the caller; added a type-only import.
- `src/components/PRBurst.vue` — removed `useWorkoutStore`, `useProgressionStore`, `buildSessionSummary`, and the local `localTodayKey` date helper. `onShareThisPR` now consumes `payload.shareSummary`; added a `canShare` computed that hides the share button when no summary is supplied (button would otherwise be inert).
- `src/components/WorkoutTracker.vue` — the `presentPRBurst` call now builds the PR-day `SessionSummary` (reusing the store access it already has) and passes it as `shareSummary`.
- `src/composables/__tests__/usePRBurst.test.ts` — added a test confirming a caller-supplied `shareSummary` round-trips through the payload.

## Verification
- `npm run lint` — clean
- `npm run build` — passes (includes vue-tsc typecheck)
- `npm test` — 2326 passed / 121 files (pre-change baseline), plus the new `usePRBurst` case (8 passed in that file)
- Confirmed `PRBurst.vue` has zero references to `useWorkoutStore`, `useProgressionStore`, `buildSessionSummary`, or a local date helper.

Note: the pre-push/post-commit Gemini review could not run — it failed with an `IneligibleTierError` auth/infra error unrelated to this change (the Gemini CLI tier was deprecated). The push itself completed successfully.

## Screenshots
None — no visual change. The PR celebration and "Share this PR" flow render identically; only the source of the share summary moved from PRBurst to its caller.

## Commits
- [`2506521`](https://github.com/aschung212/Lift/commit/2506521) refactor(LIFT-916): move store access out of presentational PRBurst component

## Test Results
- Before: 2326 passing
- After: 2327 passing (1 delta)

---
_Automated by overnight pipeline — Wed Jul  8 23:21:29 PDT 2026_

## Preview
Test on your phone: https://lift-pyrq42qmo-aschung212-1101s-projects.vercel.app