### PR TITLE
feat(LIFT-926): add a live in-workout session stopwatch

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -26,7 +26,13 @@
       >
         <span class="wtFinishWorkoutLabel">Finish workout</span>
         <span class="wtFinishWorkoutMeta">
-          {{ setsLoggedToday }} {{ setsLoggedToday === 1 ? 'set' : 'sets' }} today
+          <span
+            v-if="sessionStopwatch.isActive.value"
+            class="wtSessionClock"
+            role="timer"
+            aria-label="Session duration"
+          >{{ sessionStopwatch.label.value }}</span>
+          <span class="wtFinishWorkoutSets">{{ setsLoggedToday }} {{ setsLoggedToday === 1 ? 'set' : 'sets' }}</span>
         </span>
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18l6-6-6-6"/></svg>
       </button>
@@ -755,6 +761,7 @@ import { generateIntensityTable, DEFAULT_INTENSITY_MAX_REPS, type IntensityRow }
 import { applyStreakMultiplier, isExerciseEstablished, XP_CONFIG } from '../lib/xp'
 import { scoreSet } from '../lib/setScoring'
 import { useXPCeremony } from '../composables/useXPCeremony'
+import { useSessionStopwatch } from '../composables/useSessionStopwatch'
 import { computeWeeklyGoal } from '../lib/weeklyGoal'
 import ExerciseDetailModal from '../views/ExerciseDetailModal.vue'
 import RestTimerContent from './RestTimerContent.vue'
@@ -947,6 +954,9 @@ const setsLoggedToday = computed(() => {
   }
   return count
 })
+
+/** Live in-workout stopwatch — "time since your first set today" (LIFT-926). */
+const sessionStopwatch = useSessionStopwatch(setsLoggedToday)
 
 /** When non-null, renders the WorkoutCompleteView overlay for that date. */
 const workoutCompleteDate = ref<string | null>(null)

--- a/src/composables/__tests__/useSessionStopwatch.test.ts
+++ b/src/composables/__tests__/useSessionStopwatch.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, ref, nextTick, type Ref } from 'vue'
+import { useSessionStopwatch } from '../useSessionStopwatch'
+
+const STORAGE_KEY = 'workout-session-start'
+// A fixed local "today" so day-key logic is deterministic regardless of TZ.
+const FIXED_NOW = new Date(2026, 6, 9, 10, 0, 0).getTime() // 2026-07-09 10:00 local
+
+function createWrapper(setCount: Ref<number>) {
+  const Comp = defineComponent({
+    setup() {
+      const sw = useSessionStopwatch(setCount)
+      return { ...sw }
+    },
+    template: '<div />',
+  })
+  return mount(Comp, { attachTo: document.body })
+}
+
+describe('useSessionStopwatch', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    localStorage.clear()
+  })
+
+  it('is inactive with zero elapsed when no sets are logged', () => {
+    const setCount = ref(0)
+    const w = createWrapper(setCount)
+    expect(w.vm.isActive).toBe(false)
+    expect(w.vm.elapsedMs).toBe(0)
+    expect(w.vm.label).toBe('0:00')
+    w.unmount()
+  })
+
+  it('starts counting when the first set is logged and ticks each second', async () => {
+    const setCount = ref(0)
+    const w = createWrapper(setCount)
+
+    setCount.value = 1
+    await nextTick()
+    expect(w.vm.isActive).toBe(true)
+    expect(w.vm.label).toBe('0:00')
+
+    vi.advanceTimersByTime(65_000)
+    await nextTick()
+    expect(w.vm.label).toBe('1:05')
+    w.unmount()
+  })
+
+  it('persists the start so a remount mid-session resumes the same clock', async () => {
+    const setCount = ref(1)
+    const first = createWrapper(setCount)
+    expect(first.vm.isActive).toBe(true)
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+    expect(stored.startedAt).toBe(FIXED_NOW)
+    first.unmount()
+
+    // 90s later the user reopens the app — the clock should resume, not reset.
+    vi.setSystemTime(FIXED_NOW + 90_000)
+    const second = createWrapper(setCount)
+    await nextTick()
+    expect(second.vm.isActive).toBe(true)
+    expect(second.vm.label).toBe('1:30')
+    second.unmount()
+  })
+
+  it('resets and clears storage when every set is removed', async () => {
+    const setCount = ref(2)
+    const w = createWrapper(setCount)
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+
+    setCount.value = 0
+    await nextTick()
+    expect(w.vm.isActive).toBe(false)
+    expect(w.vm.elapsedMs).toBe(0)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    w.unmount()
+  })
+
+  it('ignores a stored start from a previous day (day rollover)', async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ dayKey: '2020-01-01', startedAt: FIXED_NOW - 5_000 }),
+    )
+    const setCount = ref(1)
+    const w = createWrapper(setCount)
+    await nextTick()
+    // Fresh start at now, not the stale day's timestamp.
+    expect(w.vm.label).toBe('0:00')
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+    expect(stored.startedAt).toBe(FIXED_NOW)
+    w.unmount()
+  })
+
+  it('stops ticking after unmount (no leaked interval)', async () => {
+    const setCount = ref(1)
+    const w = createWrapper(setCount)
+    const before = w.vm.label
+    w.unmount()
+    vi.advanceTimersByTime(120_000)
+    // The composable return is detached after unmount; assert the interval was
+    // cleared by confirming no pending timers remain.
+    expect(vi.getTimerCount()).toBe(0)
+    expect(before).toBe('0:00')
+  })
+})

