### PR TITLE
refactor(LIFT-917): extract calendar domain derivation into useCalendarData

### DIFF
--- a/src/composables/__tests__/useCalendarData.test.ts
+++ b/src/composables/__tests__/useCalendarData.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
+import { useCalendarData } from '../useCalendarData'
+import type { Exercise, WorkoutSet } from '../../stores/workout'
+
+let setSeq = 0
+function makeSet(date: string, weight: number, reps: number, e1rm: number): WorkoutSet {
+  return { id: `set-${setSeq++}`, date, weight, reps, estimated1RM: e1rm }
+}
+
+function makeExercise(id: string, name: string, sets: WorkoutSet[]): Exercise {
+  return { id, name, tags: [], sets }
+}
+
+// A getExercisePR stand-in mirroring the store: max e1RM on/after an optional baseline.
+function makeGetPR(exercises: Exercise[]) {
+  return (exerciseId: string, sinceDate?: string | null): number => {
+    const ex = exercises.find(e => e.id === exerciseId)
+    if (!ex || ex.sets.length === 0) return 0
+    const filtered = sinceDate
+      ? ex.sets.filter(s => s.date.slice(0, 10) >= sinceDate)
+      : ex.sets
+    if (filtered.length === 0) return 0
+    return Math.max(...filtered.map(s => s.estimated1RM))
+  }
+}
+
+const identity = (v: number) => v
+
+describe('useCalendarData', () => {
+  describe('trainingMap', () => {
+    it('maps each day to its unique exercise names', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-23T23:59:00.000Z', 135, 10, 180),
+          makeSet('2026-03-23T23:59:01.000Z', 135, 8, 175),
+          makeSet('2026-03-25T23:59:00.000Z', 140, 5, 163),
+        ]),
+        makeExercise('squat', 'Squat', [
+          makeSet('2026-03-23T23:59:02.000Z', 225, 5, 262),
+        ]),
+      ])
+      const { trainingMap } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+
+      expect(trainingMap.value['2026-03-23']).toEqual(['Bench Press', 'Squat'])
+      expect(trainingMap.value['2026-03-25']).toEqual(['Bench Press'])
+    })
+
+    it('reacts to exercise changes', () => {
+      const exercises = ref<Exercise[]>([])
+      const { trainingMap } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR([]),
+        displayWeight: identity,
+      })
+      expect(trainingMap.value).toEqual({})
+
+      exercises.value = [
+        makeExercise('bench', 'Bench', [makeSet('2026-03-24T23:59:00.000Z', 135, 5, 157)]),
+      ]
+      expect(trainingMap.value['2026-03-24']).toEqual(['Bench'])
+    })
+  })
+
+  describe('prMap / isPRExercise / hasPR', () => {
+    it('awards the PR to the earliest date the record e1RM was reached', () => {
+      // Two sets hit the same top e1RM (200); the earlier date owns the record.
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-20T23:59:00.000Z', 150, 5, 200),
+          makeSet('2026-03-25T23:59:00.000Z', 150, 5, 200),
+          makeSet('2026-03-22T23:59:00.000Z', 140, 5, 163),
+        ]),
+      ])
+      const { hasPR, isPRExercise } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+
+      expect(hasPR('2026-03-20')).toBe(true)
+      expect(isPRExercise('2026-03-20', 'Bench Press')).toBe(true)
+      // The later tie is not a new record.
+      expect(hasPR('2026-03-25')).toBe(false)
+      expect(isPRExercise('2026-03-25', 'Bench Press')).toBe(false)
+    })
+
+    it('excludes sets before the PR baseline from record resolution', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-01T23:59:00.000Z', 200, 5, 233), // pre-baseline all-time best
+          makeSet('2026-03-20T23:59:00.000Z', 150, 5, 175), // best within baseline window
+        ]),
+      ])
+      const { hasPR } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref('2026-03-10'),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+
+      // Pre-baseline set is ignored; the in-window best owns the PR.
+      expect(hasPR('2026-03-01')).toBe(false)
+      expect(hasPR('2026-03-20')).toBe(true)
+    })
+  })
+
+  describe('daySummary', () => {
+    it('aggregates exercises, sets, volume, and PR count for the selected day', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-23T23:59:00.000Z', 100, 10, 133), // PR set
+          makeSet('2026-03-23T23:59:01.000Z', 90, 10, 120),
+        ]),
+        makeExercise('squat', 'Squat', [
+          makeSet('2026-03-23T23:59:02.000Z', 200, 5, 233), // PR set
+        ]),
+      ])
+      const { daySummary } = useCalendarData({
+        exercises,
+        selectedDay: ref('2026-03-23'),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+
+      expect(daySummary.value).toEqual({
+        exercises: 2,
+        sets: 3,
+        volumeDisplay: '2900', // 100*10 + 90*10 + 200*5 = 2900
+        prs: 2,
+      })
+    })
+
+    it('returns null when no day is selected', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [makeSet('2026-03-23T23:59:00.000Z', 100, 10, 133)]),
+      ])
+      const { daySummary } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+      expect(daySummary.value).toBeNull()
+    })
+
+    it('formats large volumes as a k-suffixed value', () => {
+      const exercises = ref([
+        makeExercise('squat', 'Squat', [makeSet('2026-03-23T23:59:00.000Z', 250, 50, 999)]),
+      ])
+      const { daySummary } = useCalendarData({
+        exercises,
+        selectedDay: ref('2026-03-23'),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+      // 250*50 = 12500 → 12.5k
+      expect(daySummary.value?.volumeDisplay).toBe('12.5k')
+    })
+  })
+
+  describe('getSetsForDay', () => {
+    it('returns the day\'s sets sorted by e1RM descending, flagging the PR set', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-23T23:59:00.000Z', 135, 8, 171),
+          makeSet('2026-03-23T23:59:01.000Z', 155, 5, 181), // top / PR
+          makeSet('2026-03-23T23:59:02.000Z', 115, 12, 161),
+        ]),
+      ])
+      const { getSetsForDay } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+
+      const sets = getSetsForDay('2026-03-23', 'Bench Press')
+      expect(sets.map(s => s.estimated1RM)).toEqual([181, 171, 161])
+      expect(sets[0].isPR).toBe(true)
+      expect(sets[1].isPR).toBe(false)
+    })
+
+    it('does not flag any set as PR on a non-record day', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-20T23:59:00.000Z', 155, 5, 181), // PR day
+          makeSet('2026-03-23T23:59:00.000Z', 135, 5, 157), // later, lighter day
+        ]),
+      ])
+      const { getSetsForDay } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+      expect(getSetsForDay('2026-03-23', 'Bench Press').every(s => !s.isPR)).toBe(true)
+    })
+
+    it('returns an empty array for an unknown exercise name', () => {
+      const exercises = ref<Exercise[]>([])
+      const { getSetsForDay } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR([]),
+        displayWeight: identity,
+      })
+      expect(getSetsForDay('2026-03-23', 'Nope')).toEqual([])
+    })
+  })
+
+  describe('getSetCount', () => {
+    it('counts only the sets logged on the given day', () => {
+      const exercises = ref([
+        makeExercise('bench', 'Bench Press', [
+          makeSet('2026-03-23T23:59:00.000Z', 135, 8, 171),
+          makeSet('2026-03-23T23:59:01.000Z', 135, 8, 171),
+          makeSet('2026-03-24T23:59:00.000Z', 135, 8, 171),
+        ]),
+      ])
+      const { getSetCount } = useCalendarData({
+        exercises,
+        selectedDay: ref(null),
+        prBaselineDate: ref(null),
+        getExercisePR: makeGetPR(exercises.value),
+        displayWeight: identity,
+      })
+      expect(getSetCount('2026-03-23', 'Bench Press')).toBe(2)
+      expect(getSetCount('2026-03-24', 'Bench Press')).toBe(1)
+      expect(getSetCount('2026-03-23', 'Nope')).toBe(0)
+    })
+  })
+})

