### PR TITLE
refactor(LIFT-919): extract App.vue shell orchestration into lifecycle composables

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,7 @@
     <AuthScreen v-if="!user" />
 
     <!-- Onboarding -->
-    <OnboardingScreen v-else-if="showOnboarding" @complete="onOnboardingComplete" @started="onboardingInProgress = true" />
+    <OnboardingScreen v-else-if="showOnboarding" @complete="completeOnboarding" @started="onboardingInProgress = true" />
 
     <!-- Authenticated app -->
     <template v-else>
@@ -245,6 +245,8 @@ import { useFocusTrap } from './composables/useFocusTrap'
 import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
 import { useInstallPrompt } from './composables/useInstallPrompt'
 import { useServiceWorker } from './composables/useServiceWorker'
+import { useOnboarding } from './composables/useOnboarding'
+import { useTabRouting } from './composables/useTabRouting'
 import { onCrossTabMessage, type StoreKey } from './lib/crossTabSync'
 
 const { currentTheme, THEME_PREVIEWS, resolvedMode, isThemeUnlocked } = useTheme()
@@ -258,9 +260,14 @@ const { logEvent, tabSwitch, flushEngagement } = useAnalytics()
 const prefs = usePreferencesStore()
 const { toast: undoToast, performUndo } = useUndoToast()
 
+// Acquire each store once and pass references to the lifecycle composables and
+// handlers below — Pinia returns the same instance per call, so re-calling the
+// hooks in scattered handlers was redundant noise.
+const workoutStore = useWorkoutStore()
+const bodyweightStore = useBodyweightStore()
+
 // ── PWA install prompt ──────────────────────────────────────────
-const workoutStoreForInstall = useWorkoutStore()
-const installWorkoutDays = computed(() => workoutStoreForInstall.workoutDates.length)
+const installWorkoutDays = computed(() => workoutStore.workoutDates.length)
 const { showBanner: installBannerVisible, isIOSPrompt, dismiss: dismissInstallBanner, install: triggerInstall } = useInstallPrompt(installWorkoutDays)
 
 // Dismiss splash screen once auth resolves
@@ -302,47 +309,14 @@ const shortcutsFocus = useFocusTrap()
 const { checkForSWUpdate } = useServiceWorker()
 
 // ── Onboarding ──────────────────────────────────────────────────
