### PR TITLE
feat(LIFT-925): show previous-session set reference inline in the log-set modal

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -559,6 +559,16 @@
             which after step 5c removed the in-card weight display would
             leave the user with no visible weight at all).
           -->
+          <!--
+            Passive "last time" reference (#925): what you did for this same set
+            number last session, shown right above the inputs so you can beat it
+            without leaving the modal. Non-interactive by design — quick-fill
+            lives in the Suggestions drawer chips (one interaction path).
+          -->
+          <div v-if="prevSessionSetRef" class="wtLastTimeRef">
+            <span class="wtLastTimeRefLabel">Last time · Set {{ prevSessionSetRef.setNumber }}</span>
+            <span class="wtLastTimeRefValue">{{ displayWeight(prevSessionSetRef.weight) }} {{ weightUnit }} × {{ prevSessionSetRef.reps }}</span>
+          </div>
           <div class="wtInputRow logSetFieldsRow">
             <label :class="['repMaxLabel', 'logSetField', 'logSetFieldWeight', { logSetFieldActive: weightHasValue }]">
               <span class="logSetFieldLabel">Weight <span class="logSetFieldLabelUnit">({{ weightUnit }})</span></span>
@@ -1193,6 +1203,27 @@ function fillFromLastSession(set: { weight: number; reps: number }, index: numbe
   repsStr.value = String(set.reps)
   lastSessionUsed.value = { ...lastSessionUsed.value, [index]: true }
 }
+
+// ── Passive "last time" reference for the current set position (#925) ──
+// Hevy-style historical readout shown beside the inputs: what you did for THIS
+// set number last session, so you can beat it without leaving the modal. This
+// is deliberately passive (non-interactive) and distinct from the tappable
+// last-session chips (quick-fill) and PR targets — it's an always-visible
+// reference for the exact set about to be logged. The set index is how many
+// sets of this exercise are already logged today; once today's session runs
+// longer than last time it clamps to last session's final set.
+const prevSessionSetRef = computed<{ weight: number; reps: number; setNumber: number } | null>(() => {
+  if (isEditMode.value || !isLogForExercise.value) return null
+  const prev = lastSession.value
+  if (!prev || prev.sets.length === 0) return null
+  const ex = store.exercises.find(e => e.id === selectedExerciseId.value)
+  if (!ex) return null
+  const today = todayISO()
+  const loggedToday = ex.sets.reduce((n, s) => (setDayKey(s.date) === today ? n + 1 : n), 0)
+  const idx = Math.min(loggedToday, prev.sets.length - 1)
+  const refSet = prev.sets[idx]
+  return { weight: refSet.weight, reps: refSet.reps, setNumber: idx + 1 }
+})
 
 // ── Intensity lens: PR/1RM-anchored weight × reps table (#770) ─────
 // A slider picks an intensity (% of the exercise's best e1RM); the table shows,

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -1174,6 +1174,88 @@ describe('WorkoutTracker', () => {
     })
   })
 
