### PR TITLE
refactor(LIFT-948): bind SyncDescriptor row/table typing to the generated schema

### DIFF
--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { supabase, isPreviewMode } from './supabase'
+import type { Database } from './database.types'
 import { logError, logWarn } from './logger'
 import { broadcastSyncStatus } from './crossTabSync'
 import { backupToIDB, restoreFromIDB } from './durableStorage'
@@ -7,8 +8,36 @@ import { isAuthError, ensureFreshSession } from './sessionHealth'
 
 type SyncOperation = () => PromiseLike<unknown>
 
+/** The public schema's writable tables, keyed by name (LIFT-948). */
+type PublicTables = Database['public']['Tables']
+
 /**
- * Serializable description of a Supabase mutation (LIFT-706).
+ * Table names a journaled descriptor may target — bound to the generated
+ * Supabase schema (LIFT-948). Modeling this as `keyof PublicTables` instead of
+ * a bare `string` means a descriptor built with a misspelled or stale table name
+ * fails typechecking at the producer instead of at runtime against the server.
+ */
+export type SyncTable = keyof PublicTables
+
+/**
+ * Serializable description of a single-table Supabase mutation, with its `row`
+ * / `values` / `match` typed against that table's generated Insert / Update /
+ * Row shapes (LIFT-948). Generic over the specific table `T` so the table
+ * literal is linked to the column names allowed in the payload — a descriptor
+ * carrying a column that doesn't exist on `T` no longer compiles.
+ */
+export type SyncDescriptorFor<T extends SyncTable> =
+  | { op: 'upsert'; table: T; row: PublicTables[T]['Insert'] }
+  | {
+      op: 'update'
+      table: T
+      values: PublicTables[T]['Update']
+      match: Partial<PublicTables[T]['Row']>
+    }
+
+/**
+ * Serializable description of a Supabase mutation (LIFT-706, hardened in
+ * LIFT-948).
  *
  * The in-memory queue holds closures, which cannot survive a tab close or
  * app restart. To harden offline writes — where every logged set is hard-won
@@ -21,10 +50,12 @@ type SyncOperation = () => PromiseLike<unknown>
  * idempotency invariant enforced in architecturalInvariants.test.ts — replay
  * is safe because re-running an upsert or a targeted update is a no-op once the
  * server already holds the value.
+ *
+ * The union is distributed over every known table so the discriminating `table`
+ * literal is tied to the payload columns for that specific table, rather than
+ * modeling rows as an untyped `Record<string, unknown>`.
  */
