### PR TITLE
perf(LIFT-940): preload the default Workouts view chunk to remove a first-paint waterfall

### DIFF
--- a/src/lib/__tests__/buildConfigRegression.test.ts
+++ b/src/lib/__tests__/buildConfigRegression.test.ts
@@ -17,4 +17,11 @@ describe('vite.config.js regression', () => {
     expect(viteConfig).toContain('process.env.SENTRY_AUTH_TOKEN')
     expect(viteConfig).toContain('filesToDeleteAfterUpload')
   })
+
+  it('should wire the default-view preload plugin into the build', () => {
+    // Removes the first-paint request waterfall for the always-rendered Workouts
+    // tab by emitting a <link rel="modulepreload"> for its lazy chunk. See LIFT-940.
+    expect(viteConfig).toContain('preloadDefaultViewPlugin')
+    expect(viteConfig).toContain("from './vite-plugin-preload-default-view'")
+  })
 })

--- a/src/lib/__tests__/preloadDefaultView.test.ts
+++ b/src/lib/__tests__/preloadDefaultView.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import preloadDefaultViewPlugin, {
+  findDefaultViewChunk,
+} from '../../../vite-plugin-preload-default-view'
+
+/** Minimal shape of a rollup output bundle entry the plugin cares about. */
+type FakeBundle = Record<
+  string,
+  {
+    type: string
+    facadeModuleId?: string | null
+    isDynamicEntry?: boolean
+    moduleIds?: readonly string[]
+  }
+>
+
+// A dynamically-imported Vue SFC has a null facadeModuleId — its real module
+// only shows up in moduleIds (as observed in the actual production bundle), so
+// the fixture mirrors that shape.
+function makeBundle(): FakeBundle {
+  return {
+    'assets/index-abc123.js': {
+      type: 'chunk',
+      facadeModuleId: '/repo/src/main.ts',
+    },
+    'assets/WorkoutTracker-deadbeef.js': {
+      type: 'chunk',
+      facadeModuleId: null,
+      isDynamicEntry: true,
+      moduleIds: [
+        '/repo/src/components/WorkoutTracker.vue?vue&type=script&setup=true&lang.ts',
+        '/repo/src/components/WorkoutTracker.vue',
+      ],
+    },
+    'assets/CalendarView-cafe01.js': {
+      type: 'chunk',
+      facadeModuleId: null,
+      isDynamicEntry: true,
+      moduleIds: ['/repo/src/views/CalendarView.vue'],
+    },
+    'assets/index-abc123.css': {
+      type: 'asset',
+    },
+  }
+}
+
+/** Invoke the plugin's transformIndexHtml handler with a given bundle. */
+function runHandler(html: string, bundle: FakeBundle | undefined) {
+  const plugin = preloadDefaultViewPlugin()
+  const hook = plugin.transformIndexHtml
+  // Object-form hook: { order, handler }
+  type Handler = (html: string, ctx: unknown) => unknown
+  const handler: Handler =
+    typeof hook === 'function' ? hook : (hook as { handler: Handler }).handler
+  // ctx only needs `bundle` for this plugin.
+  return handler(html, { bundle })
+}
+
+describe('vite-plugin-preload-default-view', () => {
+  it('resolves the hashed WorkoutTracker chunk from a dynamic-entry bundle', () => {
+    expect(findDefaultViewChunk(makeBundle())).toBe(
+      'assets/WorkoutTracker-deadbeef.js',
+    )
+  })
+
+  it('resolves via facadeModuleId when one is present', () => {
+    const bundle: FakeBundle = {
+      'assets/WorkoutTracker-deadbeef.js': {
+        type: 'chunk',
+        facadeModuleId: '/repo/src/components/WorkoutTracker.vue',
+      },
+    }
+    expect(findDefaultViewChunk(bundle)).toBe('assets/WorkoutTracker-deadbeef.js')
+  })
+
+  it('does not match a shared chunk that merely contains the module (not a dynamic entry)', () => {
+    const bundle: FakeBundle = {
+      'assets/shared-xyz.js': {
+        type: 'chunk',
+        facadeModuleId: null,
+        isDynamicEntry: false,
+        moduleIds: ['/repo/src/components/WorkoutTracker.vue'],
+      },
+    }
+    expect(findDefaultViewChunk(bundle)).toBeUndefined()
+  })
+
+  it('returns undefined when the default-view chunk is absent', () => {
+    const bundle = makeBundle()
+    delete bundle['assets/WorkoutTracker-deadbeef.js']
+    expect(findDefaultViewChunk(bundle)).toBeUndefined()
+  })
+
+  it('ignores asset (non-chunk) entries', () => {
+    const bundle: FakeBundle = {
+      'assets/WorkoutTracker-deadbeef.css': {
+        type: 'asset',
+        facadeModuleId: '/repo/src/components/WorkoutTracker.vue',
+      },
+    }
+    expect(findDefaultViewChunk(bundle)).toBeUndefined()
+  })
+
+  it('injects a crossorigin modulepreload link for the default view chunk', () => {
+    const result = runHandler('<html><head></head><body></body></html>', makeBundle())
+    expect(result).toMatchObject({
+      tags: [
+        {
+          tag: 'link',
+          attrs: {
+            rel: 'modulepreload',
+            crossorigin: true,
+            href: '/assets/WorkoutTracker-deadbeef.js',
+          },
+          injectTo: 'head',
+        },
+      ],
+    })
+  })
+
+  it('is a no-op when there is no bundle (e.g. dev server)', () => {
+    const html = '<html><head></head></html>'
+    expect(runHandler(html, undefined)).toBe(html)
+  })
+
+  it('does not double-inject if the preload link already exists', () => {
+    const html =
+      '<html><head><link rel="modulepreload" href="/assets/WorkoutTracker-deadbeef.js"></head></html>'
+    expect(runHandler(html, makeBundle())).toBe(html)
+  })
+
+  it('only applies during build', () => {
+    expect(preloadDefaultViewPlugin().apply).toBe('build')
+  })
+})

