### PR TITLE
feat(coach): bring-your-own-AI export mode — client-side, no server (#931)

### DIFF
--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -1,6 +1,9 @@
 # AI Coach — Weekly Review (design)
 
 Status: **Phase 1 in progress** (backend scaffold landed; UI + consent + deletion wiring remain).
+The live transport today is the **bring-your-own-AI export** (open loop, no server) — see below —
+because the Anthropic key the server needs isn't provisioned yet. Flip `COACH_MODE` to `'server'`
+in `src/lib/coachExport.ts` once it is.
 
 An opt-in feature where a user taps once and gets an LLM-generated **Weekly Review** of
 their training — a fixed-shape digest rendered as themed cards. It is the smallest surface
@@ -28,6 +31,28 @@ Lift is a pure static SPA today — **zero server-side compute** before this fea
 trust boundary (key secrecy, quota, consent) depends on a backend that did not exist. So the
 **first deliverable is the backend** (`api/coach.ts` + the migration), and the client-side
 counter is cosmetic — the server is the only real cap.
+
+## Bring-your-own-AI export (interim transport + permanent free tier) — #931
+
+The whole coaching brain is pure and client-side (`buildCoachPayload`, `COACH_SYSTEM_PROMPT`,
+`buildCoachUserMessage`); the server only ever added the API key, the quota, and the network
+destination. So until the key is provisioned we deliver the value with **zero server**:
+
+- `src/lib/coachExport.ts` composes the recommended prompt + the `<data>` block into one
+  paste-ready text (`buildCoachExportText`). Because this is read in the user's own chat, the
+  prompt asks for **prose in the four sections**, not the server's `CoachReview` JSON.
+- `CoachSheet` (when `COACH_MODE === 'byo'`) renders an export panel: a bodyweight opt-out
+  (passes `[]` to `buildCoachPayload`), a "nothing leaves Lift until you paste it" disclosure,
+  and **Copy to clipboard** + **Download `.md`** actions. The server states stay intact behind
+  `mode === 'server'`.
+- **Open loop by decision:** no paste-back / JSON round-trip — the coaching lives in the chat.
+- No key, no quota, no consent-to-transmit surface (nothing is sent), so the entry card drops the
+  sign-in gate in this mode. This also stands as a permanent **free / privacy tier** after the
+  server exists: a user's data never leaves the device unless they paste it themselves.
+
+`COACH_MODE` (in `coachExport.ts`) is the single switch: `'byo'` today, `'server'` once
+`ANTHROPIC_API_KEY` et al. are provisioned. Consent (#849) and history (#851) remain their own
+follow-ups; the BYO disclosure is a lightweight stand-in, not the versioned consent modal.
 
 ## Locked decisions
 
@@ -195,6 +220,11 @@ disclosure work must ship in the **same PR as the UI** (CLAUDE.md Documentation 
   gated by `coachReviewEligibility` (≥`MIN_SETS_FOR_REVIEW` sets across ≥2 weeks) AND signed-in
   AND not a preview deploy; it doubles as the quota meter. The view wires `buildCoachPayload` to
   the stores (`getOverloadSuggestion` → `overloads`, `streakWeeks`/`weeklyTarget`, `toDisplayUnits`).
+
+- **Bring-your-own-AI export (#931)** — `src/lib/coachExport.ts` (`COACH_MODE`,
+  `RECOMMENDED_COACH_PROMPT`, `buildCoachExportText`, `coachExportFilename`) + the `CoachSheet`
+  export panel (copy / download / bodyweight opt-out) + tests. This is the live transport while
+  the server key is unprovisioned (`COACH_MODE = 'byo'`). See the section above.
 
 **Remaining Phase 1:**
 - Versioned consent modal + `LegalSheet` update + hosted `/privacy` + nutrition-label answers

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -779,6 +779,7 @@ import { computeWeeklyGoal } from '../lib/weeklyGoal'
 import ExerciseDetailModal from '../views/ExerciseDetailModal.vue'
 const CoachSheet = defineAsyncComponent(() => import('../views/CoachSheet.vue'))
 import { coachReviewEligibility } from '../lib/coachDigest'
+import { COACH_MODE } from '../lib/coachExport'
 import { useCoach } from '../composables/useCoach'
 import { useAuth } from '../composables/useAuth'
 import { isPreviewMode } from '../lib/supabase'
@@ -801,13 +802,19 @@ const { user: authUser } = useAuth()
 // ── AI Coach weekly review (LIFT-848) ────────────────────────────
 const coachOpen = ref(false)
 // Gate the entry card like the Suggestions drawer gates its lenses: only when
-// there's enough signal (a couple training weeks + the server's set floor), the
-// user is signed in (the proxy is auth-gated), and not on a preview deploy.
+// there's enough signal (a couple training weeks + the server's set floor) and
+// not on a preview deploy. In the server transport the proxy is auth-gated so we
+// also require a signed-in user; the BYO export is 100% local (nothing is sent),
+// so it needs no account — requiring sign-in to copy your own data would be odd.
 const coachEligible = computed(() => coachReviewEligibility(store.exercises, new Date()).eligible)
 const showCoachCard = computed(
-  () => coachEligible.value && authUser.value !== null && !isPreviewMode.value,
+  () =>
+    coachEligible.value &&
+    !isPreviewMode.value &&
+    (COACH_MODE === 'byo' || authUser.value !== null),
 )
 const coachCardMeta = computed(() => {
+  if (COACH_MODE === 'byo') return 'Bring your own AI'
   const n = coach.remaining.value
   if (n === null) return 'AI-written · once a week'
   if (n <= 0) {

--- a/src/lib/__tests__/coachExport.test.ts
+++ b/src/lib/__tests__/coachExport.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  COACH_MODE,
+  RECOMMENDED_COACH_PROMPT,
+  buildCoachExportText,
+  coachExportFilename,
+} from '../coachExport'
+import { COACH_SYSTEM_PROMPT, type CoachPayload } from '../aiCoach'
+
+const PAYLOAD: CoachPayload = {
+  weightUnit: 'lb',
+  windowDays: 112,
+  sets: [
+    { exercise: 'Bench Press', weightLbs: 185, reps: 5, e1rm: 208, date: '2026-07-01', intensityPct: 92, pr: true },
+  ],
+  sessions: [{ date: '2026-07-01', tags: ['chest'], setCount: 12 }],
+  prs: [{ exercise: 'Bench Press', e1rm: 208, date: '2026-07-01' }],
+  volumeByGroup: [{ group: 'chest', sets: 12 }],
+  consistency: { sessions: 4, weeks: 1 },
+  focus: [],
+} as unknown as CoachPayload
+
+describe('coachExport — recommended prompt', () => {
+  it('reuses the server coaching guidance verbatim', () => {
+    expect(RECOMMENDED_COACH_PROMPT).toContain(COACH_SYSTEM_PROMPT)
+  })
+
+  it('asks for readable prose, not the server JSON schema (open loop)', () => {
+    expect(RECOMMENDED_COACH_PROMPT).toMatch(/no JSON/i)
+    expect(RECOMMENDED_COACH_PROMPT).toContain('Focus next')
+  })
+})
+
+describe('coachExport — buildCoachExportText', () => {
+  it('embeds the prompt and the delimited data block', () => {
+    const text = buildCoachExportText(PAYLOAD)
+    expect(text).toContain(RECOMMENDED_COACH_PROMPT)
+    expect(text).toContain('<data>')
+    expect(text).toContain('</data>')
+    // The actual training data is serialized inside the block.
+    expect(text).toContain('Bench Press')
+  })
+
+  it('puts the prompt before the data so a user can swap in their own', () => {
+    const text = buildCoachExportText(PAYLOAD)
+    expect(text.indexOf(RECOMMENDED_COACH_PROMPT)).toBeLessThan(text.indexOf('<data>'))
+  })
+})
+
+describe('coachExport — coachExportFilename', () => {
+  it('builds a dated markdown filename from a local date key', () => {
+    expect(coachExportFilename('2026-07-10')).toBe('lift-weekly-review-2026-07-10.md')
+  })
+
+  it('falls back safely when handed a non-date-key string', () => {
+    expect(coachExportFilename('not-a-date')).toBe('lift-weekly-review-review.md')
+  })
+})
+
+describe('coachExport — mode switch', () => {
+  it('defaults to the client-side bring-your-own transport', () => {
+    expect(COACH_MODE).toBe('byo')
+  })
+})

--- a/src/lib/coachExport.ts
+++ b/src/lib/coachExport.ts
@@ -1,0 +1,63 @@
+/**
+ * AI Coach — "bring your own AI" export (issue #931).
+ *
+ * The server proxy (`api/coach.ts`) holds the Anthropic key and enforces quota,
+ * but that key isn't provisioned yet, so the server flow is dormant. Meanwhile
+ * the whole coaching brain is already pure and client-side:
+ *   - `buildCoachPayload` builds the training digest on-device,
+ *   - `COACH_SYSTEM_PROMPT` is provider-agnostic coaching guidance,
+ *   - `buildCoachUserMessage` serializes the payload into a delimited data block.
+ *
+ * This module composes those into a single ready-to-paste block the user hands
+ * to their OWN LLM (Claude, ChatGPT, …). Nothing is sent anywhere by Lift — the
+ * user copies or downloads it and chooses where to paste. This is an OPEN loop:
+ * the coaching lives in the user's chat; there is no JSON round-trip back into
+ * the app (that's why the recommended prompt asks for prose, not the server's
+ * fixed `CoachReview` schema).
+ *
+ * Pure by design (no browser/network/`import.meta`) so it unit-tests directly
+ * and the same text is produced everywhere.
+ */
+
+import type { CoachPayload } from './aiCoach'
+import { COACH_SYSTEM_PROMPT, buildCoachUserMessage } from './aiCoach'
+
+/**
+ * Active transport for the Weekly Review.
+ *   - `'byo'`  — this module: user pastes into their own LLM. No key, no server.
+ *   - `'server'` — the `api/coach.ts` proxy. Flip here once an Anthropic key is
+ *     provisioned; the server code path stays intact meanwhile.
+ * Kept as a single switch so turning the real backend on is a one-line change,
+ * not a rewrite.
+ */
+export const COACH_MODE: 'byo' | 'server' = 'byo'
+
+/**
+ * The recommended prompt shown to (and exported for) the user. Reuses the exact
+ * coaching instructions the server sends, then — because this is an open loop
+ * read in a chat window, not parsed by the app — asks for readable prose in the
+ * feature's four sections instead of the server's JSON schema.
+ */
+export const RECOMMENDED_COACH_PROMPT = [
+  COACH_SYSTEM_PROMPT,
+  'Write your review as plain, readable text a lifter can skim on a phone — no JSON, no code blocks, no markdown tables.',
+  'Use up to four short sections with these headings, and omit any heading whose signal is weak or absent: "Progress", "Volume", "Consistency", and a final "Focus next" naming the single most useful thing to work on.',
+].join('\n\n')
+
+/**
+ * The full, copy-paste-ready export: the recommended prompt followed by the
+ * training data as a delimited `<data>` block. A user who prefers their own
+ * prompt can simply replace everything above the `<data>` block.
+ */
+export function buildCoachExportText(payload: CoachPayload): string {
+  return `${RECOMMENDED_COACH_PROMPT}\n\n${buildCoachUserMessage(payload)}\n`
+}
+
+/**
+ * Download filename for the export. Caller passes a local date key
+ * (`YYYY-MM-DD`, e.g. from `todayISO()`) so this stays pure/testable.
+ */
+export function coachExportFilename(dateKey: string): string {
+  const safe = /^\d{4}-\d{2}-\d{2}$/.test(dateKey) ? dateKey : 'review'
+  return `lift-weekly-review-${safe}.md`
+}

--- a/src/views/CoachSheet.vue
+++ b/src/views/CoachSheet.vue
@@ -12,15 +12,62 @@
         <header class="coachHeader">
           <div class="coachHeaderText">
             <h2 id="coachSheetTitle" class="coachTitle">Weekly Review</h2>
-            <p class="coachSub">{{ quotaLabel }}</p>
+            <p class="coachSub">{{ mode === 'byo' ? 'Bring your own AI' : quotaLabel }}</p>
           </div>
           <button class="coachClose" @click="close" aria-label="Close weekly review">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </header>
 
+        <!-- Bring-your-own-AI export (open loop): build a paste-ready prompt +
+             training data; the coaching lives in the user's own chat (#931). -->
+        <div v-if="mode === 'byo'" class="coachBody">
+          <p class="coachIntro">
+            Build a summary of your recent training, then paste it into your own AI
+            chat — Claude, ChatGPT, or any other — for a written weekly review.
+          </p>
+
+          <div class="coachToggleRow">
+            <div class="coachToggleLabel">
+              <span class="coachToggleTitle">Include bodyweight</span>
+              <span class="coachToggleHint">Your logged bodyweight is the most personal field.</span>
+            </div>
+            <button
+              :class="['glassToggle', { on: includeBodyweight }]"
+              role="switch"
+              :aria-checked="includeBodyweight"
+              :aria-label="includeBodyweight ? 'Exclude bodyweight from the export' : 'Include bodyweight in the export'"
+              @click="includeBodyweight = !includeBodyweight"
+            >
+              <span class="glassToggleThumb"></span>
+            </button>
+          </div>
+
+          <p class="coachPrivacyNote">
+            Nothing leaves Lift until you paste it — this only copies your training
+            data to your clipboard or saves it to a file.
+          </p>
+
+          <div class="coachExportActions">
+            <button class="coachPrimaryBtn" :disabled="!canGenerate" @click="copyExport">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>
+              {{ copyLabel }}
+            </button>
+            <button class="coachSecondaryBtn" :disabled="!canGenerate" @click="downloadExport">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12M7 10l5 5 5-5"/><path d="M5 21h14"/></svg>
+              Download file
+            </button>
+          </div>
+          <p v-if="!canGenerate" class="coachHint">{{ disabledReason }}</p>
+
+          <details class="coachPromptPreview">
+            <summary class="coachPromptSummary">Preview what gets shared</summary>
+            <pre class="coachPromptText">{{ exportText }}</pre>
+          </details>
+        </div>
+
         <!-- pick / idle -->
-        <div v-if="coach.state.value === 'idle'" class="coachBody">
+        <div v-else-if="coach.state.value === 'idle'" class="coachBody">
           <p class="coachIntro">
             A quick, AI-written read of your recent training — what's progressing, where your
             volume sits, how consistent you've been, and the single thing to focus on next.
@@ -93,7 +140,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import SkeletonLoader from '../components/SkeletonLoader.vue'
 import { useModal } from '../composables/useModal'
 import { useCoach } from '../composables/useCoach'
@@ -104,8 +151,15 @@ import { useProgressionStore } from '../stores/progression'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { buildCoachPayload, type ExerciseOverload } from '../lib/coachDigest'
 import type { CoachSectionType } from '../lib/aiCoach'
+import { COACH_MODE, buildCoachExportText, coachExportFilename } from '../lib/coachExport'
 import { todayISO } from '../lib/dates'
 import { isPreviewMode } from '../lib/supabase'
+
+const props = withDefaults(
+  defineProps<{ mode?: 'byo' | 'server' }>(),
+  { mode: COACH_MODE },
+)
+const mode = computed(() => props.mode)
 
 const emit = defineEmits<{ (e: 'close'): void }>()
 
@@ -174,20 +228,70 @@ const errorMessage = computed(() => {
   return (kind && ERROR_MESSAGES[kind]) || ERROR_MESSAGES.unknown
 })
 
-function buildPayload() {
+function buildPayload(includeBodyweightEntries = true) {
   const overloads: ExerciseOverload[] = store.exercises.map((ex) => ({
     exerciseName: ex.name,
     suggestion: store.getOverloadSuggestion(ex.id, todayISO()),
   }))
   return buildCoachPayload({
     exercises: store.exercises,
-    bodyweightEntries: bodyweightStore.entries,
+    bodyweightEntries: includeBodyweightEntries ? bodyweightStore.entries : [],
     overloads,
     weightUnit: weightUnit.value,
     weeklyTarget: progressionStore.weeklyTarget,
     streakWeeks: progressionStore.streakWeeks,
     toDisplayUnits: (lb) => displayWeight(lb),
   })
+}
+
+// ── Bring-your-own-AI export (#931) ──────────────────────────────
+const includeBodyweight = ref(true)
+const exportText = computed(() => buildCoachExportText(buildPayload(includeBodyweight.value)))
+
+const copyState = ref<'idle' | 'copied' | 'error'>('idle')
+const copyLabel = computed(() =>
+  copyState.value === 'copied'
+    ? 'Copied to clipboard'
+    : copyState.value === 'error'
+      ? 'Copy failed — try again'
+      : 'Copy to clipboard',
+)
+let copyResetTimer: ReturnType<typeof setTimeout> | undefined
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch {
+    /* clipboard blocked or unavailable — fall through */
+  }
+  return false
+}
+
+async function copyExport() {
+  if (!canGenerate.value) return
+  const ok = await copyToClipboard(exportText.value)
+  copyState.value = ok ? 'copied' : 'error'
+  // Analytics carry only booleans/counts — never the training data itself.
+  logEvent('coach_export_copied', { ok, bodyweight: includeBodyweight.value })
+  clearTimeout(copyResetTimer)
+  copyResetTimer = setTimeout(() => { copyState.value = 'idle' }, 2500)
+}
+
+function downloadExport() {
+  if (!canGenerate.value) return
+  const blob = new Blob([exportText.value], { type: 'text/markdown' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = coachExportFilename(todayISO())
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+  URL.revokeObjectURL(url)
+  logEvent('coach_export_downloaded', { bodyweight: includeBodyweight.value })
 }
 
 async function generate() {
@@ -213,6 +317,7 @@ onMounted(() => {
   logEvent('coach_opened', {})
 })
 onUnmounted(() => {
+  clearTimeout(copyResetTimer)
   deactivateModal()
 })
 </script>
@@ -319,6 +424,89 @@ onUnmounted(() => {
   font-size: var(--font-footnote);
   color: var(--text-muted);
   text-align: center;
+}
+
+/* ── Bring-your-own-AI export (#931) ── */
+.coachToggleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.coachToggleLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.coachToggleTitle {
+  font-family: var(--ff);
+  font-weight: 600;
+  font-size: var(--font-callout);
+  color: var(--text-primary);
+}
+
+.coachToggleHint {
+  font-family: var(--ff);
+  font-size: var(--font-footnote);
+  color: var(--text-muted);
+}
+
+.coachPrivacyNote {
+  margin: 0;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  font-family: var(--ff);
+  font-size: var(--font-footnote);
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.coachExportActions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.coachPromptPreview {
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.coachPromptSummary {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  font-family: var(--ff);
+  font-weight: 600;
+  font-size: var(--font-footnote);
+  color: var(--text-secondary);
+  cursor: pointer;
+  list-style: none;
+}
+
+.coachPromptSummary::-webkit-details-marker {
+  display: none;
+}
+
+.coachPromptText {
+  margin: 8px 0 0;
+  max-height: 220px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: 12px;
+  border-radius: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  font-family: var(--ff-mono, ui-monospace, monospace);
+  font-size: var(--font-caption2, 11px);
+  line-height: 1.4;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .coachStatus {

--- a/src/views/__tests__/CoachSheet.test.ts
+++ b/src/views/__tests__/CoachSheet.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mount, type VueWrapper } from '@vue/test-utils'
+import { mount, flushPromises, type VueWrapper } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import CoachSheet from '../CoachSheet.vue'
 import { useCoach } from '../../composables/useCoach'
@@ -34,8 +34,8 @@ const REVIEW: CoachReview = {
 
 let wrapper: VueWrapper | null = null
 
-function mountSheet() {
-  wrapper = mount(CoachSheet, { attachTo: document.body })
+function mountSheet(props: { mode?: 'byo' | 'server' } = { mode: 'server' }) {
+  wrapper = mount(CoachSheet, { attachTo: document.body, props })
   return wrapper
 }
 
@@ -150,5 +150,83 @@ describe('CoachSheet — states', () => {
     closeBtn!.click()
     await nextTick()
     expect(w.emitted('close')).toBeTruthy()
+  })
+})
+
+describe('CoachSheet — bring-your-own-AI export (open loop)', () => {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  const clickNames: string[] = []
+
+  beforeEach(() => {
+    writeText.mockClear()
+    clickNames.length = 0
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    URL.createObjectURL = vi.fn(() => 'blob:mock')
+    URL.revokeObjectURL = vi.fn()
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (
+      this: HTMLAnchorElement,
+    ) {
+      clickNames.push(this.download)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the export panel instead of the server state machine', () => {
+    mountSheet({ mode: 'byo' })
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('Bring your own AI')
+    expect(text).toContain('Copy to clipboard')
+    expect(text).toContain('Download file')
+    expect(text).toContain('Nothing leaves Lift until you paste it')
+    // Server affordances are absent.
+    expect(text).not.toContain('Generate review')
+    expect(document.body.querySelector('.coachExportActions')).not.toBeNull()
+  })
+
+  it('copies the recommended prompt + training data to the clipboard', async () => {
+    mountSheet({ mode: 'byo' })
+    const copyBtn = [...document.body.querySelectorAll<HTMLButtonElement>('.coachPrimaryBtn')].find(
+      (b) => /Copy to clipboard/.test(b.textContent ?? ''),
+    )
+    expect(copyBtn).not.toBeNull()
+    copyBtn!.click()
+    await flushPromises()
+    await nextTick()
+    expect(writeText).toHaveBeenCalledTimes(1)
+    const payloadText = writeText.mock.calls[0][0] as string
+    // Carries the coaching instructions AND the delimited data block.
+    expect(payloadText).toContain('strength-training coach')
+    expect(payloadText).toContain('<data>')
+    // Open loop: the prompt asks for prose, not the server's JSON schema.
+    expect(payloadText).toContain('no JSON')
+    expect(document.body.textContent).toContain('Copied to clipboard')
+  })
+
+  it('downloads the export as a dated markdown file', async () => {
+    mountSheet({ mode: 'byo' })
+    const dlBtn = [...document.body.querySelectorAll<HTMLButtonElement>('.coachSecondaryBtn')].find(
+      (b) => /Download file/.test(b.textContent ?? ''),
+    )
+    expect(dlBtn).not.toBeNull()
+    dlBtn!.click()
+    await nextTick()
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+    expect(clickNames[0]).toMatch(/^lift-weekly-review-\d{4}-\d{2}-\d{2}\.md$/)
+  })
+
+  it('exposes a bodyweight opt-out that starts included and toggles off', async () => {
+    mountSheet({ mode: 'byo' })
+    const toggle = document.body.querySelector<HTMLButtonElement>('.coachToggleRow .glassToggle')
+    expect(toggle).not.toBeNull()
+    expect(toggle!.getAttribute('aria-checked')).toBe('true')
+    toggle!.click()
+    await nextTick()
+    expect(toggle!.getAttribute('aria-checked')).toBe('false')
   })
 })


### PR DESCRIPTION
## Summary
Closes #931.

The AI Coach Weekly Review depends on a server proxy (`api/coach.ts`) that holds an Anthropic API key. That key isn't provisioned yet (a Claude **Max** subscription is not API access — see `docs/ai-coach.md`), so the server flow is dormant in production. But the entire coaching brain is already **pure and client-side** — `buildCoachPayload`, `COACH_SYSTEM_PROMPT`, and `buildCoachUserMessage`. The server only ever added the key, the quota, and the network destination.

So this ships the coaching value **today, with zero server**: build the digest on-device, hand the user a ready-to-paste **prompt + training data**, and let them paste it into their own LLM (Claude, ChatGPT, …).

**Open loop by decision** — no paste-back / JSON round-trip; the coaching lives in the user's chat. The server path stays intact behind a `COACH_MODE` flag, and BYO also stands on its own as a permanent free / privacy tier (data never leaves the device unless the user pastes it).

## Changes
- **`src/lib/coachExport.ts`** (new, pure) — `COACH_MODE` switch (`'byo'` now → flip to `'server'` when the key lands, no code deleted); `RECOMMENDED_COACH_PROMPT` (reuses the server `COACH_SYSTEM_PROMPT` + a prose/"no JSON" instruction, because this is read in a chat, not parsed by the app); `buildCoachExportText`; `coachExportFilename`.
- **`src/views/CoachSheet.vue`** — in BYO mode renders an export panel: a **bodyweight opt-out** (passes `[]` to `buildCoachPayload`), a *"nothing leaves Lift until you paste it"* disclosure, a collapsible payload preview, and **Copy to clipboard** + **Download `.md`** actions (reusing the `navigator.clipboard` pattern from `useAppShare`). Server states stay behind `mode === 'server'` via a new `mode` prop.
- **`src/components/WorkoutTracker.vue`** — BYO entry-card subtitle ("Bring your own AI"); **drops the sign-in gate** in BYO mode — a purely local export needs no account.
- **Tests** — `coachExport.test.ts` (prompt/export/filename/mode) + BYO-mode `CoachSheet.test.ts` cases (panel render, real `clipboard.writeText`, dated file download, bodyweight toggle). Existing server-state tests pinned to `mode: 'server'`.
- **`docs/ai-coach.md`** — documents the bridge transport and the `COACH_MODE` switch.

## Out of scope (unchanged follow-ups)
- Paste-back / structured re-render (open loop by decision).
- Consent gate (#849) and history (#851) — the inline disclosure is a lightweight stand-in, not the versioned consent modal.
- Native file-save via the iOS share sheet (web `Blob` download this phase).

## Verification
- `npm run lint`, `npm run typecheck` — clean.
- `npx vitest run` — **2553 pass** (+11), 1 skipped.
- `npm run build` — passes; JS bundle **516 KB** (< 550 KB budget). `CoachSheet` code-split (9.6 kB / 3.8 kB gz).
- Dev server compiles the change with zero errors. Browser-pane visual check was blocked by an origin-approval gate in this environment; the four BYO behaviors are exercised at the DOM level by component tests (real clipboard/download/toggle) instead of a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)