### PR TITLE
perf(LIFT-941): async-load SettingsSheet out of the initial chunk

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -132,7 +132,7 @@
       </nav>
 
       <!-- Settings bottom sheet (extracted to SettingsSheet.vue) -->
-      <SettingsSheet ref="settingsSheetRef" v-model="settingsOpen" @sign-out="handleSignOut" />
+      <SettingsSheet v-if="settingsOpen" ref="settingsSheetRef" v-model="settingsOpen" @sign-out="handleSignOut" />
     </template>
 
     <!-- Undo toast -->
@@ -230,7 +230,6 @@ import { isPreviewDeploy, isPreviewMode, initSupabase } from './lib/supabase'
 import ErrorBoundary from './components/ErrorBoundary.vue'
 import AuthScreen from './views/AuthScreen.vue'
 import OnboardingScreen from './views/OnboardingScreen.vue'
-import SettingsSheet from './components/SettingsSheet.vue'
 import PRBurst from './components/PRBurst.vue'
 import GoalCelebration from './components/GoalCelebration.vue'
 
@@ -251,6 +250,10 @@ const BodyweightTracker = defineAsyncComponent({
   loadingComponent: SkeletonLoader,
   delay: 100,
 })
+// Settings is reachable only behind a tap and pulls in training-report/data-export
+// UI many users never open — split it (and its transitive deps) into an on-demand
+// chunk, gated by v-if="settingsOpen" so the chunk isn't fetched until first open.
+const SettingsSheet = defineAsyncComponent(() => import('./components/SettingsSheet.vue'))
 import { useTheme, connectProgressionStore } from './composables/useTheme'
 import type { ThemeId } from './lib/themes'
 import { useProgressionStore } from './stores/progression'
@@ -324,7 +327,10 @@ window.addEventListener('offline', updateOnlineStatus)
 if (!navigator.onLine) syncStatus.value = 'offline'
 
 const settingsOpen = ref(false)
-const settingsSheetRef = ref<InstanceType<typeof SettingsSheet> | null>(null)
+// SettingsSheet is an async component, so a `typeof`-based InstanceType would
+// resolve to the loader wrapper, not the SFC. It only exposes closeSettings(),
+// so type the ref by the exposed surface we actually call.
+const settingsSheetRef = ref<{ closeSettings: () => void } | null>(null)
 
 // ── Focus traps for modals ─────────────────────────────────────
 const shortcutsFocus = useFocusTrap()


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-941](https://github.com/aschung212/Lift/issues/941)

LIFT-941 asked to async-load `SettingsSheet` so its report/export UI (and transitive deps) stays out of the initial chunk. In `App.vue`, the three main views (`WorkoutTracker`, `CalendarView`, `BodyweightTracker`) already use `defineAsyncComponent` + `v-if` tab-gating, but `SettingsSheet` — reachable only behind a settings tap — was statically imported, dragging ~80 kB (24 kB gzip) into the boot bundle. Fix: convert it to `defineAsyncComponent` and gate its render with `v-if="settingsOpen"` so the chunk is fetched only on first open, matching the established pattern.

## Changes
- `src/App.vue`:
  - Removed the static `SettingsSheet` import; replaced with `defineAsyncComponent(() => import('./components/SettingsSheet.vue'))`.
  - Added `v-if="settingsOpen"` to the `<SettingsSheet>` element so the chunk loads only when settings first opens. The component's own animated `closeSettings()` (animation → emit `update:modelValue false`) still plays fully before the outer `v-if` unmounts it.
  - Retyped `settingsSheetRef` to its exposed surface `{ closeSettings: () => void }` — an `InstanceType<typeof …>` would resolve to the async loader wrapper, not the SFC. Only `closeSettings()` is ever called on the ref.

## Verification
- `npm run lint` — clean
- `npm run build` — succeeds; `SettingsSheet-*.js` is now its own 80.04 kB (23.87 kB gzip) chunk, split out of the main `index` bundle
- `npm test` — 2627 passed, 1 skipped (unchanged from baseline)
- The `progressbarA11y.test.ts` reference to SettingsSheet reads the `.vue` source directly, so it's unaffected by the import change.

Note: the pre-push Gemini 3.1 Pro review hook failed with `IneligibleTierError` (already-known broken reviewer, flagged in prior runs) — no adversarial review ran.

## Screenshots
None — this is a code-splitting change with no visual/behavioral difference.

## Commits
- [`6a144c8`](https://github.com/aschung212/Lift/commit/6a144c8) perf(LIFT-941): async-load SettingsSheet out of the initial chunk

## Test Results
- Before: 2627 passing
- After: 2627 passing (0 delta)

---
_Automated by overnight pipeline — Thu Jul 16 00:01:41 PDT 2026_

## Preview
Test on your phone: https://lift-9z57s84xn-aschung212-1101s-projects.vercel.app