### PR TITLE
test(LIFT-969): freeze system time in BodyweightTracker date fixtures

### DIFF
--- a/src/components/__tests__/BodyweightTracker.test.ts
+++ b/src/components/__tests__/BodyweightTracker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, VueWrapper } from '@vue/test-utils'
 import type { BodyweightEntry } from '../../stores/bodyweight'
 import { getLocalStorageMock, mockAnalytics, mockTheme, mockWeightUnit } from '../../__tests__/helpers'
@@ -76,8 +76,19 @@ function daysAgo(days: number): string {
   return new Date(Date.now() - days * 86400000).toISOString().slice(0, 10)
 }
 
+// Freeze the clock so "N days ago" day-key math is deterministic. Every fixture
+// here derives its date from live time via daysAgo()/new Date(), and the
+// component buckets those into `.slice(0,10)` day-keys — a run crossing a
+// midnight or DST boundary could produce off-by-one keys and a false failure
+// (LIFT-969). Faking only Date (not setTimeout/queueMicrotask) keeps Vue's
+// nextTick and promise flushing on the real event loop. Noon UTC on a
+// non-DST-transition date keeps the derived day-keys stable across timezones.
+const FROZEN_NOW = new Date('2026-06-15T12:00:00.000Z')
+
 describe('BodyweightTracker', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(FROZEN_NOW)
     entries = []
     localStorageMock.clear()
     mockWeightGoal.direction = 'lose'
@@ -85,6 +96,10 @@ describe('BodyweightTracker', () => {
     mockWeightGoal.gainTarget = null
     mockWeightGoal.maintainMin = null
     mockWeightGoal.maintainMax = null
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('empty state', () => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-969](https://github.com/aschung212/Lift/issues/969)

Implement LIFT-969 — freeze system time in `BodyweightTracker.test.ts` so its date-relative fixtures (`daysAgo()` and inline `new Date()`) produce deterministic day-keys, removing the midnight/DST off-by-one flake class.

## Changes
- `src/components/__tests__/BodyweightTracker.test.ts`: Added a frozen clock (`FROZEN_NOW = 2026-06-15T12:00:00Z`) via `vi.useFakeTimers({ toFake: ['Date'] })` + `vi.setSystemTime()` in the top-level `beforeEach`, restored with `vi.useRealTimers()` in a new `afterEach`. Only `Date` is faked so Vue's `nextTick`/promise flushing stays on the real event loop. Imported `afterEach`.

Left the two stranded working-tree changes (`src/__tests__/setup.ts`, `src/composables/__tests__/useTheme.test.ts` — LIFT-966, already in progress with its own PR) untouched and out of this commit.

## Verification
- `npx vitest run src/components/__tests__/BodyweightTracker.test.ts` → 74 passed
- `npx vitest run` bodyweight suites → 100 passed
- ESLint clean (pre-commit hook passed)
- Adversarial review: REVIEW_CLEAN / MERGE
- Branch `enhance/run4-2026-07-17` pushed

## Screenshots
N/A — test-only change, no UI impact.

## Commits
- [`dfeff6d`](https://github.com/aschung212/Lift/commit/dfeff6d) test(LIFT-969): freeze system time in BodyweightTracker date fixtures

## Test Results
- Before: 2771 passing
- After: 2771 passing (0 delta)

---
_Automated by overnight pipeline — Sat Jul 18 00:02:34 PDT 2026_

## Preview
Test on your phone: https://lift-7qp2mmquf-aschung212-1101s-projects.vercel.app