### PR TITLE
feat(coach): explicit per-exercise equipment classification (#931 phase C)

### DIFF
--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -81,10 +81,16 @@ destination. So until the key is provisioned we deliver the value with **zero se
   sets + first-set % of top), session shape medians, weekly volume & frequency per muscle tag
   (incl. median rest-gap days), intensity distribution (at-the-time %: <60 / 60–85 / >85), rep-range
   distribution (≤6 / 7–12 / ≥13), and within-session exercise order. Two honesty rules:
-  (1) equipment classification is a conservative NAME HEURISTIC (`classifyExercise`:
+  (1) equipment classification is **two-layered** (`resolveExerciseKind`, phase C): the explicit
+  per-exercise `Exercise.equipment` field wins — user-set in EditExerciseModal's "Equipment"
+  chips (Auto / Free weight / Machine / Bodyweight, where Auto stores nothing and shows what the
+  heuristic resolves to), synced via the additive `equipment` text column (always-send like
+  `intensity_max_reps`, so "Auto" clears server-side), sanitized at every boundary
+  (`sanitizeExerciseEquipment`: store setter, localStorage load, remote fetch — unknown values
+  degrade to unset, never trusted) — and the conservative NAME HEURISTIC (`classifyExercise`:
   free_weight / machine / bodyweight / unknown; machine markers beat free-weight markers so
-  "Seated Row" is a cable stack) — upgradeable to a real per-exercise field without changing the
-  contract; (2) `exerciseOrder` computes ONLY from real `createdAt` timestamps (#846) — for
+  "Seated Row" is a cable stack) is the fallback for never-classified exercises;
+  (2) `exerciseOrder` computes ONLY from real `createdAt` timestamps (#846) — for
   untimestamped sets, cross-exercise order within a day is array order, and we never feed the
   model fabricated sequence.
 

--- a/src/components/EditExerciseModal.vue
+++ b/src/components/EditExerciseModal.vue
@@ -119,6 +119,26 @@
           >Reset to default</button>
           <span class="iosSettingsFooter">How many rep counts (1–{{ editIntensityMaxReps }}) the Intensity table calculates when you log this exercise — from warmups up to PR-beating loads at 100%.</span>
         </div>
+        <!-- Coach equipment classification (#931 phase C): explicit kind for the
+             AI Coach's strength analytics. "Auto" stores nothing and shows what
+             the name heuristic resolves to. -->
+        <div class="iosSettingsSection">
+          <span class="iosSettingsHeader">Equipment</span>
+          <div class="wtTagPicker" role="radiogroup" aria-label="Equipment type">
+            <button
+              v-for="opt in EQUIPMENT_OPTIONS"
+              :key="opt.value ?? 'auto'"
+              role="radio"
+              :aria-checked="editEquipment === opt.value"
+              :class="['wtTagPickerChip', { wtTagPickerChipActive: editEquipment === opt.value }]"
+              :style="editEquipment !== opt.value
+                ? { borderColor: 'var(--border-strong)', color: 'var(--text-secondary)' }
+                : {}"
+              @click="editEquipment = opt.value"
+            >{{ opt.value === null ? `Auto (${autoEquipmentLabel})` : opt.label }}</button>
+          </div>
+          <span class="iosSettingsFooter">Used by Coach analytics: free-weight lifts anchor strength comparisons; machine and bodyweight numbers are flagged as not standards-comparable.</span>
+        </div>
         <div class="repMaxActions">
           <button class="repMaxBtn repMaxBtnCalc" :disabled="!editName" @click="confirmSave">Save</button>
           <button class="repMaxBtn repMaxBtnClose" @click="emit('close')">Cancel</button>
@@ -154,6 +174,7 @@
 
 <script lang="ts">
 import type { PlateCountMode } from '../stores/workout'
+import type { ExerciseEquipment } from '../lib/coachAnalytics'
 
 /** Payload emitted on Save — the parent applies it to the store. */
 export interface EditExerciseSave {
@@ -164,6 +185,8 @@ export interface EditExerciseSave {
   barWeight: number
   /** Intensity-table rep-row count; null = use the default (10). */
   intensityMaxReps: number | null
+  /** Coach equipment classification; null = Auto (name heuristic). */
+  equipment: ExerciseEquipment | null
 }
 </script>
 
@@ -180,6 +203,7 @@ import {
   MAX_INTENSITY_MAX_REPS,
   sanitizeIntensityMaxReps,
 } from '../lib/intensityTable'
+import { classifyExercise } from '../lib/coachAnalytics'
 
 const props = defineProps<{
   /** Exercise being edited; null renders nothing (modal closed). */
@@ -222,6 +246,26 @@ function resetIntensityMaxReps() {
   editIntensityMaxReps.value = DEFAULT_INTENSITY_MAX_REPS
 }
 
+// ── Coach equipment classification (#931 phase C) ───────────────
+// null = "Auto" (store nothing; the name heuristic classifies). The Auto chip
+// shows what the heuristic currently resolves to so the user can see whether
+// it's already right before overriding.
+const EQUIPMENT_OPTIONS: ReadonlyArray<{ value: ExerciseEquipment | null; label: string }> = [
+  { value: null, label: 'Auto' },
+  { value: 'free_weight', label: 'Free weight' },
+  { value: 'machine', label: 'Machine' },
+  { value: 'bodyweight', label: 'Bodyweight' },
+]
+const editEquipment = ref<ExerciseEquipment | null>(null)
+
+const AUTO_LABELS: Record<string, string> = {
+  free_weight: 'free weight',
+  machine: 'machine',
+  bodyweight: 'bodyweight',
+  unknown: 'unclassified',
+}
+const autoEquipmentLabel = computed(() => AUTO_LABELS[classifyExercise(editName.value)] ?? 'unclassified')
+
 const isArchived = computed(() => !!props.exercise?.archived_at)
 
 const focusTrap = useFocusTrap()
@@ -234,6 +278,7 @@ watch(() => props.exercise, async (exercise) => {
     editPlateCountMode.value = exercise.plateCountMode || 'per-side'
     editBarWeight.value = exercise.barWeight ?? (exercise.plateCountMode === 'total' ? 0 : 45)
     editIntensityMaxReps.value = exercise.intensityMaxReps ?? DEFAULT_INTENSITY_MAX_REPS
+    editEquipment.value = exercise.equipment ?? null
     newTagInput.value = ''
     editTagAdding.value = false
     confirmDeleteExercise.value = false
@@ -306,6 +351,7 @@ function confirmSave() {
     plateCountMode: editPlateCountMode.value,
     barWeight: editBarWeight.value,
     intensityMaxReps: editIntensityMaxReps.value === DEFAULT_INTENSITY_MAX_REPS ? null : editIntensityMaxReps.value,
+    equipment: editEquipment.value,
   })
 }
 </script>

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -2492,6 +2492,7 @@ function onEditExerciseSave(payload: EditExerciseSave) {
     store.setExerciseBarWeight(editTarget.value, payload.barWeight)
   }
   store.setExerciseIntensityMaxReps(editTarget.value, payload.intensityMaxReps)
+  store.setExerciseEquipment(editTarget.value, payload.equipment)
   editTarget.value = null
   // When switching to plate mode, reverse-sync the current weight into
   // plates so the user's entered value is preserved (LIFT-388 review fix).

--- a/src/components/__tests__/EditExerciseModal.test.ts
+++ b/src/components/__tests__/EditExerciseModal.test.ts
@@ -26,8 +26,13 @@ async function openWith(exercise: Exercise): Promise<VueWrapper> {
 const stepperValue = (w: VueWrapper) => w.find('.iosStepperValue').text()
 const lastSavePayload = (w: VueWrapper) => {
   const calls = w.emitted('save')!
-  return calls[calls.length - 1][0] as { intensityMaxReps: number | null }
+  return calls[calls.length - 1][0] as { intensityMaxReps: number | null; equipment: string | null }
 }
+
+/** The equipment radio chips (inside the radiogroup, unlike the tag chips). */
+const equipmentChips = (w: VueWrapper) => w.findAll('[role="radiogroup"] .wtTagPickerChip')
+const equipmentChip = (w: VueWrapper, label: string | RegExp) =>
+  equipmentChips(w).find((c) => (typeof label === 'string' ? c.text() === label : label.test(c.text())))!
 
 describe('EditExerciseModal — intensity rep-rows config (#770)', () => {
   it('seeds the default (10) and hides "Reset" when the exercise has no override', async () => {
@@ -72,5 +77,41 @@ describe('EditExerciseModal — intensity rep-rows config (#770)', () => {
     expect(wrapper.find('.wtIntensityEditReset').exists()).toBe(false)
     await wrapper.find('.repMaxBtnCalc').trigger('click')
     expect(lastSavePayload(wrapper).intensityMaxReps).toBeNull()
+  })
+})
+
+describe('EditExerciseModal — Coach equipment classification (#931 phase C)', () => {
+  it('defaults to Auto and shows what the name heuristic resolves to', async () => {
+    const wrapper = await openWith(makeExercise({ name: 'Bench Press' }))
+    const auto = equipmentChip(wrapper, /^Auto/)
+    expect(auto.attributes('aria-checked')).toBe('true')
+    expect(auto.text()).toBe('Auto (free weight)')
+  })
+
+  it('shows the heuristic resolution for machine and unclassified names', async () => {
+    const machine = await openWith(makeExercise({ name: 'Leg Press' }))
+    expect(equipmentChip(machine, /^Auto/).text()).toBe('Auto (machine)')
+    const unknown = await openWith(makeExercise({ name: 'Farmers Walk' }))
+    expect(equipmentChip(unknown, /^Auto/).text()).toBe('Auto (unclassified)')
+  })
+
+  it('seeds an explicit classification from the exercise', async () => {
+    const wrapper = await openWith(makeExercise({ equipment: 'machine' }))
+    expect(equipmentChip(wrapper, 'Machine').attributes('aria-checked')).toBe('true')
+    expect(equipmentChip(wrapper, /^Auto/).attributes('aria-checked')).toBe('false')
+  })
+
+  it('emits the selected equipment on save', async () => {
+    const wrapper = await openWith(makeExercise())
+    await equipmentChip(wrapper, 'Free weight').trigger('click')
+    await wrapper.find('.repMaxBtnCalc').trigger('click')
+    expect(lastSavePayload(wrapper).equipment).toBe('free_weight')
+  })
+
+  it('emits null when set back to Auto (clears the override)', async () => {
+    const wrapper = await openWith(makeExercise({ equipment: 'machine' }))
+    await equipmentChip(wrapper, /^Auto/).trigger('click')
+    await wrapper.find('.repMaxBtnCalc').trigger('click')
+    expect(lastSavePayload(wrapper).equipment).toBeNull()
   })
 })

--- a/src/lib/__tests__/coachAnalytics.test.ts
+++ b/src/lib/__tests__/coachAnalytics.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { classifyExercise, buildDerivedAnalytics } from '../coachAnalytics'
+import {
+  classifyExercise,
+  sanitizeExerciseEquipment,
+  resolveExerciseKind,
+  buildDerivedAnalytics,
+} from '../coachAnalytics'
 import type { Exercise, WorkoutSet } from '../../stores/workout'
 
 /** Fixed "now" so windowing is deterministic. */
@@ -42,6 +47,25 @@ describe('classifyExercise — name heuristic', () => {
   it('returns unknown rather than guessing', () => {
     expect(classifyExercise('Farmers Walk')).toBe('unknown')
     expect(classifyExercise('Sled Drag')).toBe('unknown')
+  })
+})
+
+describe('equipment field — sanitize + resolve (#931 phase C)', () => {
+  it('accepts only the known kinds; everything else degrades to unset', () => {
+    expect(sanitizeExerciseEquipment('free_weight')).toBe('free_weight')
+    expect(sanitizeExerciseEquipment('machine')).toBe('machine')
+    expect(sanitizeExerciseEquipment('bodyweight')).toBe('bodyweight')
+    expect(sanitizeExerciseEquipment('unknown')).toBeUndefined() // never stored — unset IS unknown
+    expect(sanitizeExerciseEquipment('MACHINE')).toBeUndefined()
+    expect(sanitizeExerciseEquipment(1)).toBeUndefined()
+    expect(sanitizeExerciseEquipment(null)).toBeUndefined()
+  })
+
+  it('explicit equipment beats the name heuristic; unset falls back to it', () => {
+    // Name says machine, user says free weight (e.g. a barbell "Hack Squat").
+    expect(resolveExerciseKind({ name: 'Hack Squat', equipment: 'free_weight' })).toBe('free_weight')
+    expect(resolveExerciseKind({ name: 'Hack Squat', equipment: undefined })).toBe('machine')
+    expect(resolveExerciseKind({ name: 'Farmers Walk', equipment: 'machine' })).toBe('machine')
   })
 })
 
@@ -111,6 +135,32 @@ describe('buildDerivedAnalytics — reliable 1RM', () => {
     const bench = exercise('Bench Press', ['chest'], [set('2026-06-15', 205, 3)])
     const d = buildDerivedAnalytics({ exercises: [bench], bodyweightLb: null, now: NOW })
     expect(d.reliable1RM[0].bwRatio).toBeUndefined()
+  })
+
+  it('honors an explicit equipment override in both directions (#931 phase C)', () => {
+    // A barbell "Hack Squat" the heuristic would call a machine…
+    const barbellHack = {
+      ...exercise('Hack Squat', ['quads'], [
+        set('2026-06-01', 225, 5),
+        set('2026-06-15', 245, 5),
+      ]),
+      equipment: 'free_weight' as const,
+    }
+    // …and a "Bench Press" done on a machine the heuristic would call free weight.
+    const machineBench = {
+      ...exercise('Bench Press', ['chest'], [
+        set('2026-06-01', 185, 5),
+        set('2026-06-15', 205, 5),
+      ]),
+      equipment: 'machine' as const,
+    }
+    const d = buildDerivedAnalytics({ exercises: [barbellHack, machineBench], now: NOW })
+    // reliable1RM includes only the overridden free-weight lift.
+    expect(d.reliable1RM.map((r) => r.exerciseName)).toEqual(['Hack Squat'])
+    // The machine override lands as a reliability flag on progression.
+    const byName = Object.fromEntries(d.perExerciseProgression.map((p) => [p.exerciseName, p]))
+    expect(byName['Bench Press'].flags).toContain('machine')
+    expect(byName['Hack Squat'].flags ?? []).not.toContain('machine')
   })
 })
 

--- a/src/lib/coachAnalytics.ts
+++ b/src/lib/coachAnalytics.ts
@@ -16,9 +16,10 @@
  * Honesty constraints baked in:
  *  - e1RM-based claims carry reliability flags: a window-best set at >10 reps is
  *    an inflated estimate; machine/bodyweight lifts aren't comparable to external
- *    strength standards. Classification is a NAME HEURISTIC (`classifyExercise`)
- *    — deliberately conservative, `unknown` when unsure; upgradeable to a real
- *    per-exercise equipment field later without changing this contract.
+ *    strength standards. Classification is two-layered (`resolveExerciseKind`):
+ *    the explicit per-exercise `equipment` field (user-set, synced) wins, and the
+ *    NAME HEURISTIC (`classifyExercise`) — deliberately conservative, `unknown`
+ *    when unsure — is the fallback for never-classified exercises.
  *  - `exerciseOrder` computes ONLY from sets with a real `createdAt` timestamp.
  *    For untimestamped sets, within-day order across exercises is array-iteration
  *    order, not performed order — feeding that to the model would fabricate data.
@@ -42,9 +43,33 @@ import {
   type ReliabilityFlag,
 } from './aiCoach'
 
-// ---- Exercise classification (name heuristic) ----
+// ---- Exercise classification ----
+// Two layers: an explicit per-exercise `equipment` field (user-set in
+// EditExerciseModal, synced via the additive `equipment` column) wins; the name
+// heuristic below is the fallback for exercises the user never classified.
 
 export type ExerciseKind = 'free_weight' | 'machine' | 'bodyweight' | 'unknown'
+
+export const EXERCISE_EQUIPMENT_KINDS = ['free_weight', 'machine', 'bodyweight'] as const
+
+/** The user-settable subset of `ExerciseKind` — 'unknown' is never stored, it IS unset. */
+export type ExerciseEquipment = (typeof EXERCISE_EQUIPMENT_KINDS)[number]
+
+/**
+ * Normalize a persisted/remote equipment value. Returns undefined for anything
+ * that isn't exactly one of the known kinds — corrupt storage or a newer client's
+ * value degrades to "unset" (heuristic) rather than throwing or misclassifying.
+ */
+export function sanitizeExerciseEquipment(raw: unknown): ExerciseEquipment | undefined {
+  return (EXERCISE_EQUIPMENT_KINDS as readonly string[]).includes(raw as string)
+    ? (raw as ExerciseEquipment)
+    : undefined
+}
+
+/** Explicit user classification wins; otherwise fall back to the name heuristic. */
+export function resolveExerciseKind(exercise: Pick<Exercise, 'name' | 'equipment'>): ExerciseKind {
+  return exercise.equipment ?? classifyExercise(exercise.name)
+}
 
 /** Substrings that mark a lift as machine/cable-loaded (not standards-comparable). */
 const MACHINE_MARKERS = [
@@ -155,7 +180,7 @@ export function buildDerivedAnalytics(input: DerivedAnalyticsInput): DerivedAnal
     if (days.size === 0) continue
     windows.push({
       exercise: ex,
-      kind: classifyExercise(ex.name),
+      kind: resolveExerciseKind(ex),
       days,
       dayKeys: Array.from(days.keys()).sort(),
       all: Array.from(days.values()).flat(),

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -72,6 +72,7 @@ export type Database = {
           bar_weight: number
           created_at: string
           deleted_at: string | null
+          equipment: string | null
           id: string
           input_mode: string | null
           intensity_max_reps: number | null
@@ -86,6 +87,7 @@ export type Database = {
           bar_weight?: number
           created_at?: string
           deleted_at?: string | null
+          equipment?: string | null
           id?: string
           input_mode?: string | null
           intensity_max_reps?: number | null
@@ -100,6 +102,7 @@ export type Database = {
           bar_weight?: number
           created_at?: string
           deleted_at?: string | null
+          equipment?: string | null
           id?: string
           input_mode?: string | null
           intensity_max_reps?: number | null

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -1180,4 +1180,50 @@ describe('workout store', () => {
       expect(() => store.setExerciseIntensityMaxReps('nope', 12)).not.toThrow()
     })
   })
+
+  // ── setExerciseEquipment (#931 phase C) ─────────────────────────
+  describe('setExerciseEquipment', () => {
+    it('stores an explicit classification and persists it to localStorage', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Hack Squat', [])
+      store.setExerciseEquipment(id, 'free_weight')
+
+      expect(store.exercises[0].equipment).toBe('free_weight')
+      const persisted = JSON.parse(localStorageMock.getItem('workout-exercises')!)
+      expect(persisted[0].equipment).toBe('free_weight')
+    })
+
+    it('clears the override ("Auto") when passed null', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Bench Press', [])
+      store.setExerciseEquipment(id, 'machine')
+      store.setExerciseEquipment(id, null)
+      expect('equipment' in store.exercises[0]).toBe(false)
+    })
+
+    it('refuses to store an unknown value (clears instead)', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Squat', [])
+      store.setExerciseEquipment(id, 'machine')
+      // Corrupt/future value degrades to unset rather than persisting garbage.
+      store.setExerciseEquipment(id, 'cable_stack' as never)
+      expect('equipment' in store.exercises[0]).toBe(false)
+    })
+
+    it('is a no-op for an unknown exercise id', () => {
+      const store = useWorkoutStore()
+      expect(() => store.setExerciseEquipment('nope', 'machine')).not.toThrow()
+    })
+
+    it('sanitizes a corrupt persisted equipment value on load', () => {
+      localStorageMock.setItem('workout-exercises', JSON.stringify([
+        { id: 'e1', name: 'Bench', tags: [], sets: [], equipment: 'laser_cannon' },
+        { id: 'e2', name: 'Squat', tags: [], sets: [], equipment: 'machine' },
+      ]))
+      setActivePinia(createPinia())
+      const store = useWorkoutStore()
+      expect('equipment' in store.exercises[0]).toBe(false)
+      expect(store.exercises[1].equipment).toBe('machine')
+    })
+  })
 })

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -13,6 +13,7 @@ import { broadcastStoreUpdate } from '../lib/crossTabSync'
 import { todayISO, setDayKey } from '../lib/dates'
 import { loadJSON, isPlainObject } from '../lib/storage'
 import { sanitizeIntensityMaxReps } from '../lib/intensityTable'
+import { sanitizeExerciseEquipment, type ExerciseEquipment } from '../lib/coachAnalytics'
 import { isAuthError, ensureFreshSession } from '../lib/sessionHealth'
 import { classifySyncError, type SyncErrorKind } from '../lib/syncStatus'
 
@@ -49,6 +50,7 @@ export interface Exercise {
   barWeight?: number               // bar weight in lbs, default 45
   plateCountMode?: PlateCountMode  // how plates are counted, default 'per-side'
   intensityMaxReps?: number        // rep rows shown in the Intensity lens; undefined = default (10) (#770)
+  equipment?: ExerciseEquipment    // explicit Coach classification; undefined = name heuristic (#931 phase C)
   updated_at?: string              // ISO 8601, used for last-write-wins merge
   archived_at?: string             // ISO 8601, soft-hide from main list; data is preserved
   sample?: boolean                 // true for onboarding sample data — never synced to Supabase
@@ -184,6 +186,11 @@ function load(): Exercise[] {
       if (ex && ex.intensityMaxReps !== undefined) {
         ex.intensityMaxReps = sanitizeIntensityMaxReps(ex.intensityMaxReps)
       }
+      if (ex && ex.equipment !== undefined) {
+        const eq = sanitizeExerciseEquipment(ex.equipment)
+        if (eq) ex.equipment = eq
+        else delete ex.equipment
+      }
     }
     return parsed
   } catch (e) {
@@ -266,6 +273,8 @@ export const useWorkoutStore = defineStore('workout', () => {
       // actually clears the override server-side — omitting it would leave a
       // stale value that re-applies on the next fetch.
       intensity_max_reps: exercise.intensityMaxReps ?? null,
+      // Same always-send rule: "Auto" clears the Coach equipment classification.
+      equipment: exercise.equipment ?? null,
     }
   }
 
@@ -409,6 +418,10 @@ export const useWorkoutStore = defineStore('workout', () => {
       if (ex.input_mode) exercise.inputMode = ex.input_mode as ExerciseInputMode
       if (ex.bar_weight != null) exercise.barWeight = ex.bar_weight
       if (ex.intensity_max_reps != null) exercise.intensityMaxReps = sanitizeIntensityMaxReps(ex.intensity_max_reps)
+      if (ex.equipment != null) {
+        const eq = sanitizeExerciseEquipment(ex.equipment)
+        if (eq) exercise.equipment = eq
+      }
       if (ex.archived_at) exercise.archived_at = ex.archived_at
       return exercise
     })
@@ -661,6 +674,27 @@ export const useWorkoutStore = defineStore('workout', () => {
     } else {
       exercise.intensityMaxReps = sanitizeIntensityMaxReps(maxReps)
     }
+    exercise.updated_at = new Date().toISOString()
+    triggerRef(exercises)
+    _persist()
+
+    if (supabase && _userId) {
+      _enqueueExerciseUpsert(exercise, _userId)
+    }
+  }
+
+  /**
+   * Set (or clear) the explicit Coach equipment classification (#931 phase C).
+   * `null` clears the override ("Auto") so the name heuristic applies again.
+   * Values are sanitized so only the known kinds are ever stored.
+   */
+  function setExerciseEquipment(exerciseId: string, equipment: ExerciseEquipment | null) {
+    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
+    if (!exercise) return
+    if (exercise.sample) _adoptExercise(exercise)
+    const eq = equipment === null ? undefined : sanitizeExerciseEquipment(equipment)
+    if (eq) exercise.equipment = eq
+    else delete exercise.equipment
     exercise.updated_at = new Date().toISOString()
     triggerRef(exercises)
     _persist()
@@ -1330,6 +1364,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     setExerciseInputMode,
     setExerciseBarWeight,
     setExerciseIntensityMaxReps,
+    setExerciseEquipment,
     logSet,
     updateSet,
     deleteSet,

--- a/supabase/migrations/20260710000000_add_equipment_to_exercises.sql
+++ b/supabase/migrations/20260710000000_add_equipment_to_exercises.sql
@@ -1,0 +1,17 @@
+-- Add equipment to exercises (#931 phase C)
+--
+-- Explicit per-exercise equipment classification for the AI Coach's derived
+-- analytics (reliable-1RM standards comparison + machine/bodyweight reliability
+-- flags). Client code falls back to a conservative name heuristic
+-- (classifyExercise in src/lib/coachAnalytics.ts) when unset; this column only
+-- stores a user OVERRIDE set in the exercise's Edit sheet:
+--   NULL           → no override, use the name heuristic ("Auto")
+--   'free_weight' | 'machine' | 'bodyweight'
+--
+-- A plain text column (not an enum) so a future kind is a client-only change;
+-- the client sanitizes on every boundary (store setter, localStorage load,
+-- remote fetch) and degrades unknown values to "unset" rather than trusting
+-- them. Purely additive, same pattern as bar_weight / intensity_max_reps:
+-- every existing query keeps working and NULL rows behave exactly as before.
+
+alter table exercises add column if not exists equipment text;


### PR DESCRIPTION
## Summary
Phase C of the coach-quality plan (#931; A = #933 analyst prompt + athlete profile, B = #934 derived analytics). Both prior PRs named the same open upgrade path: the derived analytics' **reliable-1RM list** and **machine/bodyweight reliability flags** rested on a name heuristic alone — a barbell *Hack Squat* read as a machine, a machine bench press read as free weight, and no user could correct either. Classification is now **two-layered**: an explicit per-exercise field wins; the conservative heuristic remains the fallback for never-classified exercises.

## Changes
- **`Exercise.equipment?: 'free_weight' | 'machine' | 'bodyweight'`** — undefined = Auto (heuristic). `resolveExerciseKind` in [`coachAnalytics.ts`](src/lib/coachAnalytics.ts) is the single resolution point; `buildDerivedAnalytics` uses it, so an override immediately corrects the reliable-1RM list and the progression flags (tested in both directions).
- **Sanitized at every boundary** — `sanitizeExerciseEquipment` in the store setter, localStorage load, and remote fetch; unknown/corrupt values degrade to *unset* rather than being stored or trusted.
- **Sync** — additive `equipment` **text** column ([migration](supabase/migrations/20260710000000_add_equipment_to_exercises.sql) + `database.types.ts`), same **always-send** rule as `intensity_max_reps` so switching back to Auto clears the override server-side. Text rather than an enum so a future kind is a client-only change.
- **[`EditExerciseModal`](src/components/EditExerciseModal.vue)** — new "Equipment" section: a radiogroup of the existing tag-chip chrome (**Auto / Free weight / Machine / Bodyweight**). The Auto chip shows what the heuristic resolves to for the current name (e.g. "Auto (machine)") so users can see whether it's already right before overriding. Wired through `EditExerciseSave` → `setExerciseEquipment` in WorkoutTracker. No new CSS or modal paradigms; aria `radiogroup`/`radio` + `aria-checked`.

## Verification
- `npm run lint`, `npm run typecheck` — clean.
- `npx vitest run` — **2609 pass** (+13: sanitize/resolve, override-beats-heuristic in the derived output both directions, store setter/clear/corrupt-load recovery, modal seed/select/save/Auto-reset).
- `npm run build` — passes; JS bundle **539 KB** (< 550 KB budget).
- ⚠️ Browser visual check blocked again in this environment (origin-approval gate needs interactive consent). The section reuses only existing regression-tested chip/settings classes; behavior is exercised at the DOM level by component tests. **Worth an eyeball on device**: Workouts → any exercise → settings gear → Equipment.

## Deploy note
Ships a Supabase migration (purely additive `alter table exercises add column if not exists equipment text`) — the standard `migrate-db` job applies it on merge; NULL rows behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)