### PR TITLE
fix: raise tag/gym picker chips to the 44pt iOS touch target (closes #990)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ This app will be wrapped with Capacitor for the App Store. Keep all code compati
 
 This app targets iOS App Store via Capacitor. Every UI element must meet Apple's Human Interface Guidelines:
 
-- **44pt minimum touch targets.** Buttons, toggles, tappable rows, icon buttons — all must be at least 44x44pt. Existing regression tests enforce this for known violations. When adding new interactive elements, verify and add a test.
+- **44pt minimum touch targets.** Buttons, toggles, tappable rows, icon buttons — all must be at least 44x44pt. Existing regression tests enforce this for known violations. When adding new interactive elements, verify and add a test. Two ways to reach 44pt, and the choice is not free: size the element (`min-height: 44px`) by default, or keep a compact visual and extend the hit area with an absolutely-positioned transparent `::before` (`.logSetFieldClear`). The overlay is only safe for a control ringed by inert whitespace — for controls that **tile**, like the `.wtTagPickerChip` rows (#990), overlays butt against each other and a near-miss activates the neighbour instead of doing nothing, so size those instead.
 - **Safe area insets.** All fixed/sticky elements must use `env(safe-area-inset-*)`. The Dynamic Island on newer iPhones hides content at the top. Test in PWA standalone mode — browser mode hides this issue.
 - **WCAG 2.1 AA contrast.** All 10 themes (20 variants) are tested via `themeContrast.test.ts`. When adding or modifying theme colors, run the contrast audit. Normal text needs 4.5:1, large text needs 3:1.
 - **No hover-gated interactions.** Touch-only. Hover can enhance but must never be the only way to access functionality.

--- a/src/index.css
+++ b/src/index.css
@@ -3069,9 +3069,18 @@ html.theme-fading .settingsSheet {
   margin: 12px 0 4px;
 }
 
+/* Shared by five pickers: WorkoutTracker's new-exercise Tags + Gym rows and
+   EditExerciseModal's Tags, Equipment and Gym rows. min-height is the iOS HIG
+   44pt floor (#990) — the chips previously rendered 33px, or 38px in rows
+   containing the larger "+" add chip, which stretches its row. Deliberately
+   sized rather than padded out with a transparent ::before overlay: chips tile
+   in a wrapping 8px-gap row, so 44px overlays on 33px pills would leave no dead
+   space between wrapped rows and a near-miss would toggle the neighbouring chip
+   instead of doing nothing. */
 .wtTagPickerChip {
   display: inline-flex;
   align-items: center;
+  min-height: 44px;
   font-size: var(--font-footnote);
   font-weight: 600;
   padding: 8px 16px;
@@ -3096,8 +3105,12 @@ html.theme-fading .settingsSheet {
   display: inline-flex;
 }
 
+/* Swaps in where the "+" add chip was, so it must match the chips' 44pt floor.
+   Stretch alone would not cover it: with no tags/gyms configured yet this input
+   is the only item in the row and has nothing to stretch against. */
 .wtTagInlineInput {
   width: 96px;
+  min-height: 44px;
   padding: 8px 12px;
   font-size: var(--font-footnote);
   font-family: inherit;

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -306,6 +306,48 @@ describe('CSS regression tests', () => {
     })
   })
 
+  describe('.wtTagPickerChip touch target (#990)', () => {
+    // Regression: the picker chips carried only `padding: 8px 16px` around
+    // 13px text, so they measured 33px tall (38px in rows containing the
+    // larger --font-body "+" add chip, which stretches its row) — well under
+    // the project's 44pt iOS floor. The class is shared by five pickers:
+    // WorkoutTracker's new-exercise Tags and Gym rows, and EditExerciseModal's
+    // Tags, Equipment and Gym rows, so the height must live on the shared rule
+    // rather than being patched per surface.
+    //
+    // Sized rather than padded out with a transparent ::before hit-area (the
+    // .logSetFieldClear approach): that trick suits an isolated control ringed
+    // by inert whitespace, but these chips tile in a wrapping 8px-gap row, so
+    // 44px overlays over 33px pills would tile edge-to-edge and a near-miss in
+    // the gutter would toggle the neighbouring chip instead of doing nothing.
+    it('.wtTagPickerChip has min-height: 44px for iOS HIG compliance', () => {
+      const lines = getRuleLines('.wtTagPickerChip')
+      expect(lines.some(l => l.includes('min-height') && l.includes('44px'))).toBe(true)
+    })
+
+    // The chip must carry the height itself: .wtTagPicker is a plain flex row,
+    // so a chip alone in its row has nothing to stretch against.
+    it('does not depend on a fixed height that would clip wrapped labels', () => {
+      const lines = getRuleLines('.wtTagPickerChip')
+      expect(lines.some(l => /^height:/.test(l))).toBe(false)
+    })
+
+    // The "+" chip is the narrowest in every picker; its 44pt width comes from
+    // min-width, not from a text label.
+    it('.wtTagAddChip keeps min-width: 44px so the "+" is a full target', () => {
+      const lines = getRuleLines('.wtTagAddChip')
+      expect(lines.some(l => l.includes('min-width') && l.includes('44px'))).toBe(true)
+    })
+
+    // The inline add input replaces the "+" chip in the same row. With no tags
+    // or gyms configured it is the only item in that row, so flex stretch alone
+    // would leave it at its natural 33px.
+    it('.wtTagInlineInput matches the 44pt floor it swaps in for', () => {
+      const lines = getRuleLines('.wtTagInlineInput')
+      expect(lines.some(l => l.includes('min-height') && l.includes('44px'))).toBe(true)
+    })
+  })
+
   describe('brace balance', () => {
     // Regression: an extra closing brace in index.css caused a CSS minifier
     // warning ("unexpected }") that could silently drop rules in production.


### PR DESCRIPTION
Closes #990.

`.wtTagPickerChip` carried only `padding: 8px 16px` around 13px (`--font-footnote`) text, so it measured **33px** tall — **38px** in rows containing the larger `--font-body` "+" add chip, which stretches its row via the flex row's default `align-items: stretch`. Both sit under the 44pt iOS HIG minimum that CLAUDE.md's iOS Compliance section mandates.

Widths were already compliant (the narrowest is the "+" chip at 44.8px via `min-width: 44px`), so only height moved.

## Scope

The class is shared by **five** pickers, so the fix lives on the shared rule rather than being patched per surface:

| Surface | Section |
| --- | --- |
| WorkoutTracker new-exercise form | Tags |
| WorkoutTracker new-exercise form | Gym (#984) |
| `EditExerciseModal` | Tags |
| `EditExerciseModal` | Equipment radiogroup (#931 phase C) |
| `EditExerciseModal` | Gym (#961) |

The Equipment radiogroup wasn't in the original bug report but shares the class and had the same defect.

Found while implementing #984 and deliberately deferred there — a 44pt gym chip beside 33pt tag chips would have looked broken.

## Why `min-height` and not a transparent `::before` hit-area

The issue floated keeping the pill compact and extending the tap area with an overlay, the way `.logSetFieldClear` does. **I went the other way, deliberately.**

That trick works for `.logSetFieldClear` because the × sits alone, ringed by inert whitespace. These chips **tile**: they wrap in a flex row with an 8px gap, so row pitch would be 33 + 8 = 41px while the overlays are 44px. The hit areas would butt edge-to-edge with no dead space between wrapped rows — a near-miss in the visual gutter would toggle the *neighbouring* chip instead of doing nothing. In a multi-select picker that turns a too-small target into a silently-wrong one, which is worse.

Bumping the gap to buy back dead space doesn't help either: you'd need ~20px of gap to get a meaningful buffer, which costs more vertical space than just sizing the chip and looks sparse. Sizing the chip keeps the 8px gaps as genuine dead space where a mis-tap is a no-op.

Trade-off accepted: the pills are visually chunkier. Vertical cost is +11px per chip row (+6px for rows that already contained the "+"). In the New Exercise sheet that's ~+23px total; in `EditExerciseModal` the Tags picker grows 120px → 148px.

## Also fixed

`.wtTagInlineInput` — the input that swaps in where the "+" chip was — had the same 33px height. Flex stretch alone doesn't save it: with no tags or gyms configured yet it's the only item in its row, so it has nothing to stretch against.

## Verification

Measured live in the dev server at 375x812 with seeded data (6 tags, 2 gyms):

- Every chip across all five pickers measures **>=44x44** (min height exactly 44, min width 44.75).
- **Row wrapping is unchanged** — A/B'd by neutralising the new `min-height` at runtime and re-counting wrap rows. `EditExerciseModal`'s Tags picker wraps to 3 rows both before and after; the lone "+" on its own row is pre-existing.
- The inline-add state stays uniform: chip / chip / input all render 44px.
- No horizontal overflow on the page or inside either modal; the widest chip ("Auto (free weight)", 149px) fits.
- Both modals still fit the viewport and scroll internally.
- No console errors. Dark mode re-checked — pure sizing change, no colors touched.

## Regression test

Added `.wtTagPickerChip touch target (#990)` to `cssRegression.test.ts`, following the existing 44pt-enforcement pattern (`getRuleLines` + assert `min-height: 44px`). It pins the chip height, the `.wtTagAddChip` min-width the "+" depends on, and the inline input.

**Confirmed non-vacuous:** with the two `min-height` declarations stripped, the suite reports `2 failed | 103 passed`; with them restored, 105 pass.

*Why didn't existing tests catch this?* The 44pt checks in `cssRegression.test.ts` are a hand-maintained allowlist — one `describe` per known control — and `.wtTagPickerChip` was never added. I kept the allowlist shape rather than attempting a blanket sweep, since the file legitimately mixes three compliance strategies (sized, `width`/`height` icon buttons, and `::before` overlays) that a generic rule would false-positive on.

## Docs

Added a line to CLAUDE.md's iOS Compliance bullet recording when the overlay pattern is and isn't safe, since the codebase now contains both and the tiling caveat is the non-obvious part. Happy to drop it if you'd rather keep that section terse.

## Gates

`npm run lint`, `vue-tsc --noEmit`, `npm test` (2792 passed / 1 skipped), `npm run build` — all green.

One `Errors 1 error` line appeared on a single `npm test` run while the dev server was running concurrently; it did not reproduce across two subsequent clean runs, consistent with the known vitest contention flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