--- a/src/composables/useSessionStopwatch.ts
+++ b/src/composables/useSessionStopwatch.ts
@@ -1,0 +1,150 @@
+/**
+ * Live in-workout session stopwatch composable (LIFT-926).
+ *
+ * Drives the running "time since your first set today" clock rendered next to
+ * the Finish-workout affordance in WorkoutTracker. Strong and Hevy both surface
+ * a live session duration during an active workout; Lift previously only
+ * computed it retrospectively in WorkoutCompleteView.
+ *
+ * The clock is purely a function of when the current day's first set was
+ * logged. UI-logged sets carry an `endOfDayISO` timestamp (no real wall clock),
+ * so the real start is captured once and persisted device-local (NOT synced) so
+ * it survives a reload or backgrounding within the session. Pure decisions live
+ * in `src/lib/sessionStopwatch.ts`; this composable only owns the tick loop and
+ * lifecycle wiring (cleaning up its interval + listener on unmount).
+ */
+
+import { ref, computed, watch, onMounted, onUnmounted, type Ref, type ComputedRef } from 'vue'
+import { todayISO } from '../lib/dates'
+import { loadJSON } from '../lib/storage'
+import {
+  formatSessionClock,
+  resolveSessionStart,
+  isStoredSessionStart,
+  type StoredSessionStart,
+} from '../lib/sessionStopwatch'
+
+/** Device-local key holding the active session's start. Deliberately NOT synced. */
+const STORAGE_KEY = 'workout-session-start'
+
+export interface UseSessionStopwatchReturn {
+  /** True while a session is running (at least one set logged today). */
+  isActive: ComputedRef<boolean>
+  /** Elapsed milliseconds since the session's first set (0 when inactive). */
+  elapsedMs: ComputedRef<number>
+  /** Formatted clock string (`M:SS` / `H:MM:SS`), live-updating each second. */
+  label: ComputedRef<string>
+}
+
+/**
+ * @param setCount — reactive count of sets logged on the local "today". The
+ *   stopwatch starts when this crosses 0 → >0 and resets when it returns to 0
+ *   (e.g. day rollover, or every set deleted).
+ */
+export function useSessionStopwatch(setCount: Ref<number>): UseSessionStopwatchReturn {
+  const startedAt = ref<number | null>(null)
+  const now = ref(Date.now())
+  let tickId: ReturnType<typeof setInterval> | null = null
+
+  function persist(dayKey: string, ts: number): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ dayKey, startedAt: ts }))
+    } catch {
+      /* storage full / unavailable — the clock still runs in-memory this session */
+    }
+  }
+
+  function clearPersisted(): void {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  /** Reconcile in-memory + persisted state with the current set count. */
+  function sync(): void {
+    const hasSets = setCount.value > 0
+    if (!hasSets) {
+      if (startedAt.value !== null) {
+        startedAt.value = null
+        clearPersisted()
+      }
+      return
+    }
+    // Already counting for the live session — leave it running.
+    if (startedAt.value !== null) return
+
+    const stored = loadJSON<StoredSessionStart | null>(STORAGE_KEY, null, isStoredSessionStart)
+    const today = todayISO()
+    const resolved = resolveSessionStart(stored, today, true, Date.now())
+    if (resolved === null) return
+    startedAt.value = resolved
+    now.value = Date.now()
+    persist(today, resolved)
+  }
+
+  function startTick(): void {
+    if (tickId !== null) return
+    tickId = setInterval(() => {
+      now.value = Date.now()
+    }, 1000)
+  }
+
+  function stopTick(): void {
+    if (tickId !== null) {
+      clearInterval(tickId)
+      tickId = null
+    }
+  }
+
+  function isDocHidden(): boolean {
+    return typeof document !== 'undefined' && document.visibilityState === 'hidden'
+  }
+
+  function onVisibilityChange(): void {
+    if (isDocHidden()) {
+      stopTick()
+      return
+    }
+    // Resync (the session may have started/ended while backgrounded) and snap
+    // the clock forward so it doesn't show a stale value on resume.
+    now.value = Date.now()
+    sync()
+    if (startedAt.value !== null) startTick()
+  }
+
+  // Resolve immediately so the first paint already shows the clock (avoids a
+  // one-frame flash of the plain set count on a mid-session reload).
+  sync()
+
+  watch(setCount, sync)
+  watch(startedAt, (v) => {
+    if (v !== null && !isDocHidden()) startTick()
+    else stopTick()
+  })
+
+  onMounted(() => {
+    now.value = Date.now()
+    sync()
+    if (startedAt.value !== null && !isDocHidden()) startTick()
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', onVisibilityChange)
+    }
+  })
+
+  onUnmounted(() => {
+    stopTick()
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  })
+
+  const isActive = computed(() => startedAt.value !== null)
+  const elapsedMs = computed(() =>
+    startedAt.value === null ? 0 : Math.max(0, now.value - startedAt.value),
+  )
+  const label = computed(() => formatSessionClock(elapsedMs.value))
+
+  return { isActive, elapsedMs, label }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2191,6 +2191,10 @@ html.theme-fading .settingsSheet {
 }
 
 .wtFinishWorkoutMeta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
   font-family: var(--ff-mono);
   font-size: var(--font-caption2);
   font-weight: 500;