-export type SyncDescriptor =
-  | { op: 'upsert'; table: string; row: Record<string, unknown> }
-  | { op: 'update'; table: string; values: Record<string, unknown>; match: Record<string, unknown> }
+export type SyncDescriptor = { [T in SyncTable]: SyncDescriptorFor<T> }[SyncTable]
 
 interface JournalEntry {
   descriptor: SyncDescriptor
@@ -104,6 +135,19 @@ export function isReplayableDescriptor(descriptor: unknown): descriptor is SyncD
 }
 
 /**
+ * The one place the dynamically-dispatched table name defeats the strongly-typed
+ * client surface (LIFT-948). A descriptor's `table` is only known at runtime, so
+ * `supabase.from(table)` can't be resolved to a single table's builder type —
+ * this helper isolates that single `any` cast rather than letting it leak across
+ * `executeDescriptor`. Callers reach it only after `isReplayableDescriptor` has
+ * bounded `table` to the known allowlist.
+ */
+function fromTable(table: SyncTable) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (supabase as any).from(table)
+}
+
+/**
  * Rebuild a runnable Supabase operation from its serializable descriptor.
  * Used to replay journaled writes after a reload. Returns a no-op promise when
  * Supabase is unavailable so replay degrades gracefully offline, or when the
@@ -118,15 +162,10 @@ export function executeDescriptor(descriptor: SyncDescriptor): PromiseLike<unkno
     })
     return Promise.resolve()
   }
-  // The table name is dynamic here (driven by the descriptor), so the strongly
-  // typed supabase client surface doesn't apply — cast to a loose client. The
-  // allowlist check above bounds `table` to the known set before we cast.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const client = supabase as any
   if (descriptor.op === 'upsert') {
-    return client.from(descriptor.table).upsert(descriptor.row)
+    return fromTable(descriptor.table).upsert(descriptor.row)
   }
-  let query = client.from(descriptor.table).update(descriptor.values)
+  let query = fromTable(descriptor.table).update(descriptor.values)
   for (const [col, val] of Object.entries(descriptor.match)) {
     query = query.eq(col, val)
   }

--- a/src/lib/syncQueue.typecheck.ts
+++ b/src/lib/syncQueue.typecheck.ts
@@ -1,0 +1,50 @@
+/**
+ * Compile-time assertions for the typed sync-descriptor schema (LIFT-948).
+ *
+ * This file contains NO runtime code — only type-level statements — so it emits
+ * nothing to the bundle and is never imported. It exists purely so `npm run
+ * typecheck` (vue-tsc, which covers `src/**` but excludes `*.test.ts`) fails if
+ * the `SyncDescriptor` schema ever loosens back toward `Record<string, unknown>`
+ * or lets an unknown table / column through. The `@ts-expect-error` lines are
+ * inverted assertions: each MUST error, and typecheck fails if one stops
+ * erroring (e.g. `table` widens back to `string`).
+ */
+import type { Database } from './database.types'
+import type { SyncDescriptor, SyncDescriptorFor, SyncTable } from './syncQueue'
+
+type PublicTables = Database['public']['Tables']
+
+/** `true` iff `A` and `B` are mutually assignable (exact type equality). */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false
+
+/** Compiles only when `T` is exactly `true`. */
+type Expect<T extends true> = T
+
+// ── The table union is bound to the generated schema, not a bare string ──
+export type _TableIsSchemaKeyed = Expect<Equal<SyncTable, keyof PublicTables>>
+
+// A `string`-typed table is NOT a valid SyncTable — the whole point of the
+// tightening. If this stopped erroring, `SyncTable` has widened back to string.
+// @ts-expect-error - an arbitrary string is not an allowed table name
+export type _RejectsArbitraryTable = SyncDescriptorFor<string>
+
+// @ts-expect-error - a table absent from the schema is rejected
+export type _RejectsUnknownTable = SyncDescriptorFor<'definitely_not_a_table'>
+
+// ── Upsert rows are the table's generated Insert shape, per table literal ──
+type SetUpsertRow = Extract<SyncDescriptor, { op: 'upsert'; table: 'sets' }>['row']
+export type _SetRowIsInsert = Expect<Equal<SetUpsertRow, PublicTables['sets']['Insert']>>
+
+type ExerciseUpsertRow = Extract<SyncDescriptor, { op: 'upsert'; table: 'exercises' }>['row']
+export type _ExerciseRowIsInsert = Expect<Equal<ExerciseUpsertRow, PublicTables['exercises']['Insert']>>
+
+// ── Update values are the table's generated Update shape, per table literal ──
+type SetUpdateValues = Extract<SyncDescriptor, { op: 'update'; table: 'sets' }>['values']
+export type _SetValuesAreUpdate = Expect<Equal<SetUpdateValues, PublicTables['sets']['Update']>>
+
+// The row type is NOT an untyped record any more — a set row is the strict
+// Insert shape, so it is NOT mutually assignable with `Record<string, unknown>`
+// (the old freedom this issue removes).
+// @ts-expect-error - a typed upsert row is not equal to an untyped record
+export type _RejectsUntypedRow = Expect<Equal<SetUpsertRow, Record<string, unknown>>>

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -1,8 +1,8 @@
 import { defineStore } from 'pinia'
 import { shallowRef, triggerRef, computed } from 'vue'
 import { supabase, isPreviewMode } from '../lib/supabase'
-import type { Tables } from '../lib/database.types'
-import { syncQueue } from '../lib/syncQueue'
+import type { Tables, TablesUpdate } from '../lib/database.types'
+import { syncQueue, type SyncTable, type SyncDescriptor } from '../lib/syncQueue'
 import { mergeEntities } from '../lib/conflictResolver'
 import { uuid, endOfDayISO } from '../lib/uuid'
 import { logError, logWarn } from '../lib/logger'
