### PR TITLE
test(LIFT-967): add component tests for WorkoutCompleteView and PRBurst

### DIFF
--- a/src/components/__tests__/PRBurst.test.ts
+++ b/src/components/__tests__/PRBurst.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import { setActivePinia, createPinia } from 'pinia'
+import type { SessionSummary } from '../../lib/sessionSummary'
+
+// Hoisted spies so the vi.mock factories (which are hoisted above imports) can
+// reference them.
+const { logEventMock, notifySuccessMock } = vi.hoisted(() => ({
+  logEventMock: vi.fn(),
+  notifySuccessMock: vi.fn(),
+}))
+
+vi.mock('../../composables/useAnalytics', () => ({
+  useAnalytics: () => ({ logEvent: logEventMock }),
+}))
+
+// usePRBurst fires haptics on present; keep them observable + side-effect free.
+vi.mock('../../composables/useHaptics', () => ({
+  useHaptics: () => ({
+    impactLight: vi.fn(),
+    impactMedium: vi.fn(),
+    impactHeavy: vi.fn(),
+    notifySuccess: notifySuccessMock,
+    notifyWarning: vi.fn(),
+    notifyError: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn() },
+}))
+
+import PRBurst from '../PRBurst.vue'
+import { usePRBurst, type PRBurstPayload } from '../../composables/usePRBurst'
+
+const basePayload: PRBurstPayload = {
+  exerciseName: 'Hack Squat',
+  oldE1RM: 594,
+  newE1RM: 606,
+  setWeight: 505,
+  setReps: 6,
+}
+
+describe('PRBurst', () => {
+  let wrapper: VueWrapper | null = null
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    logEventMock.mockClear()
+    notifySuccessMock.mockClear()
+    // Reset the module-scope singleton synchronously (flush the 200ms
+    // deferred payload clear) so each test starts hidden.
+    vi.useFakeTimers()
+    usePRBurst().dismissPRBurst()
+    vi.advanceTimersByTime(200)
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+  })
+
+  function mountBurst(): VueWrapper {
+    return mount(PRBurst, {
+      global: {
+        // The share picker (async, teleported) pulls in the whole share-card
+        // subsystem — stub it and render the Teleport inline so the stub is
+        // findable within the wrapper.
+        stubs: {
+          Teleport: true,
+          SharePickerSheet: { name: 'SharePickerSheet', template: '<div class="stub-picker" />' },
+        },
+      },
+    })
+  }
+
+  async function present(payload: Partial<PRBurstPayload> = {}) {
+    wrapper = mountBurst()
+    usePRBurst().presentPRBurst({ ...basePayload, ...payload })
+    await wrapper.vm.$nextTick()
+    return wrapper
+  }
+
+  it('renders nothing until a PR is presented', () => {
+    wrapper = mountBurst()
+    expect(wrapper.find('.prBurst').exists()).toBe(false)
+  })
+
+  it('renders a labelled celebration dialog on present', async () => {
+    await present()
+    const burst = wrapper!.find('.prBurst')
+    expect(burst.exists()).toBe(true)
+    expect(burst.attributes('role')).toBe('dialog')
+    expect(burst.attributes('aria-modal')).toBe('true')
+    expect(burst.attributes('aria-label')).toBe('Personal record')
+    expect(notifySuccessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the eyebrow, delta, subtitle and set chip', async () => {
+    await present()
+    expect(wrapper!.find('.prBurstEyebrow').text()).toContain('Personal Record')
+    expect(wrapper!.find('.prBurstDelta').text()).toBe('+12 lbs')
+    const subtitle = wrapper!.find('.prBurstSubtitle').text()
+    expect(subtitle).toContain('594')
+    expect(subtitle).toContain('606')
+    expect(subtitle).toContain('e1RM')
+    expect(wrapper!.find('.prBurstChip').text()).toBe('Hack Squat · 505 × 6')
+  })
+
+  it('renders the first-PR badge only when isFirstPR is set', async () => {
+    await present({ isFirstPR: true })
+    expect(wrapper!.find('.prBurstFirstBadge').exists()).toBe(true)
+    expect(wrapper!.find('.prBurstFirstBadge').text()).toBe('Your First')
+  })
+
+  it('omits the first-PR badge for a subsequent PR', async () => {
+    await present({ isFirstPR: false })
+    expect(wrapper!.find('.prBurstFirstBadge').exists()).toBe(false)
+  })
+
+  it('hides the share button when no shareSummary is supplied', async () => {
+    await present()
+    expect(wrapper!.find('.prBurstShare').exists()).toBe(false)
+  })
+
+  it('shows the share button when a shareSummary is supplied', async () => {
+    await present({ shareSummary: { rawDate: '2026-07-17' } as SessionSummary })
+    expect(wrapper!.find('.prBurstShare').exists()).toBe(true)
+  })
+
+  it('dismisses when the backdrop is tapped', async () => {
+    await present()
+    const { visible } = usePRBurst()
+    expect(visible.value).toBe(true)
+    await wrapper!.find('.prBurst').trigger('click')
+    expect(visible.value).toBe(false)
+    await wrapper!.vm.$nextTick()
+    expect(wrapper!.find('.prBurst').exists()).toBe(false)
+  })
+
+  it('share button opens the picker, logs analytics, and dismisses the burst', async () => {
+    await present({
+      isFirstPR: true,
+      shareSummary: { rawDate: '2026-07-17' } as SessionSummary,
+    })
+    const { visible } = usePRBurst()
+
+    await wrapper!.find('.prBurstShare').trigger('click')
+
+    expect(logEventMock).toHaveBeenCalledWith('pr_share_opened', {
+      exercise: 'Hack Squat',
+      firstPr: true,
+    })
+    // Handing off to the share sheet dismisses the celebration so they don't stack.
+    expect(visible.value).toBe(false)
+    await wrapper!.vm.$nextTick()
+    expect(wrapper!.find('.stub-picker').exists()).toBe(true)
+  })
+})