@@ -2198,6 +2202,18 @@ html.theme-fading .settingsSheet {
   color: var(--accent);
   opacity: 0.85;
   font-variant-numeric: tabular-nums;
+}
+
+/* Live session stopwatch — the ticking "duration" is the primary meta value. */
+.wtSessionClock {
+  font-size: var(--font-footnote);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.wtFinishWorkoutSets {
+  opacity: 0.75;
 }
 
 /* Segmented control (Exercises / Timeline) — gold-filled active pill. */

--- a/src/lib/__tests__/sessionStopwatch.test.ts
+++ b/src/lib/__tests__/sessionStopwatch.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatSessionClock,
+  resolveSessionStart,
+  isStoredSessionStart,
+  type StoredSessionStart,
+} from '../sessionStopwatch'
+
+describe('formatSessionClock', () => {
+  it('formats sub-minute spans as M:SS with padded seconds', () => {
+    expect(formatSessionClock(0)).toBe('0:00')
+    expect(formatSessionClock(7_000)).toBe('0:07')
+    expect(formatSessionClock(59_000)).toBe('0:59')
+  })
+
+  it('formats minute spans without zero-padding the minutes', () => {
+    expect(formatSessionClock(60_000)).toBe('1:00')
+    expect(formatSessionClock(24 * 60_000 + 31_000)).toBe('24:31')
+  })
+
+  it('adds an hour field with padded minutes past 60 minutes', () => {
+    expect(formatSessionClock(3_600_000)).toBe('1:00:00')
+    expect(formatSessionClock(3_600_000 + 5 * 60_000 + 9_000)).toBe('1:05:09')
+    expect(formatSessionClock(2 * 3_600_000 + 10_000)).toBe('2:00:10')
+  })
+
+  it('truncates sub-second remainders rather than rounding up', () => {
+    expect(formatSessionClock(7_999)).toBe('0:07')
+    expect(formatSessionClock(59_950)).toBe('0:59')
+  })
+
+  it('clamps negative, NaN, and infinite spans to 0:00', () => {
+    expect(formatSessionClock(-5_000)).toBe('0:00')
+    expect(formatSessionClock(Number.NaN)).toBe('0:00')
+    expect(formatSessionClock(Number.POSITIVE_INFINITY)).toBe('0:00')
+  })
+})
+
+describe('isStoredSessionStart', () => {
+  it('accepts a well-formed blob', () => {
+    expect(isStoredSessionStart({ dayKey: '2026-07-09', startedAt: 123 })).toBe(true)
+  })
+
+  it('rejects junk and corrupt shapes', () => {
+    expect(isStoredSessionStart(null)).toBe(false)
+    expect(isStoredSessionStart('nope')).toBe(false)
+    expect(isStoredSessionStart([])).toBe(false)
+    expect(isStoredSessionStart({ dayKey: '', startedAt: 1 })).toBe(false)
+    expect(isStoredSessionStart({ dayKey: '2026-07-09' })).toBe(false)
+    expect(isStoredSessionStart({ dayKey: '2026-07-09', startedAt: 'x' })).toBe(false)
+    expect(isStoredSessionStart({ dayKey: '2026-07-09', startedAt: Number.NaN })).toBe(false)
+  })
+})
+
+describe('resolveSessionStart', () => {
+  const NOW = 1_700_000_000_000
+  const stored: StoredSessionStart = { dayKey: '2026-07-09', startedAt: NOW - 60_000 }
+
+  it('returns null when no sets are logged today (no active session)', () => {
+    expect(resolveSessionStart(stored, '2026-07-09', false, NOW)).toBeNull()
+    expect(resolveSessionStart(null, '2026-07-09', false, NOW)).toBeNull()
+  })
+
+  it('trusts a stored start for today so the clock survives a reload', () => {
+    expect(resolveSessionStart(stored, '2026-07-09', true, NOW)).toBe(NOW - 60_000)
+  })
+
+  it('starts fresh at now when there is no stored value', () => {
+    expect(resolveSessionStart(null, '2026-07-09', true, NOW)).toBe(NOW)
+  })
+
+  it('ignores a stored start from a previous day (day rollover)', () => {
+    expect(resolveSessionStart(stored, '2026-07-10', true, NOW)).toBe(NOW)
+  })
+
+  it('ignores a future stored start from a backward clock change', () => {
+    const future: StoredSessionStart = { dayKey: '2026-07-09', startedAt: NOW + 5_000 }
+    expect(resolveSessionStart(future, '2026-07-09', true, NOW)).toBe(NOW)
+  })
+})