@@ -321,6 +321,23 @@ export const useWorkoutStore = defineStore('workout', () => {
    * Durable soft-delete (UPDATE { deleted_at }). Routed through enqueueDelete
    * so the circuit breaker sees it, with a journaled descriptor (LIFT-706).
    */
+  /**
+   * Build a typed `update` SyncDescriptor for a table only known as a runtime
+   * `sets | exercises` union (LIFT-948). TypeScript can't distribute a
+   * non-literal `table` across the `SyncDescriptor` union, so the single
+   * unavoidable widening cast is isolated here — the signature still bounds
+   * `table` to a real `SyncTable` and `values` to that table's generated
+   * `Update` shape rather than an untyped record. Kept local (not exported from
+   * syncQueue) so the many `syncQueue` test mocks don't each need to re-stub it.
+   */
+  function _buildUpdateDescriptor<T extends SyncTable>(
+    table: T,
+    values: TablesUpdate<T>,
+    match: Record<string, string>,
+  ): SyncDescriptor {
+    return { op: 'update', table, values, match } as SyncDescriptor
+  }
+
   function _enqueueSoftDelete(key: string, table: 'sets' | 'exercises', match: Record<string, string>) {
     const deletedAt = new Date().toISOString()
     const values = { deleted_at: deletedAt }
@@ -331,7 +348,7 @@ export const useWorkoutStore = defineStore('workout', () => {
         for (const [col, val] of Object.entries(match)) q = q.eq(col, val)
         return q
       },
-      { op: 'update', table, values, match },
+      _buildUpdateDescriptor(table, values, match),
     )
   }
 
@@ -345,7 +362,7 @@ export const useWorkoutStore = defineStore('workout', () => {
         for (const [col, val] of Object.entries(match)) q = q.eq(col, val)
         return q
       },
-      { op: 'update', table, values, match },
+      _buildUpdateDescriptor(table, values, match),
     )
   }
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -22,7 +22,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json-summary', 'json'],
       include: ['src/**/*.{ts,vue}'],
-      exclude: ['src/**/__tests__/**', 'src/main.ts', 'src/App.vue'],
+      exclude: ['src/**/__tests__/**', 'src/**/*.typecheck.ts', 'src/main.ts', 'src/App.vue'],
       // Static floor — the ratchet in .coverage-baseline.json enforces
       // the actual high-water mark via scripts/check-coverage-ratchet.js.
       // These are kept as a safety net in case the ratchet script is bypassed.


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-948](https://github.com/aschung212/Lift/issues/948)

LIFT-948 flagged that the durable sync-replay path — the last line of defense for hard-won offline writes — had zero type checking: `SyncDescriptor` modeled rows as `{ table: string; row: Record<string, unknown> }` and `executeDescriptor` cast the whole `SupabaseClient<Database>` to `any`, so a descriptor journaled with a stale or misspelled column compiled fine and failed silently only at runtime against the server. I bound the descriptor schema to the generated `Database` types, isolated the one unavoidable `any` to a single helper, and added a compile-time gate — a typing-only tightening with identical runtime behavior.

## Changes
- **`src/lib/syncQueue.ts`** — `SyncTable = keyof Database['public']['Tables']` (was `string`); `SyncDescriptor` is now a distributive union keyed by the table literal, tying each descriptor's `row`/`values`/`match` to that table's generated `Insert`/`Update`/`Row` shapes via new `SyncDescriptorFor<T>`. The `supabase as any` cast is confined to a single `fromTable()` helper (reached only after the runtime allowlist check) instead of spanning `executeDescriptor`.
- **`src/stores/workout.ts`** — soft-delete/restore target a runtime `sets | exercises` union TS can't distribute, so the one required widening cast lives in a local `_buildUpdateDescriptor` (kept out of `syncQueue` so the ~16 `syncQueue` test mocks don't each need re-stubbing).
- **`src/lib/syncQueue.typecheck.ts`** (new) — type-only compile-time assertions (no emit, never imported) enforced by `npm run typecheck`; fails if the schema loosens back toward `string`/`Record<string, unknown>` or admits an unknown table.
- **`vitest.config.js`** — excludes `*.typecheck.ts` from coverage.

## Verification
- `npm run typecheck` — clean (and the inverted `@ts-expect-error` assertions all fire as intended).
- `npm run lint` — clean.
- `npm run build` — succeeds.
- `npm test` — 2627 passed, 1 skipped. The single "unhandled error" is a pre-existing flaky teardown race in `CalendarView.test.ts` (a lazy `useSVGTimeSeries` dynamic import resolving after environment teardown) — unrelated to this change; the file passes cleanly in isolation.

## Screenshots
None — no user-facing/UI change (types-only tightening).

## Discovery
ISSUE_DISCOVER:test: CalendarView.test.ts emits an intermittent `EnvironmentTeardownError` unhandled rejection — a lazy `useSVGTimeSeries` dynamic import (via TagVolumeSparkline→MuscleGroupChart) resolves after the happy-dom environment is torn down. Passes in isolation but pollutes full-suite runs with a false-positive-risk "1 error". Fix by awaiting/eager-importing the sparkline chain in tests or guarding the dynamic import.

## Commits
- [`81861de`](https://github.com/aschung212/Lift/commit/81861de) refactor(LIFT-948): bind SyncDescriptor row/table typing to the generated schema

## Test Results
- Before: 2627 passing
- After: 2627 passing (0 delta)

---
_Automated by overnight pipeline — Thu Jul 16 01:00:21 PDT 2026_

## Preview
Test on your phone: https://lift-oamullaht-aschung212-1101s-projects.vercel.app