--- a/vite-plugin-preload-default-view.ts
+++ b/vite-plugin-preload-default-view.ts
@@ -1,0 +1,91 @@
+/**
+ * Vite plugin: preload the default (Workouts) view chunk.
+ *
+ * App.vue lazy-loads WorkoutTracker via `defineAsyncComponent`, so the browser
+ * only discovers its chunk *after* the main entry script downloads, parses, and
+ * Vue mounts — a first-paint request waterfall:
+ *
+ *   index.html → main entry (js) → App mounts → discover WorkoutTracker → fetch
+ *
+ * WorkoutTracker is the default tab and always renders on boot, so there's no
+ * reason to wait for the entry to execute before starting its download. Emitting
+ * a `<link rel="modulepreload">` in the HTML head lets the browser fetch it in
+ * parallel with the entry, so the chunk is warm by the time Vue asks for it —
+ * collapsing the waterfall to a single round trip.
+ *
+ * The chunk filename is content-hashed, so we resolve it from the build bundle
+ * at transform time rather than hardcoding it (the SEV1 rule: never fabricate an
+ * identifier — read the real one from an authoritative source).
+ */
+import type { Plugin } from 'vite'
+
+/**
+ * Matches the container component for the default Workouts tab. Vue SFC module
+ * ids carry query suffixes (`WorkoutTracker.vue?vue&type=script…`), so allow an
+ * optional `?` after the extension.
+ */
+const DEFAULT_VIEW_MODULE = /WorkoutTracker\.vue(?:$|\?)/
+
+interface OutputChunkLike {
+  type: string
+  isDynamicEntry?: boolean
+  facadeModuleId?: string | null
+  moduleIds?: readonly string[]
+}
+
+/**
+ * Locate the emitted chunk for the default view.
+ * Exported for unit testing — takes the rollup output bundle and returns the
+ * hashed filename, or `undefined` if the chunk isn't present.
+ *
+ * A dynamically-imported Vue SFC has a `null` facadeModuleId (its facade is the
+ * `?vue&type=script` sub-module), so we identify the chunk by requiring it to be
+ * a dynamic entry that contains the WorkoutTracker.vue module — narrow enough to
+ * never match a shared/vendor chunk that merely re-exports it.
+ */
+export function findDefaultViewChunk(
+  bundle: Record<string, OutputChunkLike>,
+): string | undefined {
+  for (const [fileName, chunk] of Object.entries(bundle)) {
+    if (chunk.type !== 'chunk') continue
+    const matches =
+      (chunk.facadeModuleId && DEFAULT_VIEW_MODULE.test(chunk.facadeModuleId)) ||
+      (chunk.isDynamicEntry === true &&
+        (chunk.moduleIds ?? []).some((id) => DEFAULT_VIEW_MODULE.test(id)))
+    if (matches) return fileName
+  }
+  return undefined
+}
+
+export default function preloadDefaultViewPlugin(): Plugin {
+  return {
+    name: 'lift-preload-default-view',
+    apply: 'build', // Only meaningful for the hashed production bundle.
+    transformIndexHtml: {
+      // Run after Vite has generated the bundle so `ctx.bundle` is populated.
+      order: 'post',
+      handler(html, ctx) {
+        if (!ctx.bundle) return html
+
+        const chunkFileName = findDefaultViewChunk(ctx.bundle)
+        if (!chunkFileName) return html
+
+        const href = `/${chunkFileName}`
+        // Vite may already preload it (it doesn't for async-only chunks today,
+        // but guard against double-injection if that ever changes).
+        if (html.includes(`href="${href}"`)) return html
+
+        return {
+          html,
+          tags: [
+            {
+              tag: 'link',
+              attrs: { rel: 'modulepreload', crossorigin: true, href },
+              injectTo: 'head',
+            },
+          ],
+        }
+      },
+    },
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { readFileSync } from 'fs'
 import themeStripPlugin from './vite-plugin-theme-split'
+import preloadDefaultViewPlugin from './vite-plugin-preload-default-view'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
@@ -34,6 +35,7 @@ export default defineConfig({
   plugins: [
     vue(),
     themeStripPlugin(),
+    preloadDefaultViewPlugin(),
     VitePWA({
       // Disable the service worker entirely for the native Capacitor build (#532).
       // WKWebView serves the web assets bundled in the .ipa and refreshes them via


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-940](https://github.com/aschung212/Lift/issues/940)

LIFT-940 asked to add a `modulepreload` hint for the default (Workouts) view chunk. App.vue lazy-loads `WorkoutTracker` via `defineAsyncComponent`, so the browser only discovers its chunk *after* the entry script downloads, parses, and Vue mounts — a serial first-paint waterfall for the tab that always renders on boot. Since the chunk filename is content-hashed, the fix has to resolve the real name from the build bundle (per the SEV1 rule: never fabricate identifiers), so a small build-only Vite plugin is the right mechanism rather than a hardcoded `<link>` in `index.html`.

## Changes
- **`vite-plugin-preload-default-view.ts`** (new) — build-only plugin. A `transformIndexHtml` post-hook resolves the hashed `WorkoutTracker` chunk from `ctx.bundle` and injects `<link rel="modulepreload" crossorigin href="/assets/WorkoutTracker-<hash>.js">` into `<head>`. Matches the chunk by dynamic-entry + `moduleIds` (a dynamically-imported Vue SFC has a `null` `facadeModuleId`), narrow enough to never match a shared/vendor chunk. Guards against double-injection and no-ops in dev.
- **`vite.config.js`** — import and register the plugin after `themeStripPlugin()`.
- **`src/lib/__tests__/preloadDefaultView.test.ts`** (new) — 9 cases covering chunk resolution (dynamic-entry and facadeModuleId paths), non-chunk/shared-chunk rejection, tag injection shape, dev no-op, and double-injection guard.
- **`src/lib/__tests__/buildConfigRegression.test.ts`** — assert the plugin is wired into the config.

## Verification
- `npm run build` → confirmed `<link rel="modulepreload" crossorigin href="/assets/WorkoutTracker--nmRJu93.js">` now present in `dist/index.html` alongside the existing vue-vendor preload.
- `npm run typecheck` → clean.
- `npm run lint` → clean.
- `npx vitest run` → 2637 passed, 1 skipped (one flaky parallel-teardown artifact in CalendarView unrelated to this change; reran clean).

## Screenshots
N/A — build-config/perf change with no visual surface.

## Commits
- [`946938a`](https://github.com/aschung212/Lift/commit/946938a) perf(LIFT-940): preload the default Workouts view chunk to remove a first-paint waterfall

## Test Results
- Before: 2627 passing
- After: 2637 passing (10 delta)

---
_Automated by overnight pipeline — Wed Jul 15 23:29:22 PDT 2026_

## Preview
Test on your phone: https://lift-4gwarq2d0-aschung212-1101s-projects.vercel.app