--- a/src/composables/useCalendarData.ts
+++ b/src/composables/useCalendarData.ts
@@ -1,0 +1,159 @@
+import { computed, type ComputedRef, type Ref } from 'vue'
+import type { Exercise, WorkoutSet } from '../stores/workout'
+
+export interface DaySummary {
+  exercises: number
+  sets: number
+  volumeDisplay: string
+  prs: number
+}
+
+export interface CalendarSet extends WorkoutSet {
+  isPR: boolean
+}
+
+export interface UseCalendarDataOptions {
+  /** Exercises to derive the calendar from (already tag-filtered by the view). */
+  exercises: Ref<Exercise[]>
+  /** The currently-selected day key (YYYY-MM-DD) or null. Drives daySummary. */
+  selectedDay: Ref<string | null>
+  /** PR baseline day key — sets before this are excluded from PR resolution. */
+  prBaselineDate: Ref<string | null>
+  /** Store getter: the best e1RM for an exercise on/after an optional baseline. */
+  getExercisePR: (exerciseId: string, sinceDate?: string | null) => number
+  /** Converts a stored (lb) weight into the user's display unit. */
+  displayWeight: (value: number) => number
+}
+
+export interface UseCalendarDataReturn {
+  trainingMap: ComputedRef<Record<string, string[]>>
+  prMap: ComputedRef<Record<string, Set<string>>>
+  daySummary: ComputedRef<DaySummary | null>
+  isPRExercise: (dateStr: string, exName: string) => boolean
+  hasPR: (dateStr: string) => boolean
+  getSetsForDay: (dateStr: string, exName: string) => CalendarSet[]
+  getSetCount: (dateStr: string, exName: string) => number
+}
+
+/**
+ * Owns the calendar's domain derivation — the training map, PR-date resolution,
+ * and per-day summary — so the view is left with only view state and rendering.
+ *
+ * PR-date resolution honours the baseline window and awards the record to the
+ * EARLIEST date a set reached the PR e1RM; later ties are not new records.
+ */
+export function useCalendarData(options: UseCalendarDataOptions): UseCalendarDataReturn {
+  const { exercises, selectedDay, prBaselineDate, getExercisePR, displayWeight } = options
+
+  // Map YYYY-MM-DD → unique exercise names trained that day.
+  const trainingMap = computed(() => {
+    const map: Record<string, string[]> = {}
+    for (const exercise of exercises.value) {
+      for (const set of exercise.sets) {
+        const day = set.date.slice(0, 10)
+        if (!map[day]) map[day] = []
+        if (!map[day].includes(exercise.name)) map[day].push(exercise.name)
+      }
+    }
+    return map
+  })
+
+  // Map YYYY-MM-DD → Set of exercise names that achieved a PR on that date.
+  // Only the first set to reach the PR value counts — ties on later dates are
+  // not new records. Respects the PR baseline: when set, only sets on/after the
+  // baseline count.
+  const prMap = computed(() => {
+    const map: Record<string, Set<string>> = {}
+    const baseline = prBaselineDate.value
+    for (const exercise of exercises.value) {
+      const pr = getExercisePR(exercise.id, baseline)
+      if (!pr) continue
+      // Find the earliest date (within baseline window) any set hit the PR value.
+      let earliestDate = ''
+      for (const set of exercise.sets) {
+        const day = set.date.slice(0, 10)
+        if (baseline && day < baseline) continue
+        if (set.estimated1RM === pr) {
+          if (!earliestDate || day < earliestDate) earliestDate = day
+        }
+      }
+      if (earliestDate) {
+        if (!map[earliestDate]) map[earliestDate] = new Set()
+        map[earliestDate].add(exercise.name)
+      }
+    }
+    return map
+  })
+
+  function isPRExercise(dateStr: string, exName: string): boolean {
+    return prMap.value[dateStr]?.has(exName) ?? false
+  }
+
+  function hasPR(dateStr: string): boolean {
+    return !!(prMap.value[dateStr]?.size > 0)
+  }
+
+  const daySummary = computed((): DaySummary | null => {
+    if (!selectedDay.value || !trainingMap.value[selectedDay.value]) return null
+    const dayStr = selectedDay.value.slice(0, 10)
+    let totalSets = 0
+    let totalVolume = 0
+    let exerciseCount = 0
+    let prCount = 0
+
+    for (const exercise of exercises.value) {
+      const daySets = exercise.sets.filter(s => s.date.slice(0, 10) === dayStr)
+      if (daySets.length === 0) continue
+      exerciseCount++
+      totalSets += daySets.length
+      for (const s of daySets) {
+        totalVolume += s.weight * s.reps
+      }
+      const pr = getExercisePR(exercise.id, prBaselineDate.value)
+      if (pr && daySets.some(s => s.estimated1RM === pr)) {
+        prCount++
+      }
+    }
+
+    const formatted = totalVolume >= 10000
+      ? `${(displayWeight(totalVolume) / 1000).toFixed(1)}k`
+      : String(displayWeight(totalVolume))
+
+    return {
+      exercises: exerciseCount,
+      sets: totalSets,
+      volumeDisplay: formatted,
+      prs: prCount,
+    }
+  })
+
+  function getSetsForDay(dateStr: string, exName: string): CalendarSet[] {
+    const exercise = exercises.value.find(e => e.name === exName)
+    if (!exercise) return []
+    const pr = getExercisePR(exercise.id, prBaselineDate.value)
+    const dayStr = dateStr.slice(0, 10)
+    // Only mark as PR if this is the earliest date the PR was achieved.
+    const isPRDay = prMap.value[dayStr]?.has(exName) ?? false
+    return exercise.sets
+      .filter(s => s.date.slice(0, 10) === dayStr)
+      .sort((a, b) => b.estimated1RM - a.estimated1RM)
+      .map(s => ({ ...s, isPR: isPRDay && s.estimated1RM === pr }))
+  }
+
+  function getSetCount(dateStr: string, exName: string): number {
+    const exercise = exercises.value.find(e => e.name === exName)
+    if (!exercise) return 0
+    const dayStr = dateStr.slice(0, 10)
+    return exercise.sets.filter(s => s.date.slice(0, 10) === dayStr).length
+  }
+
+  return {
+    trainingMap,
+    prMap,
+    daySummary,
+    isPRExercise,
+    hasPR,
+    getSetsForDay,
+    getSetCount,
+  }
+}

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -329,6 +329,7 @@ import { useTagVolumeTrend } from '../composables/useTagVolumeTrend'
 import { useTagRecovery } from '../composables/useTagRecovery'
 import { useVolumeTrend } from '../composables/useVolumeTrend'
 import { useRepRangeDistribution } from '../composables/useRepRangeDistribution'