--- a/src/lib/sessionStopwatch.ts
+++ b/src/lib/sessionStopwatch.ts
@@ -1,0 +1,81 @@
+/**
+ * Live in-workout session stopwatch (LIFT-926).
+ *
+ * Pure helpers for the running "time since your first set today" clock shown
+ * next to the Finish-workout affordance. Framework-free so the tick loop lives
+ * in a thin composable while the tricky bits — the display format and the
+ * decision of when a session actually started — stay unit-testable.
+ *
+ * Why a persisted start rather than deriving from set timestamps: UI-logged
+ * sets are stamped with `endOfDayISO()` (`…T23:59:ssZ`), NOT a real-time
+ * instant, so the earliest set carries no usable wall-clock start. The
+ * composable persists the real start once (device-local, deliberately NOT
+ * synced — like the overload nudge and goal-celebration state) and this module
+ * resolves what value to trust on (re)mount.
+ */
+
+/** Shape persisted to localStorage under `workout-session-start`. */
+export interface StoredSessionStart {
+  /** Local day key (YYYY-MM-DD) the session belongs to. */
+  dayKey: string
+  /** Epoch ms of the session's first set. */
+  startedAt: number
+}
+
+/** Type guard for a parsed `StoredSessionStart` blob (rejects junk/corrupt storage). */
+export function isStoredSessionStart(value: unknown): value is StoredSessionStart {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const v = value as Record<string, unknown>
+  return (
+    typeof v.dayKey === 'string' &&
+    v.dayKey.length > 0 &&
+    typeof v.startedAt === 'number' &&
+    Number.isFinite(v.startedAt)
+  )
+}
+
+/**
+ * Format an elapsed millisecond span as a wall-clock stopwatch string.
+ *
+ * - Under an hour: `M:SS` (minutes not zero-padded, seconds padded) → `0:07`, `24:31`.
+ * - An hour or more: `H:MM:SS` → `1:05:09`.
+ *
+ * Negative/non-finite spans clamp to `0:00` so a clock skew can never render a
+ * garbage or negative value.
+ */
+export function formatSessionClock(ms: number): string {
+  const safe = Number.isFinite(ms) && ms > 0 ? ms : 0
+  const totalSec = Math.floor(safe / 1000)
+  const hours = Math.floor(totalSec / 3600)
+  const minutes = Math.floor((totalSec % 3600) / 60)
+  const seconds = totalSec % 60
+  const ss = String(seconds).padStart(2, '0')
+  if (hours > 0) {
+    const mm = String(minutes).padStart(2, '0')
+    return `${hours}:${mm}:${ss}`
+  }
+  return `${minutes}:${ss}`
+}
+
+/**
+ * Decide the epoch-ms start to count up from, given the persisted value and the
+ * current session context. Returns `null` when there is no active session.
+ *
+ * - No sets logged today → no active session (`null`), regardless of storage.
+ * - A stored start for *today* whose timestamp is not in the future → trust it
+ *   (survives reload / backgrounding mid-session).
+ * - Otherwise (stale day key, corrupt/absent storage, or a future timestamp
+ *   from a clock change) → start fresh at `now`.
+ */
+export function resolveSessionStart(
+  stored: StoredSessionStart | null,
+  todayKey: string,
+  hasSetsToday: boolean,
+  now: number,
+): number | null {
+  if (!hasSetsToday) return null
+  if (stored && stored.dayKey === todayKey && stored.startedAt <= now) {
+    return stored.startedAt
+  }
+  return now
+}


### PR DESCRIPTION
## Add a live in-workout session stopwatch during an active workout

Closes #926

Implements a live session stopwatch shown during an active workout:
- `src/lib/sessionStopwatch.ts` — pure timing/formatting logic (unit-tested)
- `src/composables/useSessionStopwatch.ts` — reactive composable wiring the stopwatch into workout state (unit-tested)
- `src/components/WorkoutTracker.vue` — surfaces the running timer during an active session
- `src/index.css` — stopwatch styling

**451 insertions**, including 193 lines of tests across `sessionStopwatch.test.ts` and `useSessionStopwatch.test.ts`.

### ⚠️ Recovery note
This branch was produced by the overnight builder's Run 2 on **2026-07-09**, which committed and pushed this work but hung before opening the PR (the `claude` call had no timeout, and the stuck process silently blocked the launchd builder for ~5 days). The work itself is complete and tested; it was manually recovered.

Because it sat unmerged, the branch is **~16 commits behind `master`** and may need an "Update branch" / rebase before merge. CI did not run at push time (no PR existed yet), so this PR is its first CI pass.

🤖 Recovered by Claude Code
