### PR TITLE
perf(LIFT-939): memoize store-level PR computation

### DIFF
--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -532,6 +532,56 @@ describe('workout store', () => {
         expect(allTime).toBeGreaterThan(store.getExercisePR(id, '2026-01-01'))
       })
     })
+
+    // The PR cache (LIFT-939) is keyed off the reactive `exercises` ref, and
+    // most store mutations edit sets IN PLACE and only call triggerRef — the
+    // array identity never changes. These guard that the memo invalidates on
+    // every mutation path rather than serving a stale value.
+    describe('memoization invalidation', () => {
+      it('reflects a newly logged set on the next read', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 135, 10) // ≈ 180
+        expect(store.getExercisePR(id)).toBe(store.getExercisePR(id)) // warm the cache
+        const before = store.getExercisePR(id)
+        store.logSet(id, 225, 3) // ≈ 248, higher
+        expect(store.getExercisePR(id)).toBeGreaterThan(before)
+        expect(store.getExercisePR(id)).toBe(248)
+      })
+
+      it('reflects an updated set on the next read', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 135, 10)
+        const setId = store.exercises.find(e => e.id === id)!.sets[0].id
+        expect(store.getExercisePR(id)).toBeGreaterThan(0) // warm the cache
+        store.updateSet(id, setId, 315, 5) // much heavier
+        expect(store.getExercisePR(id)).toBe(store.getExercisePRSet(id)!.estimated1RM)
+        expect(store.getExercisePRSet(id)!.weight).toBe(315)
+      })
+
+      it('reflects a deleted PR set on the next read', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 135, 10) // ≈ 180
+        store.logSet(id, 225, 3) // ≈ 248, the PR
+        const prSet = store.getExercisePRSet(id)! // warm the cache
+        expect(prSet.weight).toBe(225)
+        store.deleteSet(id, prSet.id)
+        expect(store.getExercisePRSet(id)!.weight).toBe(135)
+      })
+
+      it('caches distinct results per sinceDate baseline', () => {
+        const store = useWorkoutStore()
+        const id = store.addExercise('Bench')!
+        store.logSet(id, 315, 5, '2020-01-01T10:00:00Z') // high, pre-baseline
+        store.logSet(id, 135, 5, '2026-03-01T10:00:00Z') // low, post-baseline
+        // Interleave the two baselines to exercise the per-sinceDate memo maps.
+        expect(store.getExercisePR(id)).toBeGreaterThan(store.getExercisePR(id, '2026-01-01'))
+        expect(store.getExercisePR(id, '2026-01-01')).toBe(store.getExercisePRSet(id, '2026-01-01')!.estimated1RM)
+        expect(store.getExercisePRSet(id)!.weight).toBe(315)
+      })
+    })
   })
 
   describe('getLastSession', () => {

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -1047,6 +1047,54 @@ export const useWorkoutStore = defineStore('workout', () => {
     return [...dates].sort()
   })
 
+  // ── PR memoization (LIFT-939) ───────────────────────────────────
+  // getExercisePR / getExercisePRSet are called many times per render
+  // (the exercise list calls getRowMeta 3× per row, prsThisWeek loops
+  // every exercise), and each call did an O(n) `.find` plus an O(m) scan
+  // over the exercise's sets — O(rows × (n + m)) per WorkoutTracker render.
+  // This computed rebuilds an id→exercise index and an empty result memo,
+  // and is invalidated only when `exercises` changes (ref reassignment or
+  // the store's in-place-mutation `triggerRef(exercises)` calls). Results
+  // are filled lazily per baseline date and cached until the next mutation,
+  // so repeat lookups are O(1) and each exercise is scanned at most once.
+  interface PRResult {
+    pr: number
+    prSet: WorkoutSet | null
+  }
+  const _prCache = computed<{ byId: Map<string, Exercise>; bySince: Map<string, Map<string, PRResult>> }>(() => {
+    const byId = new Map<string, Exercise>()
+    for (const e of exercises.value) byId.set(e.id, e)
+    return { byId, bySince: new Map<string, Map<string, PRResult>>() }
+  })
+
+  function _computePRResult(exercise: Exercise | undefined, sinceDate: string | null): PRResult {
+    if (!exercise || exercise.sets.length === 0) return { pr: 0, prSet: null }
+    let best: WorkoutSet | null = null
+    for (const s of exercise.sets) {
+      if (sinceDate && s.date.slice(0, 10) < sinceDate) continue
+      // Strict `>` keeps the first set that reaches the max, matching the
+      // prior reduce()/Math.max() tie-breaking behavior.
+      if (!best || s.estimated1RM > best.estimated1RM) best = s
+    }
+    return best ? { pr: best.estimated1RM, prSet: best } : { pr: 0, prSet: null }
+  }
+
+  function _prResult(exerciseId: string, sinceDate: string | null): PRResult {
+    const { byId, bySince } = _prCache.value
+    const key = sinceDate ?? ''
+    let memo = bySince.get(key)
+    if (!memo) {
+      memo = new Map<string, PRResult>()
+      bySince.set(key, memo)
+    }
+    let result = memo.get(exerciseId)
+    if (!result) {
+      result = _computePRResult(byId.get(exerciseId), sinceDate)
+      memo.set(exerciseId, result)
+    }
+    return result
+  }
+
   /**
    * Max estimated1RM across all sets for an exercise.
    * When `sinceDate` (YYYY-MM-DD) is provided, only sets on or after that
@@ -1054,13 +1102,7 @@ export const useWorkoutStore = defineStore('workout', () => {
    * all-time behavior.
    */
   function getExercisePR(exerciseId: string, sinceDate?: string | null): number {
-    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
-    if (!exercise || exercise.sets.length === 0) return 0
-    const filtered = sinceDate
-      ? exercise.sets.filter((s: WorkoutSet) => s.date.slice(0, 10) >= sinceDate)
-      : exercise.sets
-    if (filtered.length === 0) return 0
-    return Math.max(...filtered.map((s: WorkoutSet) => s.estimated1RM))
+    return _prResult(exerciseId, sinceDate ?? null).pr
   }
 
   /**
@@ -1068,15 +1110,7 @@ export const useWorkoutStore = defineStore('workout', () => {
    * Respects `sinceDate` like getExercisePR.
    */
   function getExercisePRSet(exerciseId: string, sinceDate?: string | null): WorkoutSet | null {
-    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
-    if (!exercise || exercise.sets.length === 0) return null
-    const filtered = sinceDate
-      ? exercise.sets.filter((s: WorkoutSet) => s.date.slice(0, 10) >= sinceDate)
-      : exercise.sets
-    if (filtered.length === 0) return null
-    return filtered.reduce((best: WorkoutSet, s: WorkoutSet) =>
-      s.estimated1RM > best.estimated1RM ? s : best
-    )
+    return _prResult(exerciseId, sinceDate ?? null).prSet
   }
 
   /**


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-939](https://github.com/aschung212/Lift/issues/939)

LIFT-939 flagged that `getExercisePR`/`getExercisePRSet` are recomputed O(n×m) per WorkoutTracker render — each call did an O(n) `.find` to locate the exercise plus an O(m) scan over its sets. The exercise list calls `getRowMeta` 3× per row (each doing a `getExercisePRSet`) and `prsThisWeek` loops every exercise, so a single render was O(rows × (n + m)).

Key finding while reading the store: `exercises` is a `shallowRef` mutated **in place** (`exercise.sets.push(...)`) with `triggerRef(exercises)` — the array identity does *not* change on most mutations. A naive identity-keyed manual memo would therefore go stale. The correct invalidation signal is a Vue `computed` reading `exercises.value`, which `triggerRef` invalidates.

## Changes
- `src/stores/workout.ts` — Added a reactive PR cache: a `computed` builds an id→exercise index plus an empty per-baseline result memo, invalidated whenever `exercises` changes (reassignment or `triggerRef`). `_prResult(id, sinceDate)` fills results lazily, so repeat lookups are O(1) and each exercise is scanned at most once. `getExercisePR`/`getExercisePRSet` now delegate to it. Original tie-breaking (first set reaching the max) and `sinceDate` filtering preserved.
- `src/stores/__tests__/workout.test.ts` — Added a `memoization invalidation` block: verifies the cache busts across log/update/delete paths (the in-place-mutation risk) and isolates results per `sinceDate` baseline.

## Verification
- `npm test` — 2631 passed | 1 skipped (added 4 tests; the pre-run "1 error" is gone)
- `npm run lint` — clean
- `npm run build` — built in 3.88s, PWA generated

## Screenshots
None — internal store perf refactor, no UI change.

## Commits
- [`f18c996`](https://github.com/aschung212/Lift/commit/f18c996) perf(LIFT-939): memoize store-level PR computation

## Test Results
- Before: 2627 passing
- After: 2631 passing (4 delta)

---
_Automated by overnight pipeline — Wed Jul 15 23:54:26 PDT 2026_

## Preview
Test on your phone: https://lift-7gj4e0cr6-aschung212-1101s-projects.vercel.app