### PR TITLE
perf(LIFT-937): code-split the 11 share-card components into per-card chunks

### DIFF
--- a/src/components/share/SharePickerSheet.vue
+++ b/src/components/share/SharePickerSheet.vue
@@ -39,7 +39,7 @@
         >
           <div class="spThumbCard" :class="{ spThumbCardStory: format === 'story' }">
             <div class="spThumbInner" :class="{ spThumbInnerStory: format === 'story' }">
-              <component :is="card.component" :summary="summary" />
+              <component :is="cardComponent(card.id)" :summary="summary" />
               <span v-if="showWatermark" class="spWatermark" aria-hidden="true">{{ WATERMARK_TEXT }}</span>
             </div>
           </div>
@@ -74,7 +74,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { SessionSummary } from '../../lib/sessionSummary'
 import { WATERMARK_TEXT, type CardFormat } from '../../lib/shareImage'
-import { eligibleSquareCards, eligibleStoryCards, resolveInitialCard } from './cardRegistry'
+import { cardComponent, eligibleSquareCards, eligibleStoryCards, loadCardComponent, resolveInitialCard } from './cardRegistry'
 import { useWorkoutShare } from '../../composables/useWorkoutShare'
 import { useTheme } from '../../composables/useTheme'
 import { useModal } from '../../composables/useModal'