--- a/src/components/__tests__/WorkoutCompleteView.test.ts
+++ b/src/components/__tests__/WorkoutCompleteView.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import WorkoutCompleteView from '../WorkoutCompleteView.vue'
+import type { SessionSummary } from '../../lib/sessionSummary'
+
+function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    rawDate: '2026-07-17',
+    date: 'Fri, Jul 17',
+    duration: '1h 12m',
+    totalVolume: 12500,
+    setsCompleted: 8,
+    exercises: 3,
+    prs: 1,
+    repPRs: 1,
+    bestSet: {
+      exerciseId: 'ex-1',
+      name: 'Bench Press',
+      weight: 225,
+      reps: 5,
+      e1RM: 262,
+      isPR: true,
+    },
+    highlights: [],
+    weekVolume: [0, 0, 0, 0, 0, 0, 0],
+    priorWeekVolume: 0,
+    streak: 2,
+    unitLabel: 'lbs',
+    ...overrides,
+  }
+}
+
+function mountView(summary: SessionSummary): VueWrapper {
+  return mount(WorkoutCompleteView, {
+    props: { summary },
+    global: {
+      // The share picker is an async child that pulls in the whole share-card
+      // subsystem — stub it so these tests stay focused on the summary surface.
+      stubs: {
+        SharePickerSheet: { name: 'SharePickerSheet', template: '<div class="stub-picker" />' },
+      },
+    },
+  })
+}
+
+describe('WorkoutCompleteView', () => {
+  beforeEach(() => {
+    // useModal toggles html.modal-open; reset so a prior test can't leak it.
+    document.documentElement.classList.remove('modal-open')
+  })
+
+  describe('accessibility scaffolding', () => {
+    it('renders a labelled modal dialog', () => {
+      const wrapper = mountView(makeSummary())
+      const overlay = wrapper.find('.wcOverlay')
+      expect(overlay.attributes('role')).toBe('dialog')
+      expect(overlay.attributes('aria-modal')).toBe('true')
+      expect(overlay.attributes('aria-labelledby')).toBe('wcTitle')
+      expect(wrapper.find('#wcTitle').text()).toBe('Workout complete')
+    })
+  })
+
+  describe('session with sets', () => {
+    it('renders the total-volume hero with a grouped number', () => {
+      const wrapper = mountView(makeSummary())
+      expect(wrapper.find('.wcHeroNumber').text()).toBe('12,500')
+      expect(wrapper.find('.wcHeroUnit').text()).toBe('lbs moved')
+    })
+
+    it('renders time / sets / PR stats', () => {
+      const wrapper = mountView(makeSummary())
+      const vals = wrapper.findAll('.wcStatVal').map((n) => n.text())
+      expect(vals).toEqual(['1h 12m', '8', '2'])
+    })
+
+    it('sums weight PRs and rep PRs into the PR stat', () => {
+      const wrapper = mountView(makeSummary({ prs: 3, repPRs: 2 }))
+      const prStat = wrapper.find('.wcStatAccent .wcStatVal')
+      expect(prStat.text()).toBe('5')
+    })
+
+    it('renders the best set with a NEW PR badge when it is a PR', () => {
+      const wrapper = mountView(makeSummary())
+      expect(wrapper.find('.wcBestSetName').text()).toBe('Bench Press')
+      expect(wrapper.find('.wcBestSetWeight').text()).toBe('225 × 5')
+      expect(wrapper.find('.wcBestSetE1RM').text()).toBe('~262 lbs e1RM')
+      expect(wrapper.find('.wcBestSetBadge').exists()).toBe(true)
+    })
+
+    it('omits the NEW PR badge when the best set is not a PR', () => {
+      const summary = makeSummary()
+      summary.bestSet!.isPR = false
+      const wrapper = mountView(summary)
+      expect(wrapper.find('.wcBestSet').exists()).toBe(true)
+      expect(wrapper.find('.wcBestSetBadge').exists()).toBe(false)
+    })
+
+    it('omits the best-set section when there is no best set', () => {
+      const wrapper = mountView(makeSummary({ bestSet: null }))
+      expect(wrapper.find('.wcBestSet').exists()).toBe(false)
+    })
+
+    it('shows the share affordance', () => {
+      const wrapper = mountView(makeSummary())
+      expect(wrapper.find('.wcShare').exists()).toBe(true)
+    })
+  })
+
+  describe('empty session', () => {
+    it('shows the empty state instead of the hero when no sets were logged', () => {
+      const wrapper = mountView(makeSummary({ setsCompleted: 0, bestSet: null }))
+      expect(wrapper.find('.wcEmpty').exists()).toBe(true)
+      expect(wrapper.find('.wcHero').exists()).toBe(false)
+      expect(wrapper.find('.wcEmptyTitle').text()).toContain('No sets logged')
+    })
+
+    it('hides the share button when there are no sets', () => {
+      const wrapper = mountView(makeSummary({ setsCompleted: 0, bestSet: null }))
+      expect(wrapper.find('.wcShare').exists()).toBe(false)
+      expect(wrapper.find('.wcDone').exists()).toBe(true)
+    })
+  })
+
+  describe('dismissal', () => {
+    it('emits close when Done is pressed', async () => {
+      const wrapper = mountView(makeSummary())
+      await wrapper.find('.wcDone').trigger('click')
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('emits close when the Close link is pressed', async () => {
+      const wrapper = mountView(makeSummary())
+      await wrapper.find('.wcLink').trigger('click')
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('emits close when the backdrop itself is tapped', async () => {
+      const wrapper = mountView(makeSummary())
+      await wrapper.find('.wcOverlay').trigger('click')
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+
+    it('emits close on Escape', async () => {
+      const wrapper = mountView(makeSummary())
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+  })
+
+  describe('share picker layering', () => {
+    it('opens the share picker from the share button', async () => {
+      const wrapper = mountView(makeSummary())
+      expect(wrapper.find('.stub-picker').exists()).toBe(false)
+      await wrapper.find('.wcShare').trigger('click')
+      expect(wrapper.find('.stub-picker').exists()).toBe(true)
+    })
+
+    it('Escape closes the picker first without closing the whole summary', async () => {
+      const wrapper = mountView(makeSummary())
+      await wrapper.find('.wcShare').trigger('click')
+      expect(wrapper.find('.stub-picker').exists()).toBe(true)
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await wrapper.vm.$nextTick()
+
+      // First Escape consumed by the picker layer — summary stays open.
+      expect(wrapper.find('.stub-picker').exists()).toBe(false)
+      expect(wrapper.emitted('close')).toBeUndefined()
+
+      // Second Escape now closes the summary.
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-967](https://github.com/aschung212/Lift/issues/967)

Implement LIFT-967 — add component tests for the two celebration surfaces (`WorkoutCompleteView` and `PRBurst`), which render on emotionally-critical moments (session finish, new PR) yet had no component test. Follow the repo's existing mount/mocking patterns (`OnboardingScreen.test.ts`, `SharePickerSheet.test.ts`, `usePRBurst.test.ts`).

## Changes
- **`src/components/__tests__/WorkoutCompleteView.test.ts`** (new, 16 tests): dialog a11y scaffolding, total-volume hero, TIME/SETS/PR stats (PR stat = `prs + repPRs`), best-set card + NEW PR badge (present/absent), no-sets empty state, all four dismissal paths (Done, Close link, backdrop `@click.self`, Escape), and the two-layer Escape handoff between the share picker and the summary. Share picker stubbed via `global.stubs`.
- **`src/components/__tests__/PRBurst.test.ts`** (new, 9 tests): drives the real `usePRBurst` singleton through `presentPRBurst`, covering hidden-until-presented, labelled celebration dialog + success haptic, delta/subtitle/chip formatting, first-PR badge, inert vs. active share button (`shareSummary` gating), backdrop dismissal, and the share handoff (opens picker, logs `pr_share_opened`, dismisses burst). Haptics/analytics/syncQueue mocked; picker + Teleport stubbed.

## Verification
- New files: 25 tests pass.
- Full suite: 2796 passed | 1 skipped (was 2771 → +25), no regressions.
- `npm run lint`: clean.
- `npm run build`: succeeds.
- Post-commit adversarial review: `REVIEW_CLEAN` / `MERGE`.
- Committed only the two new files; left the unrelated working-tree changes to `setup.ts`/`useTheme.test.ts` (LIFT-966 in-progress work) untouched.

## Screenshots
N/A — test-only change, no UI surface modified.

## Commits
- [`1cff837`](https://github.com/aschung212/Lift/commit/1cff837) test(LIFT-967): add component tests for WorkoutCompleteView and PRBurst

## Test Results
- Before: 2771 passing
- After: 2796 passing (25 delta)

---
_Automated by overnight pipeline — Fri Jul 17 23:51:44 PDT 2026_

## Preview
Test on your phone: https://lift-9kpvw0gyn-aschung212-1101s-projects.vercel.app