### PR TITLE
feat(LIFT-998): add a crawlable no-JS content fallback to the HTML shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,6 +223,56 @@
     }
   </style>
   <div id="app"></div>
+
+  <!--
+    Crawlable / no-JS fallback (LIFT-998). The app shell above renders entirely
+    client-side, so agents that do NOT execute JavaScript — Bing, DuckDuckGo,
+    most social-card scrapers, and LLM crawlers — would otherwise index an empty
+    body. This <noscript> block gives them real content (app name, tagline, core
+    features) and doubles as a graceful message for humans with JS disabled: its
+    inline style hides the (otherwise permanently stuck) splash and paints a
+    readable panel instead of a frozen "Loading local data…" screen.
+  -->
+  <noscript>
+    <style>
+      #splash { display: none !important; }
+      .noscriptFallback {
+        position: fixed;
+        inset: 0;
+        overflow: auto;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 16px;
+        padding: 32px;
+        text-align: center;
+        line-height: 1.5;
+        background: #0f0f0f;
+        color: #e8f0eb;
+        font-family: -apple-system, 'SF Pro Display', 'Inter', system-ui, sans-serif;
+      }
+      .noscriptFallback h1 {
+        margin: 0;
+        font-size: 32px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        color: #d4af37;
+      }
+      .noscriptFallback p {
+        margin: 0;
+        max-width: 34rem;
+        font-size: 16px;
+        color: #c3d0c9;
+      }
+    </style>
+    <div class="noscriptFallback">
+      <h1>Lift — Workout Tracker</h1>
+      <p>A free, open-source, offline-capable PWA for strength training. Log sets, track estimated 1RM progress, visualize your training history across 10 themes, and celebrate new personal records.</p>
+      <p>Lift needs JavaScript to run. Please enable JavaScript in your browser to start tracking your workouts.</p>
+    </div>
+  </noscript>
+
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/src/lib/__tests__/metaRegression.test.ts
+++ b/src/lib/__tests__/metaRegression.test.ts
@@ -64,6 +64,33 @@ describe('index.html meta tag regression tests', () => {
     })
   })
 
+  describe('crawlable content fallback for non-JS indexers (LIFT-998)', () => {
+    const noscript = html.match(/<noscript>([\s\S]*?)<\/noscript>/)?.[1] ?? ''
+
+    it('ships a <noscript> block so non-JS crawlers see indexable content', () => {
+      expect(noscript.trim().length).toBeGreaterThan(0)
+    })
+
+    it('exposes a single crawlable <h1> naming the app', () => {
+      const h1 = noscript.match(/<h1[^>]*>([\s\S]*?)<\/h1>/)
+      expect(h1).not.toBeNull()
+      expect(h1![1]).toContain('Lift')
+      // Only the no-JS fallback carries a static heading; the live app renders
+      // its own headings client-side, so the raw shell must not double up.
+      const allH1s = html.match(/<h1[^>]*>/g) ?? []
+      expect(allH1s.length).toBe(1)
+    })
+
+    it('describes core features so there is real first-pass body copy', () => {
+      expect(noscript).toMatch(/1RM/)
+      expect(noscript.toLowerCase()).toContain('workout')
+    })
+
+    it('hides the splash when JavaScript is disabled so no-JS users are not stuck', () => {
+      expect(noscript).toMatch(/#splash\s*\{[^}]*display:\s*none/)
+    })
+  })
+
   describe('no references to domains we do not own', () => {
     it('does not reference liftracker.app (competitor domain)', () => {
       expect(html).not.toContain('liftracker.app')


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-998](https://github.com/aschung212/Lift/issues/998)

Implement LIFT-998: add a `<noscript>`/crawlable content fallback to the CSR HTML shell so non-JS indexers (Bing, DuckDuckGo, social scrapers, LLM crawlers) see real body content, and no-JS humans get a graceful message instead of a frozen splash.

## Changes
- **index.html** — Added a `<noscript>` block after `#app` containing a single `<h1>` (app name), a feature/tagline paragraph (sets, 1RM, history, PRs), and a "please enable JavaScript" line. Its scoped inline `<style>` hides the permanently-stuck `#splash` and paints a themed, readable fallback panel. Uses the Eternal palette hex values (matching the existing splash fallback tokens) since this renders with no CSS bundle when JS is disabled.
- **src/lib/__tests__/metaRegression.test.ts** — Added a `crawlable content fallback (LIFT-998)` describe block: asserts the noscript block exists, exposes exactly one crawlable `<h1>` naming the app (guards against duplicate static headings that would confuse SR/SEO), carries core-feature copy (`1RM`/`workout`), and hides `#splash` when JS is disabled.

## Verification
- `npx vitest run src/lib/__tests__/metaRegression.test.ts` — 13 passed
- `npm run build` — succeeded; confirmed `noscriptFallback` present in `dist/index.html`
- `npm run lint` — clean
- Post-commit adversarial review: REVIEW_CLEAN / MERGE

## Screenshots
None — the noscript block only renders in a JS-disabled context, not observable in the normal running app.

## Commits
- [`17875f2`](https://github.com/aschung212/Lift/commit/17875f2) feat(LIFT-998): add a crawlable no-JS content fallback to the HTML shell

## Test Results
- Before: 2886 passing
- After: 2890 passing (4 delta)

---
_Automated by overnight pipeline — Tue Jul 21 23:28:28 PDT 2026_

## Preview
Test on your phone: https://lift-ns79kewcc-aschung212-1101s-projects.vercel.app