+  describe('last-time reference (#925)', () => {
+    function localDay(daysAgo = 0): string {
+      const d = new Date()
+      d.setDate(d.getDate() - daysAgo)
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    }
+
+    /** Two-set prior session used as the historical reference. */
+    function priorSession() {
+      return {
+        date: '2026-01-20',
+        sets: [
+          { id: 's-a', date: '2026-01-20T12:00:00', weight: 185, reps: 8, estimated1RM: 231 },
+          { id: 's-b', date: '2026-01-20T12:00:00', weight: 205, reps: 5, estimated1RM: 239 },
+        ],
+      }
+    }
+
+    /** Appends `count` sets dated today to ex-1 so the set-position advances. */
+    function seedTodaySets(count: number) {
+      for (let i = 0; i < count; i++) {
+        mockState.exercises[0].sets.push({
+          id: `s-today-${i}`,
+          date: `${localDay()}T23:59:00.000Z`,
+          weight: 100,
+          reps: 10,
+          estimated1RM: 133,
+        })
+      }
+    }
+
+    async function openBenchModal(wrapper: VueWrapper) {
+      await wrapper.findAll('.wtExerciseLogBtn')[0].trigger('click')
+      await wrapper.vm.$nextTick()
+    }
+
+    beforeEach(() => {
+      mockState.exercises = createExercises()
+    })
+
+    it('shows the first prior-session set when no sets are logged today', async () => {
+      mockGetLastSession.mockReturnValue(priorSession())
+      const wrapper = mountTracker()
+      await openBenchModal(wrapper)
+
+      const ref = wrapper.find('.wtLastTimeRef')
+      expect(ref.exists()).toBe(true)
+      expect(ref.find('.wtLastTimeRefLabel').text()).toBe('Last time · Set 1')
+      expect(ref.find('.wtLastTimeRefValue').text()).toBe('185 lbs × 8')
+    })
+
+    it('advances the reference to the matching set position as today fills in', async () => {
+      mockGetLastSession.mockReturnValue(priorSession())
+      seedTodaySets(1)
+      const wrapper = mountTracker()
+      await openBenchModal(wrapper)
+
+      const ref = wrapper.find('.wtLastTimeRef')
+      expect(ref.find('.wtLastTimeRefLabel').text()).toBe('Last time · Set 2')
+      expect(ref.find('.wtLastTimeRefValue').text()).toBe('205 lbs × 5')
+    })
+
+    it('clamps to the final prior set once today runs longer than last time', async () => {
+      mockGetLastSession.mockReturnValue(priorSession())
+      seedTodaySets(5)
+      const wrapper = mountTracker()
+      await openBenchModal(wrapper)
+
+      const ref = wrapper.find('.wtLastTimeRef')
+      expect(ref.find('.wtLastTimeRefLabel').text()).toBe('Last time · Set 2')
+      expect(ref.find('.wtLastTimeRefValue').text()).toBe('205 lbs × 5')
+    })
+
+    it('renders nothing when there is no prior session', async () => {
+      mockGetLastSession.mockReturnValue(null)
+      const wrapper = mountTracker()
+      await openBenchModal(wrapper)
+
+      expect(wrapper.find('.wtLastTimeRef').exists()).toBe(false)
+    })
+  })
+
   describe('overload nudge (#741)', () => {
     function localDay(daysAgo = 0): string {
       const d = new Date()

--- a/src/index.css
+++ b/src/index.css
@@ -5196,6 +5196,35 @@ html.theme-fading .settingsSheet {
   cursor: default;
 }
 
+/* Passive "last time" reference above the weight/reps inputs (#925) — a
+   greyed Hevy-style readout of the same set number from last session. */
+.wtLastTimeRef {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 8px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+}
+
+.wtLastTimeRefLabel {
+  font-size: var(--font-caption2);
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.wtLastTimeRefValue {
+  font-size: var(--font-footnote);
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
 /* ─── XP toast ───────────────────────────────────────────────────── */
 
 .xpToast {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-925](https://github.com/aschung212/Lift/issues/925)

Implement LIFT-925: a passive, always-visible "last time" reference in the log-set modal showing the previous-session set for the current set position (Hevy-style progressive-overload affordance), distinct from the existing tappable quick-fill chips and PR targets.

## Changes
- **`src/components/WorkoutTracker.vue`** — Added `prevSessionSetRef` computed that resolves the previous session's set at the current set position (index = sets already logged today for that exercise), clamping to last session's final set when today runs longer. Added a non-interactive `.wtLastTimeRef` readout directly above the weight/reps input row.
- **`src/index.css`** — Added `.wtLastTimeRef` / `.wtLastTimeRefLabel` / `.wtLastTimeRefValue` styles using theme CSS custom properties, the app's type/spacing scale, and tabular-nums.
- **`src/components/__tests__/WorkoutTracker.test.ts`** — New `last-time reference (#925)` describe block with 4 regression tests (first set shown, position advances with today's sets, clamps past last-session length, hidden when no prior session).

## Verification
- WorkoutTracker suite: 155 passed (incl. 4 new tests)
- `npm run lint`: clean
- `npm run build`: succeeds
- Note: the pre-push Gemini review hook failed to authenticate (`IneligibleTierError` — Gemini Code Assist infra/tier issue, unrelated to this diff). Push to `origin/enhance/run1-2026-07-09` completed successfully.

## Screenshots
Not captured (headless iteration). The reference renders as a dim bordered row — `Last time · Set N` on the left, `185 lbs × 8` on the right — above the weight/reps inputs; visible only in log mode for an existing exercise with a prior session.

## Commits
- [`ebef8af`](https://github.com/aschung212/Lift/commit/ebef8af) feat(LIFT-925): show previous-session set reference inline in the log-set modal

## Test Results
- Before: 2499 passing
- After: 2503 passing (4 delta)

---
_Automated by overnight pipeline — Thu Jul  9 23:09:01 PDT 2026_

## Preview
Test on your phone: https://lift-71m497bjx-aschung212-1101s-projects.vercel.app