### PR TITLE
fix(LIFT-947): validate localStorage JSON before the one-way Supabase migration insert

### DIFF
--- a/src/lib/__tests__/migrate.test.ts
+++ b/src/lib/__tests__/migrate.test.ts
@@ -250,4 +250,104 @@ describe('migrateLocalStorageToSupabase', () => {
 
     expect(mockInsert).not.toHaveBeenCalledWith('bodyweight_entries', expect.anything())
   })
+
+  // ── LIFT-947: validate untrusted localStorage before the one-way cloud insert ──
+
+  it('drops sets with missing/invalid required fields, migrating only valid ones', async () => {
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      {
+        name: 'Bench Press',
+        sets: [
+          { date: '2026-03-30', weight: 100, reps: 8, estimated1RM: 125 }, // valid
+          { weight: 100, reps: 8, estimated1RM: 125 }, // missing date
+          { date: '2026-03-30', weight: '110', reps: 5, estimated1RM: 128 }, // string weight
+          { date: '2026-03-30', weight: 120, reps: null, estimated1RM: 130 }, // null reps
+          { date: '2026-03-30', weight: Infinity, reps: 5, estimated1RM: 130 }, // non-finite weight
+          null, // not an object
+        ],
+      },
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).toHaveBeenCalledWith('exercises', [
+      { id: 'test-uuid-1', user_id: 'user-1', name: 'Bench Press' },
+    ])
+    expect(mockInsert).toHaveBeenCalledWith('sets', [
+      { id: 'test-uuid-2', user_id: 'user-1', exercise_id: 'test-uuid-1', date: '2026-03-30', weight: 100, reps: 8, estimated_1rm: 125 },
+    ])
+  })
+
+  it('repairs a missing/invalid estimated1RM via Epley instead of dropping the set', async () => {
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      {
+        name: 'Squat',
+        sets: [
+          { date: '2026-03-30', weight: 100, reps: 10 }, // no estimated1RM → epley(100,10)=133
+          { date: '2026-03-30', weight: 140, reps: 5, estimated1RM: 'oops' }, // bad type → epley(140,5)=163
+        ],
+      },
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).toHaveBeenCalledWith('sets', [
+      { id: 'test-uuid-2', user_id: 'user-1', exercise_id: 'test-uuid-1', date: '2026-03-30', weight: 100, reps: 10, estimated_1rm: 133 },
+      { id: 'test-uuid-3', user_id: 'user-1', exercise_id: 'test-uuid-1', date: '2026-03-30', weight: 140, reps: 5, estimated_1rm: 163 },
+    ])
+  })
+
+  it('drops malformed exercises (missing/blank name or non-object) before inserting', async () => {
+    localStorageMock['workout-exercises'] = JSON.stringify([
+      { name: 'Deadlift', sets: [] }, // valid
+      { name: '' }, // blank name
+      { sets: [] }, // no name
+      'not-an-object',
+      null,
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).toHaveBeenCalledWith('exercises', [
+      { id: 'test-uuid-1', user_id: 'user-1', name: 'Deadlift' },
+    ])
+  })
+
+  it('ignores a non-array exercises blob without throwing', async () => {
+    localStorageMock['workout-exercises'] = JSON.stringify({ not: 'an array' })
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).not.toHaveBeenCalled()
+  })
+
+  it('drops bodyweight entries with missing/invalid fields, migrating only valid ones', async () => {
+    localStorageMock['bodyweight-entries'] = JSON.stringify([
+      { date: '2026-03-28', weight: 185 }, // valid
+      { weight: 185 }, // missing date
+      { date: '2026-03-29', weight: 'heavy' }, // string weight
+      { date: '2026-03-30', weight: NaN }, // non-finite
+      null,
+    ])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).toHaveBeenCalledWith('bodyweight_entries', [
+      { id: 'test-uuid-1', user_id: 'user-1', date: '2026-03-28', weight: 185 },
+    ])
+  })
+
+  it('surfaces (does not silently drop) a failed bodyweight insert', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockInsert.mockImplementation((table: string) =>
+      table === 'bodyweight_entries' ? { error: { message: 'insert failed' } } : { error: null }
+    )
+    localStorageMock['bodyweight-entries'] = JSON.stringify([{ date: '2026-03-28', weight: 185 }])
+
+    await migrateLocalStorageToSupabase('user-1')
+
+    expect(mockInsert).toHaveBeenCalledWith('bodyweight_entries', expect.anything())
+    expect(errorSpy).toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
 })