-const onboardingComplete = ref(!!localStorage.getItem('onboarding-complete'))
-const workoutStoreForOnboarding = useWorkoutStore()
-const bodyweightStoreForOnboarding = useBodyweightStore()
-
-// Skip onboarding if user already has any data (exercises or bodyweight entries)
-// Reactive so it catches data that loads asynchronously after auth.
-// onboardingInProgress prevents the watcher from firing when the onboarding
-// screen itself adds exercises (e.g. Popular Exercises option).
-const onboardingInProgress = ref(false)
-watch(
-  () => workoutStoreForOnboarding.exercises.length + bodyweightStoreForOnboarding.entries.length,
-  (total) => {
-    if (!onboardingComplete.value && !onboardingInProgress.value && total > 0) {
-      localStorage.setItem('onboarding-complete', 'true')
-      onboardingComplete.value = true
-    }
-  },
-  { immediate: true },
-)
-const showOnboarding = computed(() => !onboardingComplete.value)
-const hasSampleData = ref(localStorage.getItem('sample-data') === 'true')
-
-function onOnboardingComplete() {
-  onboardingInProgress.value = false
-  onboardingComplete.value = true
-  hasSampleData.value = localStorage.getItem('sample-data') === 'true'
-}
-
-function clearSampleData() {
-  const workoutStore = useWorkoutStore()
-  const bwStore = useBodyweightStore()
-  const exerciseIds = [...workoutStore.exercises.map(e => e.id)]
-  for (const id of exerciseIds) {
-    workoutStore.deleteExercise(id)
-  }
-  bwStore.clearAll()
-  localStorage.removeItem('sample-data')
-  localStorage.setItem('fresh-start', 'true')
-  hasSampleData.value = false
-  window.dispatchEvent(new CustomEvent('fresh-start'))
-}
+const {
+  showOnboarding,
+  onboardingInProgress,
+  hasSampleData,
+  completeOnboarding,
+  clearSampleData,
+  resetOnboarding,
+} = useOnboarding({ workoutStore, bodyweightStore })
 
 function closeSettings() {
   settingsSheetRef.value?.closeSettings()
@@ -350,8 +324,7 @@ function closeSettings() {
 
 // ── Sign out handler (from SettingsSheet) ────────────────────────
 function handleSignOut() {
-  localStorage.removeItem('onboarding-complete')
-  onboardingComplete.value = false
+  resetOnboarding()
   signOut()
 }
 
@@ -362,19 +335,18 @@ function handleSignOut() {
 // measurable without a backend.
 captureAcquisitionSource()
 
-// ── Tab initialization (supports PWA manifest shortcuts via ?tab= param) ──
-const VALID_TABS = ['workouts', 'calendar', 'weight'] as const
-const urlTab = new URLSearchParams(window.location.search).get('tab')
-const initialTab = urlTab && VALID_TABS.includes(urlTab as typeof VALID_TABS[number])
-  ? urlTab
-  : localStorage.getItem('active-tab') || 'workouts'
-const activeTab = ref(initialTab)
-// Clean up the query param so it doesn't persist on reload
-if (urlTab) {
-  const url = new URL(window.location.href)
-  url.searchParams.delete('tab')
-  window.history.replaceState({}, '', url.pathname)
-}
+// ── Tab routing (supports PWA manifest shortcuts via ?tab= param) ─────
+// The scrollable tab-content element, used to preserve per-tab scroll offset.
+const tabContentEl = ref<HTMLElement | null>(null)
+const { activeTab, switchTab } = useTabRouting({
+  scrollContainer: tabContentEl,
+  // Runs on every tap (including the active tab) — dismiss the settings sheet.
+  onBeforeSwitch: closeSettings,
+  onSwitch: (from, to) => {
+    tabSwitch(from, to)
+    checkForSWUpdate()
+  },
+})
 
 // ── Keyboard shortcuts ─────────────────────────────────────────────
 const { helpOpen: shortcutsOpen, toggleHelp: toggleShortcuts, closeHelp: closeShortcuts } = useKeyboardShortcuts(() => [
@@ -438,31 +410,6 @@ watch(() => prefs.features, () => {
   }
 }, { deep: true })
 
-// ── Tab scroll position preservation ─────────────────────────────
-const tabContentEl = ref<HTMLElement | null>(null)
-const tabScrollPositions: Record<string, number> = {}
-
-// ── Analytics ────────────────────────────────────────────────────
-function switchTab(tabId: string) {
-  const from = activeTab.value
-  closeSettings()
-  if (from === tabId) return
-  // Save scroll position of outgoing tab
-  if (tabContentEl.value) {
-    tabScrollPositions[from] = tabContentEl.value.scrollTop
-  }
-  activeTab.value = tabId
-  localStorage.setItem('active-tab', tabId)
-  tabSwitch(from, tabId)
-  checkForSWUpdate()
-  // Restore scroll position of incoming tab (default to top)
-  nextTick(() => {
-    if (tabContentEl.value) {
-      tabContentEl.value.scrollTop = tabScrollPositions[tabId] ?? 0
-    }
-  })
-}
-
 // Exposed from WorkoutTracker via defineExpose so the top-bar "+" can open the
 // new-exercise modal directly. Logging a set is a per-exercise action (the "+"
 // on each exercise row); the top-bar "+" is reserved for adding an exercise.
@@ -509,7 +456,7 @@ onMounted(async () => {
 
   // Startup migration and streak catch-up
   if (progressionStore.progressionEnabled && !isMigrated()) {
-    const result = computeRetroactiveXP(workoutStoreForOnboarding.exercises, bodyweightStoreForOnboarding.entries)
+    const result = computeRetroactiveXP(workoutStore.exercises, bodyweightStore.entries)
     if (result.totalXP > 0) {
       progressionStore.totalXP = result.totalXP
       progressionStore.xpPerSet = result.xpPerSet
@@ -535,23 +482,23 @@ onMounted(async () => {
         progressionStore.weeklyTarget = progressionStore.pendingTargetChange
         progressionStore.pendingTargetChange = null
         const setIdToDate: Record<string, string> = {}
-        for (const exercise of workoutStoreForOnboarding.exercises) {
+        for (const exercise of workoutStore.exercises) {
           for (const set of exercise.sets) {
             setIdToDate[set.id] = set.date.slice(0, 10)
           }
         }
-        progressionStore.reEvaluateStreaks(workoutStoreForOnboarding.workoutDates, new Date(), setIdToDate)
+        progressionStore.reEvaluateStreaks(workoutStore.workoutDates, new Date(), setIdToDate)
       }
     }
     // Evaluate missed weeks
     const setIdToDate: Record<string, string> = {}
-    for (const exercise of workoutStoreForOnboarding.exercises) {
+    for (const exercise of workoutStore.exercises) {
       for (const set of exercise.sets) {
         setIdToDate[set.id] = set.date.slice(0, 10)
       }
     }
     const streakBefore = progressionStore.streakWeeks
-    progressionStore.evaluatePendingWeeks(workoutStoreForOnboarding.workoutDates, new Date(), setIdToDate)
+    progressionStore.evaluatePendingWeeks(workoutStore.workoutDates, new Date(), setIdToDate)
     const streakAfter = progressionStore.streakWeeks
     if (progressionStore.showProgression && streakAfter > streakBefore) {
       const MILESTONES = [12, 8, 4, 2] as const
@@ -572,8 +519,8 @@ onMounted(async () => {
 
   // Cross-tab sync: reload stores when another tab persists data
   const storeMap: Record<StoreKey, { _reloadFromStorage(): void }> = {
-    workout: useWorkoutStore(),
-    bodyweight: useBodyweightStore(),
+    workout: workoutStore,
+    bodyweight: bodyweightStore,
     preferences: usePreferencesStore(),
     progression: progressionStore,
   }

--- a/src/composables/__tests__/useOnboarding.test.ts
+++ b/src/composables/__tests__/useOnboarding.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { reactive, nextTick } from 'vue'
+import { useOnboarding, type OnboardingStores } from '../useOnboarding'
+
+function makeStores(): OnboardingStores & {
+  workoutStore: { exercises: Array<{ id: string }>; deleteExercise: (id: string) => void }
+  bodyweightStore: { entries: unknown[]; clearAll: () => void }
+} {
+  const workoutStore = reactive({
+    exercises: [] as Array<{ id: string }>,
+    deleteExercise(id: string) {
+      const i = workoutStore.exercises.findIndex(e => e.id === id)
+      if (i >= 0) workoutStore.exercises.splice(i, 1)
+    },
+  })
+  const bodyweightStore = reactive({
+    entries: [] as unknown[],
+    clearAll() {
+      bodyweightStore.entries.splice(0, bodyweightStore.entries.length)
+    },
+  })
+  return { workoutStore, bodyweightStore }
+}
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows onboarding when there is no flag and no data', () => {
+    const { showOnboarding } = useOnboarding(makeStores())
+    expect(showOnboarding.value).toBe(true)
+  })
+
+  it('does not show onboarding when the completion flag is already set', () => {
+    localStorage.setItem('onboarding-complete', 'true')
+    const { showOnboarding } = useOnboarding(makeStores())
+    expect(showOnboarding.value).toBe(false)
+  })
+
+  it('auto-completes immediately when the user already has data on init', () => {
+    const stores = makeStores()
+    stores.workoutStore.exercises.push({ id: 'a' })
+    const { showOnboarding } = useOnboarding(stores)
+    expect(showOnboarding.value).toBe(false)
+    expect(localStorage.getItem('onboarding-complete')).toBe('true')
+  })
+
+  it('auto-completes when data appears asynchronously after init', async () => {
+    const stores = makeStores()
+    const { showOnboarding } = useOnboarding(stores)
+    expect(showOnboarding.value).toBe(true)
+
+    stores.bodyweightStore.entries.push({ weight: 180 })
+    await nextTick()
+    expect(showOnboarding.value).toBe(false)
+    expect(localStorage.getItem('onboarding-complete')).toBe('true')
+  })
+
+  it('does not auto-complete while onboarding is in progress', async () => {
+    const stores = makeStores()
+    const { showOnboarding, onboardingInProgress } = useOnboarding(stores)
+    onboardingInProgress.value = true
+
+    // Onboarding screen itself adds an exercise — must not flip complete.
+    stores.workoutStore.exercises.push({ id: 'seed' })
+    await nextTick()
+    expect(showOnboarding.value).toBe(true)
+    expect(localStorage.getItem('onboarding-complete')).toBeNull()
+  })
+
+  it('completeOnboarding finishes onboarding and refreshes sample-data state', () => {
+    localStorage.setItem('sample-data', 'true')
+    const { showOnboarding, onboardingInProgress, hasSampleData, completeOnboarding } =
+      useOnboarding(makeStores())
+    onboardingInProgress.value = true
+    completeOnboarding()
+    expect(onboardingInProgress.value).toBe(false)
+    expect(showOnboarding.value).toBe(false)
+    expect(hasSampleData.value).toBe(true)
+  })
+
+  it('clearSampleData wipes seeded data and signals a fresh start', () => {
+    localStorage.setItem('sample-data', 'true')
+    const stores = makeStores()
+    stores.workoutStore.exercises.push({ id: 'x' }, { id: 'y' })
+    stores.bodyweightStore.entries.push({ weight: 1 })
+
+    const clearAllSpy = vi.spyOn(stores.bodyweightStore, 'clearAll')
+    const dispatchSpy = vi.spyOn(window, 'dispatchEvent')
+
+    const { hasSampleData, clearSampleData } = useOnboarding(stores)
+    clearSampleData()
+
+    expect(stores.workoutStore.exercises).toHaveLength(0)
+    expect(clearAllSpy).toHaveBeenCalledTimes(1)
+    expect(localStorage.getItem('sample-data')).toBeNull()
+    expect(localStorage.getItem('fresh-start')).toBe('true')
+    expect(hasSampleData.value).toBe(false)
+    expect(dispatchSpy).toHaveBeenCalledWith(expect.any(CustomEvent))
+    expect((dispatchSpy.mock.calls.at(-1)![0] as CustomEvent).type).toBe('fresh-start')
+  })
+
+  it('resetOnboarding clears the persisted flag and re-shows onboarding', () => {
+    localStorage.setItem('onboarding-complete', 'true')
+    const { showOnboarding, resetOnboarding } = useOnboarding(makeStores())
+    expect(showOnboarding.value).toBe(false)
+    resetOnboarding()
+    expect(showOnboarding.value).toBe(true)
+    expect(localStorage.getItem('onboarding-complete')).toBeNull()
+  })
+})

--- a/src/composables/__tests__/useTabRouting.test.ts
+++ b/src/composables/__tests__/useTabRouting.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useTabRouting, VALID_TABS } from '../useTabRouting'
+
+function makeScrollContainer(scrollTop = 0): HTMLElement {
+  return { scrollTop } as unknown as HTMLElement
+}
+
+describe('useTabRouting', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('initial tab resolution', () => {
+    it('uses a valid ?tab= deep-link param over everything else', () => {
+      localStorage.setItem('active-tab', 'weight')
+      const { activeTab } = useTabRouting({
+        scrollContainer: ref(null),
+        search: '?tab=calendar',
+      })
+      expect(activeTab.value).toBe('calendar')
+    })
+
+    it('ignores an invalid ?tab= param and falls back to the persisted tab', () => {
+      localStorage.setItem('active-tab', 'weight')
+      const { activeTab } = useTabRouting({
+        scrollContainer: ref(null),
+        search: '?tab=bogus',
+      })
+      expect(activeTab.value).toBe('weight')
+    })
+
+    it('falls back to the persisted active-tab when no param is present', () => {
+      localStorage.setItem('active-tab', 'calendar')
+      const { activeTab } = useTabRouting({ scrollContainer: ref(null), search: '' })
+      expect(activeTab.value).toBe('calendar')
+    })
+
+    it('defaults to workouts when nothing is persisted', () => {
+      const { activeTab } = useTabRouting({ scrollContainer: ref(null), search: '' })
+      expect(activeTab.value).toBe('workouts')
+    })
+
+    it('exposes the three valid tabs', () => {
+      expect([...VALID_TABS]).toEqual(['workouts', 'calendar', 'weight'])
+    })
+  })
+
+  describe('?tab= cleanup', () => {
+    it('strips the tab param from the URL via replaceState', () => {
+      const spy = vi.spyOn(window.history, 'replaceState')
+      useTabRouting({ scrollContainer: ref(null), search: '?tab=weight' })
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not touch history when no tab param is present', () => {
+      const spy = vi.spyOn(window.history, 'replaceState')
+      useTabRouting({ scrollContainer: ref(null), search: '' })
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('switchTab', () => {
+    it('updates activeTab, persists it, and fires onSwitch with from/to', () => {
+      const onSwitch = vi.fn()
+      const { activeTab, switchTab } = useTabRouting({
+        scrollContainer: ref(null),
+        search: '',
+        onSwitch,
+      })
+      switchTab('calendar')
+      expect(activeTab.value).toBe('calendar')
+      expect(localStorage.getItem('active-tab')).toBe('calendar')
+      expect(onSwitch).toHaveBeenCalledWith('workouts', 'calendar')
+    })
+
+    it('runs onBeforeSwitch on every call but skips onSwitch when the tab is unchanged', () => {
+      const onBeforeSwitch = vi.fn()
+      const onSwitch = vi.fn()
+      const { switchTab } = useTabRouting({
+        scrollContainer: ref(null),
+        search: '',
+        onBeforeSwitch,
+        onSwitch,
+      })
+      switchTab('workouts') // already active
+      expect(onBeforeSwitch).toHaveBeenCalledTimes(1)
+      expect(onSwitch).not.toHaveBeenCalled()
+    })
+
+    it('preserves and restores per-tab scroll position', async () => {
+      const container = ref<HTMLElement | null>(makeScrollContainer(120))
+      const { switchTab } = useTabRouting({ scrollContainer: container, search: '' })
+
+      // Leave workouts scrolled to 120 → switch to calendar (starts at top)
+      switchTab('calendar')
+      await nextTick()
+      expect(container.value!.scrollTop).toBe(0)
+
+      // Scroll calendar, go back to workouts → restores 120
+      container.value!.scrollTop = 40
+      switchTab('workouts')
+      await nextTick()
+      expect(container.value!.scrollTop).toBe(120)
+
+      // Return to calendar → restores its saved 40
+      switchTab('calendar')
+      await nextTick()
+      expect(container.value!.scrollTop).toBe(40)
+    })
+  })
+})

--- a/src/composables/useOnboarding.ts
+++ b/src/composables/useOnboarding.ts
@@ -1,0 +1,104 @@
+import { ref, computed, watch, type ComputedRef, type Ref } from 'vue'
+
+const ONBOARDING_KEY = 'onboarding-complete'
+const SAMPLE_DATA_KEY = 'sample-data'
+const FRESH_START_KEY = 'fresh-start'
+
+/**
+ * The minimal store surface the onboarding flow depends on. Kept structural
+ * (not the full Pinia store type) so the composable stays decoupled and can be
+ * unit-tested with lightweight fakes.
+ */
+export interface OnboardingStores {
+  workoutStore: {
+    exercises: ReadonlyArray<{ id: string }>
+    deleteExercise: (id: string) => void
+  }
+  bodyweightStore: {
+    entries: ReadonlyArray<unknown>
+    clearAll: () => void
+  }
+}
+
+export interface Onboarding {
+  /** True while the onboarding screen should be shown. */
+  showOnboarding: ComputedRef<boolean>
+  /**
+   * True while the onboarding screen itself is adding data, so the
+   * auto-complete watcher doesn't fire on exercises it created.
+   */
+  onboardingInProgress: Ref<boolean>
+  /** True while the seeded sample dataset is still present. */
+  hasSampleData: Ref<boolean>
+  /** Mark onboarding finished (from the OnboardingScreen `complete` event). */
+  completeOnboarding: () => void
+  /** Delete the seeded sample data and start the user fresh. */
+  clearSampleData: () => void
+  /** Reset the persisted onboarding flag (used on sign-out). */
+  resetOnboarding: () => void
+}
+
+/**
+ * Owns onboarding lifecycle for the app shell: persisted completion state,
+ * auto-completion once the user has any real data, sample-data teardown, and
+ * the sign-out reset. Stores are injected so App.vue can acquire each store
+ * once and hand references in, rather than re-calling the store hooks inside
+ * scattered handlers.
+ */
+export function useOnboarding(stores: OnboardingStores): Onboarding {
+  const { workoutStore, bodyweightStore } = stores
+
+  const onboardingComplete = ref(!!localStorage.getItem(ONBOARDING_KEY))
+  const onboardingInProgress = ref(false)
+  const hasSampleData = ref(localStorage.getItem(SAMPLE_DATA_KEY) === 'true')
+
+  // Skip onboarding if the user already has any data (exercises or bodyweight
+  // entries). Reactive so it catches data that loads asynchronously after auth.
+  // onboardingInProgress prevents the watcher from firing when the onboarding
+  // screen itself adds exercises (e.g. Popular Exercises option).
+  watch(
+    () => workoutStore.exercises.length + bodyweightStore.entries.length,
+    (total) => {
+      if (!onboardingComplete.value && !onboardingInProgress.value && total > 0) {
+        localStorage.setItem(ONBOARDING_KEY, 'true')
+        onboardingComplete.value = true
+      }
+    },
+    { immediate: true },
+  )
+
+  const showOnboarding = computed(() => !onboardingComplete.value)
+
+  function completeOnboarding() {
+    onboardingInProgress.value = false
+    onboardingComplete.value = true
+    hasSampleData.value = localStorage.getItem(SAMPLE_DATA_KEY) === 'true'
+  }
+
+  function clearSampleData() {
+    // Snapshot ids first — deleteExercise mutates the underlying array.
+    const exerciseIds = [...workoutStore.exercises.map(e => e.id)]
+    for (const id of exerciseIds) {
+      workoutStore.deleteExercise(id)
+    }
+    bodyweightStore.clearAll()
+    localStorage.removeItem(SAMPLE_DATA_KEY)
+    localStorage.setItem(FRESH_START_KEY, 'true')
+    hasSampleData.value = false
+    window.dispatchEvent(new CustomEvent(FRESH_START_KEY))
+  }
+
+  function resetOnboarding() {
+    localStorage.removeItem(ONBOARDING_KEY)
+    onboardingComplete.value = false
+  }
+
+  return {
+    showOnboarding,
+    onboardingInProgress,
+    hasSampleData,
+    completeOnboarding,
+    clearSampleData,
+    resetOnboarding,
+  }
+}

--- a/src/composables/useTabRouting.ts
+++ b/src/composables/useTabRouting.ts
@@ -1,0 +1,85 @@
+import { ref, nextTick, type Ref } from 'vue'
+
+/**
+ * The three top-level tabs. Kept here (not in the view) so tab resolution and
+ * validation have a single owner shared by the router and any deep-link handling.
+ */
+export const VALID_TABS = ['workouts', 'calendar', 'weight'] as const
+export type TabId = (typeof VALID_TABS)[number]
+
+const ACTIVE_TAB_KEY = 'active-tab'
+
+export interface TabRoutingOptions {
+  /** The scrollable tab-content element, used to preserve per-tab scroll offset. */
+  scrollContainer: Ref<HTMLElement | null>
+  /**
+   * Runs on every switchTab call — including a tap on the already-active tab —
+   * before the early-return. Used to dismiss transient UI (e.g. settings sheet).
+   */
+  onBeforeSwitch?: () => void
+  /** Runs only when the tab actually changes, after activeTab updates. */
+  onSwitch?: (from: string, to: string) => void
+  /** Query string to resolve the initial tab from (defaults to live location). */
+  search?: string
+}
+
+export interface TabRouting {
+  /** The currently active tab id. */
+  activeTab: Ref<string>
+  /** Switch to a tab, persisting the choice and preserving scroll positions. */
+  switchTab: (tabId: string) => void
+}
+
+/**
+ * Resolve the initial tab: a valid `?tab=` deep-link param wins (PWA manifest
+ * shortcuts use it), then the last persisted tab, then the Workouts default.
+ */
+function resolveInitialTab(search: string): string {
+  const urlTab = new URLSearchParams(search).get('tab')
+  if (urlTab && (VALID_TABS as readonly string[]).includes(urlTab)) return urlTab
+  return localStorage.getItem(ACTIVE_TAB_KEY) || 'workouts'
+}
+
+/**
+ * Owns top-level tab routing: initial-tab resolution (`?tab=` deep-link →
+ * persisted → default), `?tab=` cleanup so it doesn't persist on reload or leak
+ * into shared links, active-tab persistence, and per-tab scroll preservation.
+ *
+ * Side effects that belong to the shell (analytics, service-worker update check,
+ * closing the settings sheet) are injected via `onSwitch`/`onBeforeSwitch` so the
+ * router stays free of view-specific concerns and is unit-testable in isolation.
+ */
+export function useTabRouting(options: TabRoutingOptions): TabRouting {
+  const search = options.search ?? window.location.search
+  const activeTab = ref<string>(resolveInitialTab(search))
+
+  // Strip the query param so a deep-link `?tab=` doesn't persist on reload.
+  const urlTab = new URLSearchParams(search).get('tab')
+  if (urlTab && typeof window !== 'undefined' && window.history?.replaceState) {
+    const url = new URL(window.location.href)
+    url.searchParams.delete('tab')
+    window.history.replaceState({}, '', url.pathname)
+  }
+
+  const scrollPositions: Record<string, number> = {}
+
+  function switchTab(tabId: string) {
+    const from = activeTab.value
+    options.onBeforeSwitch?.()
+    if (from === tabId) return
+    // Save scroll position of the outgoing tab before it unmounts.
+    const container = options.scrollContainer.value
+    if (container) scrollPositions[from] = container.scrollTop
+    activeTab.value = tabId
+    localStorage.setItem(ACTIVE_TAB_KEY, tabId)
+    options.onSwitch?.(from, tabId)
+    // Restore scroll position of the incoming tab (default to top).
+    nextTick(() => {
+      if (options.scrollContainer.value) {
+        options.scrollContainer.value.scrollTop = scrollPositions[tabId] ?? 0
+      }
+    })
+  }
+
+  return { activeTab, switchTab }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-919](https://github.com/aschung212/Lift/issues/919)

Implement LIFT-919: extract App.vue's inline shell orchestration into focused, unit-testable lifecycle composables and acquire each store once. Scoped to the two cleanest, highest-value extractions the issue calls out (`useTabRouting`, `useOnboarding`) plus the store-consolidation cleanup — behavior-preserving, fully tested.

## Changes
- **`src/composables/useTabRouting.ts`** (new) — owns initial-tab resolution (`?tab=` deep-link → persisted → `workouts` default), `?tab=` URL cleanup, `active-tab` persistence, and per-tab scroll preservation. Shell side effects (analytics `tabSwitch`, SW-update check, closing settings) are injected via `onSwitch`/`onBeforeSwitch` so the router carries no view concerns. Exports `VALID_TABS`.
- **`src/composables/useOnboarding.ts`** (new) — owns persisted completion state, async auto-completion once real data exists, sample-data teardown, and the sign-out reset. Stores are injected (structural interface, not the full Pinia type) so it's testable with fakes.
- **`src/App.vue`** — acquires `workoutStore`/`bodyweightStore` once at the top and passes references everywhere (removed 4×/3× redundant hook calls across install, onboarding, `clearSampleData`, and the cross-tab `storeMap`); replaced the inline onboarding + tab blocks with the two composables. Net −91 lines of inline logic in the shell.
- **Tests** (new) — `useTabRouting.test.ts` (10) + `useOnboarding.test.ts` (8) covering tab resolution/cleanup/scroll and the full onboarding lifecycle.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 123 files, 2344 tests pass (was 2326; +18 new)
- `npm run build` — succeeds
- Pre-push Gemini review skipped itself (Google retired the free-tier client; auth error, unrelated to this diff).

## Screenshots
None — pure refactor, no visual change.

## Commits
- [`65faabd`](https://github.com/aschung212/Lift/commit/65faabd) refactor(LIFT-919): extract App.vue shell orchestration into lifecycle composables

## Test Results
- Before: 2326 passing
- After: 2344 passing (18 delta)

---
_Automated by overnight pipeline — Wed Jul  8 23:45:07 PDT 2026_

## Preview
Test on your phone: https://lift-mivtwkvkd-aschung212-1101s-projects.vercel.app