### PR TITLE
feat(coach): rename Weekly Review to AI Review + move entry to Calendar top bar (closes #972)

### DIFF
--- a/docs/ai-coach.md
+++ b/docs/ai-coach.md
@@ -1,11 +1,15 @@
-# AI Coach — Weekly Review (design)
+# AI Coach — AI Review (design)
+
+> **Naming (#972):** the user-facing feature name is **"AI Review"** (sheet title, aria-labels,
+> download filename `lift-ai-review-YYYY-MM-DD.md`). It was called "Weekly Review" until
+> 2026-07-16; the weekly *cadence* (quota window, digest framing) is unchanged — only the label.
 
 Status: **Phase 1 in progress** (backend scaffold landed; UI + consent + deletion wiring remain).
 The live transport today is the **bring-your-own-AI export** (open loop, no server) — see below —
 because the Anthropic key the server needs isn't provisioned yet. Flip `COACH_MODE` to `'server'`
 in `src/lib/coachExport.ts` once it is.
 
-An opt-in feature where a user taps once and gets an LLM-generated **Weekly Review** of
+An opt-in feature where a user taps once and gets an LLM-generated **AI Review** of
 their training — a fixed-shape digest rendered as themed cards. It is the smallest surface
 that delivers a genuine, differentiating coaching moment without the cost, abuse,
 hallucination, and prompt-injection blast radius of free-form chat.
@@ -23,7 +27,7 @@ This collapses the three UX options we considered into the best one:
 - **Not** free-form chat (biggest cost/abuse/injection surface; weekly cadence doesn't suit it).
 - **Not** an "ask N questions" menu (its value is absorbed by the digest's four sections,
   delivered proactively instead of making the user pick).
-- A single **Weekly Review** digest, server-validated against a fixed JSON schema.
+- A single weekly **AI Review** digest, server-validated against a fixed JSON schema.
 
 ## The load-bearing reality
 
@@ -63,7 +67,7 @@ destination. So until the key is provisioned we deliver the value with **zero se
   "nothing leaves Lift until you paste it" disclosure, and **Copy to clipboard** + **Download
   `.md`** actions. The server states stay intact behind `mode === 'server'`.
 - **Open loop by decision:** no paste-back / JSON round-trip — the coaching lives in the chat.
-- No key, no quota, no consent-to-transmit surface (nothing is sent), so the entry card drops the
+- No key, no quota, no consent-to-transmit surface (nothing is sent), so the entry point drops the
   sign-in gate in this mode. This also stands as a permanent **free / privacy tier** after the
   server exists: a user's data never leaves the device unless they paste it themselves.
 - **Privacy:** the profile adds sensitive fields (age, injuries). In BYO nothing is auto-sent — the
@@ -233,8 +237,11 @@ disclosure work must ship in the **same PR as the UI** (CLAUDE.md Documentation 
 
 ## UX (Phase 1, after backend)
 
-- One entry point: a **"Coach" card** at the top of the Workouts tab that doubles as the quota
-  meter ("Coach · N reviews left this week"). Appears only with ≥2 weeks of data + a trend.
+- One entry point: a compact **top-bar icon button on the Calendar tab** (#972) — the
+  retrospective surface — mirroring the contextual "+" that shows on the Workouts tab. It
+  replaced the original full-width Workouts-page card, which was too prominent for an
+  infrequently used feature. Appears only with ≥2 weeks of data; the quota meter now lives
+  inside the sheet header, not the entry point.
 - Tapping opens `CoachSheet` (built on `useModal` for the #830 scroll lock) with four states:
   consent gate → loading skeleton → result cards → quota-exceeded ("Resets in N days").
 - No text input on the primary path → sidesteps the iOS-keyboard-modal bug class.
@@ -263,13 +270,14 @@ disclosure work must ship in the **same PR as the UI** (CLAUDE.md Documentation 
   is a deliberate Phase 2 change. The CoachSheet "Past insights" list consumes this once #848
   lands.
 
-- `CoachSheet` + the Workouts-tab entry card (LIFT-848): `src/lib/coachClient.ts` (pure status→
+- `CoachSheet` + the entry point (LIFT-848, moved in #972): `src/lib/coachClient.ts` (pure status→
   result mapping + abort-timeout fetch + `daysUntilReset`), `src/composables/useCoach.ts`
   (singleton UI state + device-local cosmetic quota cache + `getSession` token), and
   `src/views/CoachSheet.vue` (idle/loading/result/error states; output rendered via text
-  interpolation, NEVER `v-html`). The entry card lives in `WorkoutTracker`'s `wtPageHeader`,
-  gated by `coachReviewEligibility` (≥`MIN_SETS_FOR_REVIEW` sets across ≥2 weeks) AND signed-in
-  AND not a preview deploy; it doubles as the quota meter. The view wires `buildCoachPayload` to
+  interpolation, NEVER `v-html`). The entry is a `topBarCoachBtn` icon in `App.vue`'s top bar,
+  shown on the Calendar tab, gated by `coachReviewEligibility` (≥`MIN_SETS_FOR_REVIEW` sets across
+  ≥2 weeks) AND not a preview deploy AND (BYO mode OR signed-in). `CoachSheet` mounts from
+  `App.vue` (lazy chunk, fetched on first open) and wires `buildCoachPayload` to
   the stores (`getOverloadSuggestion` → `overloads`, `streakWeeks`/`weeklyTarget`, `toDisplayUnits`).
 
 - **Bring-your-own-AI export (#931)** — `src/lib/coachExport.ts` (`COACH_MODE`, analyst

--- a/src/App.vue
+++ b/src/App.vue
@@ -81,6 +81,15 @@
             >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             </button>
+            <button
+              v-if="activeTab === 'calendar' && showCoachBtn"
+              class="topBarCoachBtn"
+              @click="coachOpen = true"
+              title="AI Review"
+              aria-label="Open AI Review"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v2M12 19v2M5 12H3M21 12h-2M6.3 6.3 4.9 4.9M19.1 19.1l-1.4-1.4M17.7 6.3l1.4-1.4M4.9 19.1l1.4-1.4"/><circle cx="12" cy="12" r="4"/></svg>
+            </button>
           </div>
         </div>
         <div
@@ -133,6 +142,9 @@
 
       <!-- Settings bottom sheet (extracted to SettingsSheet.vue) -->
       <SettingsSheet v-if="settingsOpen" ref="settingsSheetRef" v-model="settingsOpen" @sign-out="handleSignOut" />
+
+      <!-- AI Review sheet (entry: Calendar-tab top-bar button) -->
+      <CoachSheet v-if="coachOpen" @close="coachOpen = false" />
     </template>
 
     <!-- Undo toast -->
@@ -261,6 +273,11 @@ const BodyweightTracker = defineAsyncComponent({
 // UI many users never open — split it (and its transitive deps) into an on-demand
 // chunk, gated by v-if="settingsOpen" so the chunk isn't fetched until first open.
 const SettingsSheet = defineAsyncComponent(() => import('./components/SettingsSheet.vue'))
+// AI Review sheet — reached only from the Calendar-tab top-bar button, so its
+// chunk (and the export/profile UI it pulls in) loads on first open.
+const CoachSheet = defineAsyncComponent(() => import('./views/CoachSheet.vue'))
+import { coachReviewEligibility } from './lib/coachDigest'
+import { COACH_MODE } from './lib/coachExport'
 import { useTheme, connectProgressionStore } from './composables/useTheme'
 import type { ThemeId } from './lib/themes'
 import { useProgressionStore } from './stores/progression'
@@ -338,6 +355,24 @@ const settingsOpen = ref(false)
 // resolve to the loader wrapper, not the SFC. It only exposes closeSettings(),
 // so type the ref by the exposed surface we actually call.
 const settingsSheetRef = ref<{ closeSettings: () => void } | null>(null)
+
+// ── AI Review entry (#972) ──────────────────────────────────────
+// Lives in the top bar on the Calendar tab (mirroring the contextual "+" on
+// Workouts) rather than as a card on the Workouts page: it's an infrequent,
+// retrospective feature, so it gets a compact nav-bar affordance on the
+// retrospective surface. Gate: enough training signal (a couple weeks + the
+// set floor), not a preview deploy, and — server transport only — a signed-in
+// user; the BYO export is 100% local, so it needs no account.
+const coachOpen = ref(false)
+const coachEligible = computed(
+  () => coachReviewEligibility(workoutStore.exercises, new Date()).eligible,
+)
+const showCoachBtn = computed(
+  () =>
+    coachEligible.value &&
+    !isPreviewMode.value &&
+    (COACH_MODE === 'byo' || user.value !== null),
+)
 
 // ── Focus traps for modals ─────────────────────────────────────
 const shortcutsFocus = useFocusTrap()

--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -32,23 +32,6 @@
       </button>
     </header>
 
-    <!-- AI Coach weekly-review entry card + quota meter (only with enough data) -->
-    <button
-      v-if="showCoachCard"
-      class="wtCoachCard"
-      @click="openCoach"
-      aria-label="Open your AI weekly training review"
-    >
-      <span class="wtCoachIcon" aria-hidden="true">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v2M12 19v2M5 12H3M21 12h-2M6.3 6.3 4.9 4.9M19.1 19.1l-1.4-1.4M17.7 6.3l1.4-1.4M4.9 19.1l1.4-1.4"/><circle cx="12" cy="12" r="4"/></svg>
-      </span>
-      <span class="wtCoachText">
-        <span class="wtCoachTitle">Weekly Review</span>
-        <span class="wtCoachMeta">{{ coachCardMeta }}</span>
-      </span>
-      <svg class="wtCoachChevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18l6-6-6-6"/></svg>
-    </button>
-
     <!-- View toggle (Exercises / Timeline) -->
     <div v-if="store.exercises.length > 0" class="wtViewToggle">
       <button :class="['wtViewToggleBtn', { active: listView === 'exercises' }]" @click="listView = 'exercises'">Exercises</button>
@@ -273,8 +256,6 @@
     @delete-set="undoDeleteSet"
   />
 
-  <!-- AI Coach weekly-review sheet -->
-  <CoachSheet v-if="coachOpen" @close="coachOpen = false" />
 
   <!-- Log / Edit Set Modal -->
   <Teleport to="body">
@@ -820,12 +801,6 @@ import { scoreSet } from '../lib/setScoring'
 import { useXPCeremony } from '../composables/useXPCeremony'
 import { computeWeeklyGoal } from '../lib/weeklyGoal'
 import ExerciseDetailModal from '../views/ExerciseDetailModal.vue'
-const CoachSheet = defineAsyncComponent(() => import('../views/CoachSheet.vue'))
-import { coachReviewEligibility } from '../lib/coachDigest'
-import { COACH_MODE } from '../lib/coachExport'
-import { useCoach } from '../composables/useCoach'
-import { useAuth } from '../composables/useAuth'
-import { isPreviewMode } from '../lib/supabase'
 import RestTimerContent from './RestTimerContent.vue'
 import WorkoutTimeline from './WorkoutTimeline.vue'
 import EditExerciseModal, { type EditExerciseSave } from './EditExerciseModal.vue'
@@ -842,36 +817,6 @@ import { matchesGymFilter, loadActiveGymFilter, saveActiveGymFilter } from '../l
 const store = useWorkoutStore()
 const progressionStore = useProgressionStore()
 const { logEvent } = useAnalytics()
-const coach = useCoach()
-const { user: authUser } = useAuth()
-
-// ── AI Coach weekly review (LIFT-848) ────────────────────────────
-const coachOpen = ref(false)
-// Gate the entry card like the Suggestions drawer gates its lenses: only when
-// there's enough signal (a couple training weeks + the server's set floor) and
-// not on a preview deploy. In the server transport the proxy is auth-gated so we
-// also require a signed-in user; the BYO export is 100% local (nothing is sent),
-// so it needs no account — requiring sign-in to copy your own data would be odd.
-const coachEligible = computed(() => coachReviewEligibility(store.exercises, new Date()).eligible)
-const showCoachCard = computed(
-  () =>
-    coachEligible.value &&
-    !isPreviewMode.value &&
-    (COACH_MODE === 'byo' || authUser.value !== null),
-)
-const coachCardMeta = computed(() => {
-  if (COACH_MODE === 'byo') return 'Bring your own AI'
-  const n = coach.remaining.value
-  if (n === null) return 'AI-written · once a week'
-  if (n <= 0) {
-    const days = coach.resetDays.value
-    return days && days > 0 ? `Resets in ${days} ${days === 1 ? 'day' : 'days'}` : 'No reviews left'
-  }
-  return `${n} ${n === 1 ? 'review' : 'reviews'} left this week`
-})
-function openCoach() {
-  coachOpen.value = true
-}
 const { show: showUndo } = useUndoToast()
 const { currentTheme } = useTheme()
 const { restTimerEnabled, restTimerAutoStart } = useRestTimer()

--- a/src/index.css
+++ b/src/index.css
@@ -1074,7 +1074,8 @@ html.modal-open .tabContent {
 }
 
 .settingsGearBtn,
-.topBarPlusBtn {
+.topBarPlusBtn,
+.topBarCoachBtn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1120,6 +1121,24 @@ html.modal-open .tabContent {
 .topBarPlusBtn svg {
   width: 22px;
   height: 22px;
+}
+
+/* AI Review entry — subtle like the gear (accent fill is reserved for the
+   primary "+" action), with the coach's accent color on the icon. */
+.topBarCoachBtn {
+  background: var(--bg-elevated);
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+
+.topBarCoachBtn:active {
+  background: var(--accent-subtle);
+  transform: scale(0.95);
+}
+
+.topBarCoachBtn svg {
+  width: 20px;
+  height: 20px;
 }
 
 .syncIndicator {
@@ -2198,70 +2217,6 @@ html.theme-fading .settingsSheet {
   color: var(--accent);
   opacity: 0.85;
   font-variant-numeric: tabular-nums;
-}
-
-/* AI Coach weekly-review entry card + quota meter (LIFT-848). */
-.wtCoachCard {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  width: 100%;
-  margin: 0 0 12px;
-  padding: 12px 16px;
-  min-height: 56px;
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-strong);
-  border-radius: 16px;
-  color: var(--text-primary);
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: background 120ms ease, border-color 120ms ease;
-}
-
-.wtCoachCard:active {
-  transform: scale(0.99);
-  background: var(--bg-secondary);
-}
-
-.wtCoachIcon {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  background: var(--accent-subtle);
-  color: var(--accent);
-}
-
-.wtCoachText {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.wtCoachTitle {
-  font-size: var(--font-callout);
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.wtCoachMeta {
-  font-family: var(--ff-mono);
-  font-size: var(--font-caption2);
-  font-weight: 500;
-  letter-spacing: 0.03em;
-  color: var(--text-secondary);
-  font-variant-numeric: tabular-nums;
-}
-
-.wtCoachChevron {
-  flex: 0 0 auto;
-  color: var(--text-muted);
 }
 
 /* Segmented control (Exercises / Timeline) — gold-filled active pill. */

--- a/src/lib/__tests__/coachExport.test.ts
+++ b/src/lib/__tests__/coachExport.test.ts
@@ -78,11 +78,11 @@ describe('coachExport — buildCoachExportText', () => {
 
 describe('coachExport — coachExportFilename', () => {
   it('builds a dated markdown filename from a local date key', () => {
-    expect(coachExportFilename('2026-07-10')).toBe('lift-weekly-review-2026-07-10.md')
+    expect(coachExportFilename('2026-07-10')).toBe('lift-ai-review-2026-07-10.md')
   })
 
   it('falls back safely when handed a non-date-key string', () => {
-    expect(coachExportFilename('not-a-date')).toBe('lift-weekly-review-review.md')
+    expect(coachExportFilename('not-a-date')).toBe('lift-ai-review-review.md')
   })
 })
 

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -200,6 +200,22 @@ describe('CSS regression tests', () => {
     })
   })
 
+  describe('.topBarCoachBtn AI Review entry (#972)', () => {
+    // The AI Review entry moved from a full-width Workouts card to a compact
+    // top-bar icon on the Calendar tab; it must inherit the shared 44px
+    // top-bar button sizing (.settingsGearBtn, .topBarPlusBtn, .topBarCoachBtn).
+    const lines = getRuleLines('.topBarCoachBtn')
+
+    it('meets the 44px iOS HIG touch target via the shared top-bar rule', () => {
+      expect(lines.some(l => l.startsWith('width') && l.includes('44px'))).toBe(true)
+      expect(lines.some(l => l.startsWith('height') && l.includes('44px'))).toBe(true)
+    })
+
+    it('the removed Workouts entry card does not linger in the stylesheet', () => {
+      expect(css.includes('.wtCoachCard')).toBe(false)
+    })
+  })
+
   describe('Vue component touch target compliance', () => {
     // jsdom does not apply scoped CSS from Vue SFCs, so getComputedStyle
     // cannot verify sizing in component tests. These CSS regression tests

--- a/src/lib/aiCoach.ts
+++ b/src/lib/aiCoach.ts
@@ -1,5 +1,5 @@
 /**
- * AI Coach — shared, pure contract + guardrail logic (issue: AI Coach "Weekly Review").
+ * AI Coach — shared, pure contract + guardrail logic (user-facing name: "AI Review", #972).
  *
  * This module is the single source of truth for what data leaves the device, what
  * shape the model must return, and the server-side validation/cost rules. It is

--- a/src/lib/coachExport.ts
+++ b/src/lib/coachExport.ts
@@ -23,7 +23,7 @@ import type { CoachPayload } from './aiCoach'
 import { buildCoachUserMessage } from './aiCoach'
 
 /**
- * Active transport for the Weekly Review.
+ * Active transport for the AI Review.
  *   - `'byo'`  — this module: user pastes into their own LLM. No key, no server.
  *   - `'server'` — the `api/coach.ts` proxy. Flip here once an Anthropic key is
  *     provisioned; the server code path stays intact meanwhile.
@@ -95,5 +95,5 @@ export function buildCoachExportText(payload: CoachPayload, athleteBlock = ''): 
  */
 export function coachExportFilename(dateKey: string): string {
   const safe = /^\d{4}-\d{2}-\d{2}$/.test(dateKey) ? dateKey : 'review'
-  return `lift-weekly-review-${safe}.md`
+  return `lift-ai-review-${safe}.md`
 }

--- a/src/lib/coachHistory.ts
+++ b/src/lib/coachHistory.ts
@@ -1,7 +1,7 @@
 /**
  * AI Coach — device-local insight history (LIFT-851, part of #842).
  *
- * Each generated Weekly Review costs a quota slot and real money to produce, so
+ * Each generated AI Review costs a quota slot and real money to produce, so
  * once a review exists it should not evaporate. This module persists generated
  * reviews to localStorage as a bounded **last-12 ring** (drop oldest), turning the
  * coach into an accruing coaching journal: re-opening a past insight is FREE — it
@@ -29,7 +29,7 @@ export const COACH_HISTORY_KEY = 'coach-insights-history'
 /** Ring capacity. Bounded so the PWA can't grow this key without limit. */
 export const COACH_HISTORY_LIMIT = 12
 
-/** One persisted Weekly Review plus the metadata needed to list and re-open it. */
+/** One persisted AI Review plus the metadata needed to list and re-open it. */
 export interface StoredCoachInsight {
   /** Stable unique id (for list keys + dedupe). */
   id: string

--- a/src/views/CoachSheet.vue
+++ b/src/views/CoachSheet.vue
@@ -11,10 +11,10 @@
       <div class="repMaxModal coachSheet">
         <header class="coachHeader">
           <div class="coachHeaderText">
-            <h2 id="coachSheetTitle" class="coachTitle">Weekly Review</h2>
+            <h2 id="coachSheetTitle" class="coachTitle">AI Review</h2>
             <p class="coachSub">{{ mode === 'byo' ? 'Bring your own AI' : quotaLabel }}</p>
           </div>
-          <button class="coachClose" @click="close" aria-label="Close weekly review">
+          <button class="coachClose" @click="close" aria-label="Close AI review">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </header>
@@ -24,7 +24,7 @@
         <div v-if="mode === 'byo'" class="coachBody">
           <p class="coachIntro">
             Build a summary of your recent training, then paste it into your own AI
-            chat — Claude, ChatGPT, or any other — for a written weekly review.
+            chat — Claude, ChatGPT, or any other — for a written review.
           </p>
 
           <div class="coachModeRow" role="group" aria-label="Review depth">
@@ -233,7 +233,7 @@ function sectionLabel(type: CoachSectionType): string {
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
-  unauthorized: 'Sign in to get your weekly review.',
+  unauthorized: 'Sign in to get your AI review.',
   email_unverified: 'Verify your email to use Coach.',
   consent_required: "You'll need to accept the Coach privacy terms before your training is reviewed.",
   paused: 'Coach is resting for today — try again tomorrow.',

--- a/src/views/__tests__/CoachSheet.test.ts
+++ b/src/views/__tests__/CoachSheet.test.ts
@@ -72,7 +72,7 @@ describe('CoachSheet — states', () => {
     mountSheet()
     const html = document.body.textContent ?? ''
     expect(html).toContain('Generate review')
-    expect(html).toContain('Weekly Review')
+    expect(html).toContain('AI Review')
   })
 
   it('shows the quota meter in the header from the cached remaining count', async () => {
@@ -233,7 +233,7 @@ describe('CoachSheet — bring-your-own-AI export (open loop)', () => {
     dlBtn!.click()
     await nextTick()
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
-    expect(clickNames[0]).toMatch(/^lift-weekly-review-\d{4}-\d{2}-\d{2}\.md$/)
+    expect(clickNames[0]).toMatch(/^lift-ai-review-\d{4}-\d{2}-\d{2}\.md$/)
   })
 
   it('offers a review-depth control and a profile entry point', () => {


### PR DESCRIPTION
Closes #972.

Feedback from testing: the feature should be called **AI Review**, and the full-width entry card on the Workouts page was too prominent for something used at most weekly.

## What changed

**Rename (user-visible strings only):**
- Sheet title, close aria-label, and sign-in error copy now say "AI Review"
- Download filename: `lift-weekly-review-YYYY-MM-DD.md` → `lift-ai-review-YYYY-MM-DD.md`
- The weekly *cadence* (quota window, digest framing, server prompt semantics) is unchanged — only the label. `docs/ai-coach.md` carries a naming note, and the two "Weekly Review" comment references in the freshly-landed `coachHistory.ts` (#863) were updated in passing.

**Relocation:**
- The `wtCoachCard` is gone from WorkoutTracker (−55 lines of template/state/imports, card CSS removed).
- New entry: a compact 44pt icon button in the app **top bar on the Calendar tab**, mirroring the existing contextual "+" (add exercise) that shows only on Workouts — same slot, same sizing rule, no new navigation pattern. Calendar is the retrospective surface, which matches the "review my training" mental model.
- `CoachSheet` now mounts from `App.vue` and stays a **lazy chunk fetched on first open** (same pattern as SettingsSheet — previously its async definition lived inside the WorkoutTracker chunk).
- Gate unchanged: `coachReviewEligibility` + not preview + (BYO mode OR signed in). The quota/BYO meta that lived on the card already lives inside the sheet header.

## Design-principle fit
- **Progressive disclosure / real-estate:** infrequent feature → nav-bar affordance, not a hero card on the most-used screen.
- **One interaction path:** enhances the existing per-tab top-bar action pattern instead of inventing a new surface.
- **iOS HIG:** 44×44 via the shared top-bar rule (`.settingsGearBtn, .topBarPlusBtn, .topBarCoachBtn`), regression-pinned in `cssRegression.test.ts`; subtle gear-like styling so the accent fill stays reserved for the primary "+".

## Verification
- Rebased onto master past #863 (coach insight history) and #767 (first-set celebration); both auto-merged cleanly — #863 only added new files, #767's App.vue/WorkoutTracker changes don't overlap the removed card.
- Verified in the browser preview: Workouts page renders with no card; the sparkle button appears top-right on the Calendar tab (eligible sample data), opens the sheet titled "AI Review" with the full BYO export panel.
- Post-rebase gates: 2757/2757 tests passed, `vue-tsc` + ESLint clean, build clean, bundle 560 KB vs 570 KB budget (CI formula).

🤖 Generated with [Claude Code](https://claude.com/claude-code)