### PR TITLE
perf(LIFT-938): lazy-load modern-screenshot rasterizer via dynamic import (#938)

### DIFF
--- a/src/lib/shareImage.ts
+++ b/src/lib/shareImage.ts
@@ -8,8 +8,6 @@
  * the pixelRatio multiplier produces the resolution platforms expect.
  */
 
-import { domToBlob } from 'modern-screenshot'
-
 export type CardFormat = 'square' | 'story'
 
 export interface ExportOptions {
@@ -39,8 +37,15 @@ export const EXPORT_PIXEL_RATIO = 3 // 360 → 1080, 640 → 1920
  * and a clone with `left: -10000px` renders entirely outside the SVG
  * viewport, producing a transparent PNG. Forcing the clone to render at
  * (0,0) inside the foreignObject is what we want.
+ *
+ * `modern-screenshot` is loaded via a dynamic `import()` so the rasterizer
+ * (a heavy dependency only ever used when the user actually exports a share
+ * card) splits into its own chunk instead of riding along in whatever chunk
+ * imports this module's lightweight constants (SHARE_CARD_HANDLE, watermark,
+ * CardFormat) — many card components pull those in eagerly (#938).
  */
 export async function renderNodeToBlob(node: HTMLElement, opts: ExportOptions): Promise<Blob> {
+  const { domToBlob } = await import('modern-screenshot')
   return domToBlob(node, {
     width: opts.width,
     height: opts.height,


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-938](https://github.com/aschung212/Lift/issues/938)

LIFT-938 asked to lazy-load the share-card rasterizer so it isn't in the eager path. Investigation showed the library was already migrated to `modern-screenshot` (LIFT-812) and statically imported in `src/lib/shareImage.ts`. Because that module also exports lightweight constants (`SHARE_CARD_HANDLE`, `WATERMARK_TEXT`, `CardFormat`) imported eagerly by all 11 card components and `SharePickerSheet`, the heavy rasterizer was dragged into the SharePickerSheet chunk — loaded the moment the picker opens, before any export. The fix: move `domToBlob` to a dynamic `import()` inside `renderNodeToBlob`, decoupling the rasterizer from the synchronous constant imports.

## Changes
- `src/lib/shareImage.ts` — removed the top-level `import { domToBlob } from 'modern-screenshot'`; `renderNodeToBlob` now does `const { domToBlob } = await import('modern-screenshot')`. Added a comment explaining the split.

## Verification
- Build: `modern-screenshot` splits into its own chunk. `SharePickerSheet` chunk drops **47.79 kB → 23.46 kB**; the ~24 kB rasterizer now loads only on actual card export, not on picker-open. Confirmed via before/after builds that it's absent from the boot entry (`index-*.js`).
- Tests: full suite `2627 passed | 1 skipped`. `shareImage.test.ts` + `useWorkoutShare.test.ts` (46 tests) pass — `vi.mock('modern-screenshot')` intercepts the dynamic import unchanged.
- Lint: clean.

## Issue updates
ISSUE_DONE:LIFT-938:Moved modern-screenshot to a dynamic import in renderNodeToBlob; rasterizer splits into its own chunk loaded only on export. SharePickerSheet chunk 47.8kB→23.5kB.

## Discoveries
ISSUE_DISCOVER:tooling: The pre-push Gemini 3.1 Pro review hook remains broken across all runs tonight — pinned `gemini-cli` 0.35.3 returns `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals` (migrate to Antigravity). Adversarial review has silently no-op'd for at least 4 consecutive runs; migrate the hook to a supported reviewer/client.

## Commits
- [`331d5ff`](https://github.com/aschung212/Lift/commit/331d5ff) perf(LIFT-938): lazy-load modern-screenshot rasterizer via dynamic import (#938)

## Test Results
- Before: 2627 passing
- After: 2627 passing (0 delta)

---
_Automated by overnight pipeline — Wed Jul 15 23:46:27 PDT 2026_

## Preview
Test on your phone: https://lift-o78tf716f-aschung212-1101s-projects.vercel.app