@@ -142,11 +142,14 @@ function selectCard(i: number) {
 watch(cards, () => { activeIndex.value = 0 })
 
 async function onShare() {
-  if (!activeCard.value) return
+  const card = activeCard.value
+  if (!card) return
   lastResult.value = null
+  const component = await loadCardComponent(card.id)
+  if (!component) return
   const res = await shareCard({
-    component: activeCard.value.component,
-    format: activeCard.value.format,
+    component,
+    format: card.format,
     summary: props.summary,
     theme: currentTheme.value,
     mode: resolvedMode.value,
@@ -158,11 +161,14 @@ async function onShare() {
 }
 
 async function onSave() {
-  if (!activeCard.value) return
+  const card = activeCard.value
+  if (!card) return
   lastResult.value = null
+  const component = await loadCardComponent(card.id)
+  if (!component) return
   const res = await downloadCard({
-    component: activeCard.value.component,
-    format: activeCard.value.format,
+    component,
+    format: card.format,
     summary: props.summary,
     theme: currentTheme.value,
     mode: resolvedMode.value,

--- a/src/components/share/__tests__/SharePickerSheet.test.ts
+++ b/src/components/share/__tests__/SharePickerSheet.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { mount, VueWrapper } from '@vue/test-utils'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils'
 import { ref } from 'vue'
 import SharePickerSheet from '../SharePickerSheet.vue'
 import type { SessionSummary } from '../../../lib/sessionSummary'
@@ -66,9 +66,16 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
 describe('SharePickerSheet share-funnel analytics (#712)', () => {
   let wrapper: VueWrapper
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     wrapper = mount(SharePickerSheet, { props: { summary: makeSummary() } })
+    // Cards are code-split behind dynamic imports (#937); let the thumbnails'
+    // async components settle so their imports don't resolve after teardown.
+    await flushPromises()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
   })
 
   it('logs share_opened when the sheet mounts', () => {

--- a/src/components/share/__tests__/cardHandle.test.ts
+++ b/src/components/share/__tests__/cardHandle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { SQUARE_CARDS, STORY_CARDS } from '../cardRegistry'
+import { SQUARE_CARDS, STORY_CARDS, loadCardComponent } from '../cardRegistry'
 import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
 import type { SessionSummary } from '../../../lib/sessionSummary'
 
@@ -51,19 +51,23 @@ describe('share-card handle (issue #714)', () => {
     expect(SHARE_CARD_HANDLE).not.toMatch(/^https?:\/\//)
   })
 
-  it.each(ALL_CARDS.map((c) => [c.id, c.component] as const))(
+  it.each(ALL_CARDS.map((c) => c.id))(
     'renders the app handle on the %s card',
-    (_id, component) => {
+    async (id) => {
+      // Cards are code-split behind a dynamic import (#937); resolve the real
+      // component before mounting so we still assert on rendered card content.
+      const component = (await loadCardComponent(id))!
       const wrapper = mount(component, { props: { summary: makeSummary() } })
       expect(wrapper.text()).toContain(SHARE_CARD_HANDLE)
     },
   )
 
-  it('still renders the handle when there is no best set (defensive empty-day render)', () => {
+  it('still renders the handle when there is no best set (defensive empty-day render)', async () => {
     // PR Focus / Best Set bodies are v-if'd on bestSet; the handle lives
     // outside those guards so it must survive a null bestSet.
-    for (const { id, component } of ALL_CARDS) {
+    for (const { id } of ALL_CARDS) {
       if (id === 'pr-focus') continue // hidden entirely when prs === 0 / no bestSet
+      const component = (await loadCardComponent(id))!
       const wrapper = mount(component, {
         props: { summary: makeSummary({ bestSet: null, prs: 0, repPRs: 0, highlights: [] }) },
       })

--- a/src/components/share/cardRegistry.ts
+++ b/src/components/share/cardRegistry.ts
@@ -7,22 +7,17 @@
  * PR Focus card is hidden when no PRs were set).
  */
 
-import type { Component } from 'vue'
+import { defineAsyncComponent, type Component } from 'vue'
 import type { CardFormat } from '../../lib/shareImage'
 import type { SessionSummary } from '../../lib/sessionSummary'
 
-import BoldFloodCard from './cards/BoldFloodCard.vue'
-import ReceiptCard from './cards/ReceiptCard.vue'
-import WeekChartCard from './cards/WeekChartCard.vue'
-import BestSetCard from './cards/BestSetCard.vue'
-import StatGridCard from './cards/StatGridCard.vue'
-import DailyRingCard from './cards/DailyRingCard.vue'
-import TicketStubCard from './cards/TicketStubCard.vue'
-import PrFocusCard from './cards/PrFocusCard.vue'
-
-import BoldFloodStory from './cards/BoldFloodStory.vue'
-import BestSetStory from './cards/BestSetStory.vue'
-import WeekChartStory from './cards/WeekChartStory.vue'
+/**
+ * A card component is loaded lazily via dynamic `import()` so the 11 SVG-heavy
+ * card `.vue` files are code-split out of the boot bundle and out of the
+ * SharePickerSheet chunk (#937). A card's code is only fetched when its
+ * thumbnail renders in the picker or when it's rasterized for a share.
+ */
+type CardLoader = () => Promise<{ default: Component }>
 
 export interface CardEntry {
   id: string
@@ -32,30 +27,31 @@ export interface CardEntry {
   format: CardFormat
   /** Returns false to hide this card given the current summary. */
   eligible?: (summary: SessionSummary) => boolean
-  component: Component
+  /** Dynamically imports the card component (lazy, code-split per card). */
+  loader: CardLoader
 }
 
 export const SQUARE_CARDS: CardEntry[] = [
-  { id: 'bold-flood', label: 'Bold', format: 'square', component: BoldFloodCard },
-  { id: 'receipt', label: 'Receipt', format: 'square', component: ReceiptCard },
-  { id: 'week-chart', label: 'Week', format: 'square', component: WeekChartCard },
-  { id: 'best-set', label: 'Best set', format: 'square', component: BestSetCard },
-  { id: 'stat-grid', label: 'Stats', format: 'square', component: StatGridCard },
-  { id: 'daily-ring', label: 'Ring', format: 'square', component: DailyRingCard },
-  { id: 'ticket-stub', label: 'Ticket', format: 'square', component: TicketStubCard },
+  { id: 'bold-flood', label: 'Bold', format: 'square', loader: () => import('./cards/BoldFloodCard.vue') },
+  { id: 'receipt', label: 'Receipt', format: 'square', loader: () => import('./cards/ReceiptCard.vue') },
+  { id: 'week-chart', label: 'Week', format: 'square', loader: () => import('./cards/WeekChartCard.vue') },
+  { id: 'best-set', label: 'Best set', format: 'square', loader: () => import('./cards/BestSetCard.vue') },
+  { id: 'stat-grid', label: 'Stats', format: 'square', loader: () => import('./cards/StatGridCard.vue') },
+  { id: 'daily-ring', label: 'Ring', format: 'square', loader: () => import('./cards/DailyRingCard.vue') },
+  { id: 'ticket-stub', label: 'Ticket', format: 'square', loader: () => import('./cards/TicketStubCard.vue') },
   {
     id: 'pr-focus',
     label: 'PR',
     format: 'square',
-    component: PrFocusCard,
+    loader: () => import('./cards/PrFocusCard.vue'),
     eligible: (s) => s.prs > 0 && s.bestSet !== null,
   },
 ]
 
 export const STORY_CARDS: CardEntry[] = [
-  { id: 'bold-flood-story', label: 'Bold', format: 'story', component: BoldFloodStory },
-  { id: 'best-set-story', label: 'Best set', format: 'story', component: BestSetStory },
-  { id: 'week-chart-story', label: 'Week', format: 'story', component: WeekChartStory },
+  { id: 'bold-flood-story', label: 'Bold', format: 'story', loader: () => import('./cards/BoldFloodStory.vue') },
+  { id: 'best-set-story', label: 'Best set', format: 'story', loader: () => import('./cards/BestSetStory.vue') },
+  { id: 'week-chart-story', label: 'Week', format: 'story', loader: () => import('./cards/WeekChartStory.vue') },
 ]
 
 /**
@@ -81,6 +77,36 @@ export function eligibleStoryCards(summary: SessionSummary): CardEntry[] {
 /** Look up a card by id, regardless of format bucket. */
 export function findCard(id: string): CardEntry | null {
   return SQUARE_CARDS.find((c) => c.id === id) || STORY_CARDS.find((c) => c.id === id) || null
+}
+
+/**
+ * Async component wrappers for rendering card thumbnails in the picker.
+ * Memoized per id so Vue sees a stable component identity across re-renders
+ * (a fresh `defineAsyncComponent` each render would remount the thumbnail).
+ */
+const asyncComponentCache = new Map<string, Component>()
+
+/** Returns the lazily-loaded async component for a card id (for the picker). */
+export function cardComponent(id: string): Component | null {
+  const cached = asyncComponentCache.get(id)
+  if (cached) return cached
+  const entry = findCard(id)
+  if (!entry) return null
+  const comp = defineAsyncComponent(entry.loader)
+  asyncComponentCache.set(id, comp)
+  return comp
+}
+
+/**
+ * Resolves a card id to its concrete component (awaiting the dynamic import).
+ * The offscreen rasterizer needs the real component so it renders synchronously
+ * before capture — an unresolved async wrapper would rasterize a blank frame.
+ */
+export async function loadCardComponent(id: string): Promise<Component | null> {
+  const entry = findCard(id)
+  if (!entry) return null
+  const mod = await entry.loader()
+  return mod.default
 }
 
 /**


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-937](https://github.com/aschung212/Lift/issues/937)

LIFT-937 flagged that `cardRegistry.ts` statically imported all 11 SVG-heavy share-card `.vue` components, so any module referencing the registry pulled every card into its chunk. Investigation showed `SharePickerSheet` is already lazy-loaded (via `defineAsyncComponent` from `PRBurst`/`WorkoutCompleteView`), so the cards weren't in the *boot* bundle — they were bloating the ~47.8 kB SharePickerSheet chunk. Fix: replace the eager `component` field with a per-card dynamic-import `loader`, splitting each card into its own on-demand chunk.

Key constraint: `useWorkoutShare.renderCardOffscreen` renders the card via `h(component)` + two `nextTick`s and immediately rasterizes it — an unresolved async wrapper would capture a blank frame. So I resolve the concrete component (`loadCardComponent`) *before* sharing, rather than relying on the thumbnail having pre-resolved it.

## Changes
- **`src/components/share/cardRegistry.ts`** — `CardEntry.component: Component` → `loader: () => Promise<{ default: Component }>`, each entry using `() => import('./cards/X.vue')`. Added `cardComponent(id)` (memoized `defineAsyncComponent` for stable thumbnail identity) and `loadCardComponent(id)` (awaits the real component for rasterization).
- **`src/components/share/SharePickerSheet.vue`** — thumbnails render via `cardComponent(card.id)`; `onShare`/`onSave` await `loadCardComponent(card.id)` before invoking the rasterizer.
- **`src/components/share/__tests__/cardHandle.test.ts`** — resolves each card via `loadCardComponent` before mounting (preserves the handle-rendering assertion).
- **`src/components/share/__tests__/SharePickerSheet.test.ts`** — `flushPromises()` after mount + `afterEach` unmount so lazy thumbnail imports settle before teardown (avoids an environment-teardown race).

## Verification
- `npm run lint` — clean
- `npm run typecheck` (vue-tsc) — clean
- `npm run build` — succeeds; each card is now its own chunk (~1–2 kB each), SharePickerSheet chunk drops 47.8 kB → 35.53 kB (16.8 → 13.57 kB gzip)
- `npx vitest run` — 2627 passed / 1 skipped
- Gemini pre-push review hook errored with the known `IneligibleTierError` (broken client, already tracked); push completed.

## Screenshots
N/A — no visual change (build-time code-splitting only; picker/share UX identical).

## Commits
- [`d4ebaa9`](https://github.com/aschung212/Lift/commit/d4ebaa9) perf(LIFT-937): code-split the 11 share-card components into per-card chunks

## Test Results
- Before: 2627 passing
- After: 2627 passing (0 delta)

---
_Automated by overnight pipeline — Thu Jul 16 00:10:53 PDT 2026_

## Preview
Test on your phone: https://lift-4fp2r6ek5-aschung212-1101s-projects.vercel.app