--- a/src/lib/migrate.ts
+++ b/src/lib/migrate.ts
@@ -1,22 +1,126 @@
 import { supabase } from './supabase'
 import { uuid } from './uuid'
+import { epley } from './epley'
+import { logError, logWarn } from './logger'
 
 const WORKOUT_KEY = 'workout-exercises'
 const BODYWEIGHT_KEY = 'bodyweight-entries'
 
-interface LocalExercise {
+interface ValidExerciseRow {
+  id: string
+  user_id: string
   name: string
-  sets?: Array<{
-    date: string
-    weight: number
-    reps: number
-    estimated1RM: number
-  }>
 }
 
-interface LocalBodyweightEntry {
+interface ValidSetRow {
+  id: string
+  user_id: string
+  exercise_id: string
   date: string
   weight: number
+  reps: number
+  estimated_1rm: number
+}
+
+interface ValidBodyweightRow {
+  id: string
+  user_id: string
+  date: string
+  weight: number
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.length > 0
+}
+
+function isFiniteNumber(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+/**
+ * Validate the localStorage exercise blob element-by-element and build the
+ * concrete insert rows. This is a one-way boundary into the cloud DB, so a
+ * single corrupt element (a string weight, a missing date) must be dropped
+ * here rather than propagated into a NOT NULL / numeric-column insert that
+ * fails the whole batch — or, worse, persisted and synced back to every
+ * device. (LIFT-947) A missing/invalid `estimated1RM` on an otherwise-valid
+ * set is repaired via Epley rather than discarded, preserving legacy and
+ * CSV-imported data whose e1RM was never computed.
+ */
+function buildExerciseAndSetRows(
+  raw: unknown,
+  userId: string,
+): { exerciseRows: ValidExerciseRow[]; setRows: ValidSetRow[] } {
+  const exerciseRows: ValidExerciseRow[] = []
+  const setRows: ValidSetRow[] = []
+  if (!Array.isArray(raw)) {
+    if (raw !== undefined) logWarn('Migration: exercises blob is not an array, skipping', { raw })
+    return { exerciseRows, setRows }
+  }
+
+  for (const ex of raw) {
+    if (typeof ex !== 'object' || ex === null || !isNonEmptyString((ex as { name?: unknown }).name)) {
+      logWarn('Migration: skipping malformed exercise', { ex })
+      continue
+    }
+    const exercise = ex as { name: string; sets?: unknown }
+    const exerciseId = uuid()
+    exerciseRows.push({ id: exerciseId, user_id: userId, name: exercise.name })
+
+    if (exercise.sets === undefined) continue
+    if (!Array.isArray(exercise.sets)) {
+      logWarn('Migration: exercise sets is not an array, skipping its sets', { name: exercise.name })
+      continue
+    }
+    for (const s of exercise.sets) {
+      if (typeof s !== 'object' || s === null) {
+        logWarn('Migration: skipping malformed set', { exercise: exercise.name, set: s })
+        continue
+      }
+      const set = s as { date?: unknown; weight?: unknown; reps?: unknown; estimated1RM?: unknown }
+      if (!isNonEmptyString(set.date) || !isFiniteNumber(set.weight) || !isFiniteNumber(set.reps)) {
+        logWarn('Migration: skipping set with missing/invalid required field', {
+          exercise: exercise.name,
+          set: s,
+        })
+        continue
+      }
+      setRows.push({
+        id: uuid(),
+        user_id: userId,
+        exercise_id: exerciseId,
+        date: set.date,
+        weight: set.weight,
+        reps: set.reps,
+        estimated_1rm: isFiniteNumber(set.estimated1RM)
+          ? set.estimated1RM
+          : epley(set.weight, set.reps),
+      })
+    }
+  }
+  return { exerciseRows, setRows }
+}
+
+/** Validate the localStorage bodyweight blob element-by-element. (LIFT-947) */
+function buildBodyweightRows(raw: unknown, userId: string): ValidBodyweightRow[] {
+  const rows: ValidBodyweightRow[] = []
+  if (!Array.isArray(raw)) {
+    if (raw !== undefined) logWarn('Migration: bodyweight blob is not an array, skipping', { raw })
+    return rows
+  }
+  for (const e of raw) {
+    if (typeof e !== 'object' || e === null) {
+      logWarn('Migration: skipping malformed bodyweight entry', { entry: e })
+      continue
+    }
+    const entry = e as { date?: unknown; weight?: unknown }
+    if (!isNonEmptyString(entry.date) || !isFiniteNumber(entry.weight)) {
+      logWarn('Migration: skipping bodyweight entry with missing/invalid field', { entry: e })
+      continue
+    }
+    rows.push({ id: uuid(), user_id: userId, date: entry.date, weight: entry.weight })
+  }
+  return rows
 }
 
 export async function migrateLocalStorageToSupabase(userId: string): Promise<void> {
@@ -36,45 +140,28 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
   if (countError) return // can't trust the guard — retry next session
   if (count && count > 0) return // User already has cloud data, skip
 
-  // Read localStorage data
-  let exercises: LocalExercise[] = []
-  let bodyweightEntries: LocalBodyweightEntry[] = []
+  // Read + validate localStorage data at this one-way boundary. Untrusted JSON
+  // is validated element-by-element (LIFT-947) so corrupt/legacy rows are
+  // dropped here instead of failing the whole cloud insert or persisting bad
+  // data that then syncs back to every device.
+  let rawExercisesParsed: unknown
+  let rawEntriesParsed: unknown
   try {
     const rawExercises = localStorage.getItem(WORKOUT_KEY)
-    if (rawExercises) exercises = JSON.parse(rawExercises)
+    if (rawExercises) rawExercisesParsed = JSON.parse(rawExercises)
   } catch { /* empty */ }
   try {
     const rawEntries = localStorage.getItem(BODYWEIGHT_KEY)
-    if (rawEntries) bodyweightEntries = JSON.parse(rawEntries)
+    if (rawEntries) rawEntriesParsed = JSON.parse(rawEntries)
   } catch { /* empty */ }
 
-  if (exercises.length === 0 && bodyweightEntries.length === 0) return
+  const { exerciseRows, setRows } = buildExerciseAndSetRows(rawExercisesParsed, userId)
+  const bwRows = buildBodyweightRows(rawEntriesParsed, userId)
+
+  if (exerciseRows.length === 0 && bwRows.length === 0) return
 
   // Migrate exercises and sets
-  if (exercises.length > 0) {
-    const exerciseRows: Array<{ id: string; user_id: string; name: string }> = []
-    const setRows: Array<{ id: string; user_id: string; exercise_id: string; date: string; weight: number; reps: number; estimated_1rm: number }> = []
-
-    for (const ex of exercises) {
-      const exerciseId = uuid()
-      exerciseRows.push({
-        id: exerciseId,
-        user_id: userId,
-        name: ex.name
-      })
-      for (const s of (ex.sets || [])) {
-        setRows.push({
-          id: uuid(),
-          user_id: userId,
-          exercise_id: exerciseId,
-          date: s.date,
-          weight: s.weight,
-          reps: s.reps,
-          estimated_1rm: s.estimated1RM
-        })
-      }
-    }
-
+  if (exerciseRows.length > 0) {
     const { error: exerciseError } = await supabase.from('exercises').insert(exerciseRows)
     // Abort before touching dependent sets if the exercises insert failed.
     // Nothing has landed, so the count guard stays open and a later session
@@ -105,7 +192,7 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
   // a partial failure (e.g. exercises migrated but a previous run died before
   // this insert) can resume without duplicating already-migrated bodyweight,
   // and a transient error here leaves the door open for a clean retry. (LIFT-787)
-  if (bodyweightEntries.length > 0) {
+  if (bwRows.length > 0) {
     const { count: bwCount, error: bwCountError } = await supabase
       .from('bodyweight_entries')
       .select('*', { count: 'exact', head: true })
@@ -114,12 +201,10 @@ export async function migrateLocalStorageToSupabase(userId: string): Promise<voi
     if (bwCountError) return // can't trust the guard — retry next session
     if (bwCount && bwCount > 0) return // bodyweight already migrated, skip
 
-    const bwRows = bodyweightEntries.map(e => ({
-      id: uuid(),
-      user_id: userId,
-      date: e.date,
-      weight: e.weight
-    }))
-    await supabase.from('bodyweight_entries').insert(bwRows)
+    // Surface a failed bodyweight insert instead of dropping it fire-and-forget
+    // — a rejected migration was previously invisible, masking data loss. The
+    // bodyweight count guard stays open so a later session can retry. (LIFT-947)
+    const { error: bwError } = await supabase.from('bodyweight_entries').insert(bwRows)
+    if (bwError) logError(bwError, { context: 'migrateLocalStorageToSupabase: bodyweight insert failed' })
   }
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-947](https://github.com/aschung212/Lift/issues/947)

LIFT-947 flagged that `migrate.ts` deserialized `workout-exercises`/`bodyweight-entries` with a bare `JSON.parse(...) as LocalExercise[]` and pushed `date`/`weight`/`reps`/`estimated1RM` straight into the exercises/sets/bodyweight_entries inserts. This is a one-way boundary into the cloud DB, so corrupt or legacy-shaped local data (missing date, string weight, missing set field) could violate NOT NULL / numeric constraints and fail the whole batch — or persist and sync bad rows to every device. The shared `parseGuards.ts` from LIFT-946 is not on master yet, so I kept validation self-contained in `migrate.ts` to avoid a merge conflict.

## Changes
- `src/lib/migrate.ts` — added `buildExerciseAndSetRows`/`buildBodyweightRows` validators that check each element: exercises need a non-empty string `name`; sets need present, correctly-typed `date`/`weight`/`reps`; malformed rows are dropped with `logWarn`. A missing/invalid `estimated1RM` is repaired via the existing `epley()` helper rather than discarding an otherwise-valid set. Replaced the `as`-cast parse with `unknown` + validation, and surfaced a failed bodyweight insert via `logError` instead of the previous fire-and-forget `await`.
- `src/lib/__tests__/migrate.test.ts` — 6 new regression tests: bad-field set drop, e1RM Epley repair, malformed-exercise drop, non-array blob, bad-field bodyweight drop, surfaced bodyweight insert error.

## Verification
- `npm run lint` — clean
- `npm run build` — clean (typecheck + Vite build succeed)
- `npx vitest run src/lib/__tests__/migrate.test.ts` — 18/18 pass
- `npx vitest run` — 2633 passed, 1 skipped (the 1 unhandled rejection is pre-existing chart-component flakiness, confirmed unrelated to this change)

## Screenshots
None — this is a non-visual data-integrity change to the migration boundary.

## Commits
- [`9049440`](https://github.com/aschung212/Lift/commit/9049440) fix(LIFT-947): validate localStorage JSON before the one-way Supabase migration insert

## Test Results
- Before: 2627 passing
- After: 2633 passing (6 delta)

---
_Automated by overnight pipeline — Thu Jul 16 00:30:30 PDT 2026_

## Preview
Test on your phone: https://lift-iw3cr0c0j-aschung212-1101s-projects.vercel.app