+import { useCalendarData } from '../composables/useCalendarData'
 
 const MuscleGroupChart = defineAsyncComponent(() => import('../components/MuscleGroupChart.vue'))
 const MuscleGroupRecovery = defineAsyncComponent(() => import('../components/MuscleGroupRecovery.vue'))
@@ -392,86 +393,20 @@ const hasAnyData = computed(() =>
   store.exercises.some(e => e.sets.length > 0)
 )
 
-// Map YYYY-MM-DD → unique exercise names (respects tag filter)
-const trainingMap = computed(() => {
-  const map: Record<string, string[]> = {}
-  for (const exercise of filteredExercises.value) {
-    for (const set of exercise.sets) {
-      const day = set.date.slice(0, 10)
-      if (!map[day]) map[day] = []
-      if (!map[day].includes(exercise.name)) map[day].push(exercise.name)
-    }
-  }
-  return map
-})
-
-// Map YYYY-MM-DD → Set of exercise names that achieved a PR on that date.
-// Only the first set to reach the PR value counts — ties on later dates are not new records.
-// Respects the PR baseline: when set, only sets on/after the baseline count.
-const prMap = computed(() => {
-  const map: Record<string, Set<string>> = {}
-  const baseline = prBaselineDate.value
-  for (const exercise of filteredExercises.value) {
-    const pr = store.getExercisePR(exercise.id, baseline)
-    if (!pr) continue
-    // Find the earliest date (within baseline window) any set hit the PR value
-    let earliestDate = ''
-    for (const set of exercise.sets) {
-      const day = set.date.slice(0, 10)
-      if (baseline && day < baseline) continue
-      if (set.estimated1RM === pr) {
-        if (!earliestDate || day < earliestDate) earliestDate = day
-      }
-    }
-    if (earliestDate) {
-      if (!map[earliestDate]) map[earliestDate] = new Set()
-      map[earliestDate].add(exercise.name)
-    }
-  }
-  return map
-})
-
-function isPRExercise(dateStr: string, exName: string) {
-  return prMap.value[dateStr]?.has(exName) ?? false
-}
-
-function hasPR(dateStr: string) {
-  return !!(prMap.value[dateStr]?.size > 0)
-}
-
-// ── Daily workout summary ────────────────────────────────────────
-const daySummary = computed(() => {
-  if (!selectedDay.value || !trainingMap.value[selectedDay.value]) return null
-  const dayStr = selectedDay.value.slice(0, 10)
-  let totalSets = 0
-  let totalVolume = 0
-  let exerciseCount = 0
-  let prCount = 0
-
-  for (const exercise of filteredExercises.value) {
-    const daySets = exercise.sets.filter(s => s.date.slice(0, 10) === dayStr)
-    if (daySets.length === 0) continue
-    exerciseCount++
-    totalSets += daySets.length
-    for (const s of daySets) {
-      totalVolume += s.weight * s.reps
-    }
-    const pr = store.getExercisePR(exercise.id, prBaselineDate.value)
-    if (pr && daySets.some(s => s.estimated1RM === pr)) {
-      prCount++
-    }
-  }
-
-  const formatted = totalVolume >= 10000
-    ? `${(displayWeight(totalVolume) / 1000).toFixed(1)}k`
-    : String(displayWeight(totalVolume))
-
-  return {
-    exercises: exerciseCount,
-    sets: totalSets,
-    volumeDisplay: formatted,
-    prs: prCount,
-  }
+// ── Calendar domain derivation (training map, PR dates, day summary) ──
+const {
+  trainingMap,
+  daySummary,
+  isPRExercise,
+  hasPR,
+  getSetsForDay,
+  getSetCount,
+} = useCalendarData({
+  exercises: filteredExercises,
+  selectedDay,
+  prBaselineDate,
+  getExercisePR: store.getExercisePR,
+  displayWeight,
 })
 
 // Exercise detail expand: "YYYY-MM-DD::Exercise Name" or null
@@ -486,27 +421,6 @@ function toggleDetail(dateStr: string, exName: string) {
     expandedExercises.value.add(key)
   }
 }
-
-function getSetsForDay(dateStr: string, exName: string) {
-  const exercise = store.exercises.find(e => e.name === exName)
-  if (!exercise) return []
-  const pr = store.getExercisePR(exercise.id, prBaselineDate.value)
-  const dayStr = dateStr.slice(0, 10)
-  // Only mark as PR if this is the earliest date the PR was achieved
-  const isPRDay = prMap.value[dayStr]?.has(exName) ?? false
-  return exercise.sets
-    .filter(s => s.date.slice(0, 10) === dayStr)
-    .sort((a, b) => b.estimated1RM - a.estimated1RM)
-    .map(s => ({ ...s, isPR: isPRDay && s.estimated1RM === pr }))
-}
-
-function getSetCount(dateStr: string, exName: string) {
-  const exercise = store.exercises.find(e => e.name === exName)
-  if (!exercise) return 0
-  const dayStr = dateStr.slice(0, 10)
-  return exercise.sets.filter(s => s.date.slice(0, 10) === dayStr).length
-}
-
 
 // Navigation label
 const navLabel = computed(() => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-917](https://github.com/aschung212/Lift/issues/917)

Implement LIFT-917 by extracting CalendarView's inline domain derivation (training map, PR-date resolution, day summary, per-day set helpers) into a testable `useCalendarData` composable, leaving the view responsible only for view state and rendering. Scoped exactly to the issue's proposed approach — behavior-preserving, fully tested.

## Changes
- **`src/composables/useCalendarData.ts`** (new) — owns `trainingMap`, `prMap`, `daySummary`, `isPRExercise`, `hasPR`, `getSetsForDay`, `getSetCount`. Takes filtered exercises + `selectedDay` + `prBaselineDate` + the store's `getExercisePR` + `displayWeight` as injected dependencies, so PR-date resolution is unit-testable in isolation and reuses `getExercisePR` rather than re-deriving.
- **`src/views/CalendarView.vue`** — replaced ~90 lines of inline derivation with a single `useCalendarData({...})` call; the view retains cursor/selectedDay/view-mode state and rendering. No template changes.
- **`src/composables/__tests__/useCalendarData.test.ts`** (new) — 11 tests covering training-map reactivity, earliest-record vs later-tie PR resolution, baseline windowing, day-summary aggregation + k-suffix volume formatting, sorted PR-flagged set rows, and set counts.

## Verification
- `npm run lint` — clean
- `npm run build` — typecheck + build pass
- Full suite: **2337 passed** (122 files), up from 2326 (+11 new)
- CalendarView tests: 54 passed (no regressions)

## Screenshots
None — pure refactor, no visual or behavioral change.

## Commits
- [`a830f96`](https://github.com/aschung212/Lift/commit/a830f96) refactor(LIFT-917): extract calendar domain derivation into useCalendarData

## Test Results
- Before: 2326 passing
- After: 2337 passing (11 delta)

---
_Automated by overnight pipeline — Wed Jul  8 23:53:53 PDT 2026_

## Preview
Test on your phone: https://lift-nugjwmd94-aschung212-1101s-projects.vercel.app