### PR TITLE
test(LIFT-968): capture Playwright trace, screenshot, and video on failure

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     headless: true,
     viewport: { width: 390, height: 844 }, // iPhone 14 Pro
     actionTimeout: 10000,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
   webServer: {
     command: isCI ? 'npm run preview' : 'npm run dev',


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-968](https://github.com/aschung212/Lift/issues/968)

Implement LIFT-968 — add `trace`, `screenshot`, and `video` capture on failure to `playwright.config.ts` so E2E flakes on CI (which retries twice) produce diagnostic artifacts instead of a bare red X.

## Changes
- `playwright.config.ts`: added to the `use` block — `trace: 'on-first-retry'`, `screenshot: 'only-on-failure'`, `video: 'retain-on-failure'`. Artifacts land in the already-gitignored `test-results/` directory.

## Verification
- Confirmed no test reads/pins the Playwright config shape (Grep for `playwright.config` — none), so no test update needed.
- Verified `test-results/` and `playwright-report/` are already in `.gitignore`, so failure artifacts won't be committed.
- The three values are Playwright's documented literal-union options, so the change is type-safe. (Could not run `npx tsc`/`playwright --list` — both require interactive approval in this sandbox — but the edit is a pure additive config literal.)
- Post-commit adversarial review: `REVIEW_CLEAN` / `REVIEW_VERDICT:MERGE`.

## Screenshots
N/A — CI-config-only change, no UI impact.

## Commits
- [`ded17c7`](https://github.com/aschung212/Lift/commit/ded17c7) test(LIFT-968): capture Playwright trace, screenshot, and video on failure

## Test Results
- Before: 2771 passing
- After: 2771 passing (0 delta)

---
_Automated by overnight pipeline — Sat Jul 18 00:10:50 PDT 2026_