### PR TITLE
feat(LIFT-1001): stamp a build-time lastmod into sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,6 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://spa-rho-sandy.vercel.app/</loc>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/lib/__tests__/buildConfigRegression.test.ts
+++ b/src/lib/__tests__/buildConfigRegression.test.ts
@@ -24,4 +24,11 @@ describe('vite.config.js regression', () => {
     expect(viteConfig).toContain('preloadDefaultViewPlugin')
     expect(viteConfig).toContain("from './vite-plugin-preload-default-view'")
   })
+
+  it('should wire the sitemap lastmod plugin into the build', () => {
+    // Stamps a build-time <lastmod> into dist/sitemap.xml so Google can schedule
+    // recrawls accurately after each deploy. See LIFT-1001.
+    expect(viteConfig).toContain('sitemapLastmodPlugin')
+    expect(viteConfig).toContain("from './vite-plugin-sitemap-lastmod'")
+  })
 })

--- a/src/lib/__tests__/seoStaticFiles.test.ts
+++ b/src/lib/__tests__/seoStaticFiles.test.ts
@@ -48,6 +48,16 @@ describe('sitemap.xml', () => {
     expect(content).toContain(`<loc>https://${DEPLOYMENT_DOMAIN}/</loc>`)
   })
 
+  it('declares a lastmod in valid W3C date-only format (Google uses it for recrawl scheduling)', () => {
+    const content = readFileSync(sitemapPath, 'utf-8')
+    const match = content.match(/<lastmod>(.*?)<\/lastmod>/)
+    expect(match).not.toBeNull()
+    const lastmod = match![1]
+    expect(lastmod).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    // Must be a real calendar date, not just digit-shaped.
+    expect(Number.isNaN(Date.parse(lastmod))).toBe(false)
+  })
+
   it('does not reference liftracker.app', () => {
     const content = readFileSync(sitemapPath, 'utf-8')
     expect(content).not.toContain('liftracker.app')

--- a/src/lib/__tests__/sitemapLastmod.test.ts
+++ b/src/lib/__tests__/sitemapLastmod.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import sitemapLastmodPlugin, {
+  injectSitemapLastmod,
+  buildDateISO,
+} from '../../../vite-plugin-sitemap-lastmod'
+
+const BASE = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://spa-rho-sandy.vercel.app/</loc>
+    <lastmod>2026-07-21</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>
+`
+
+describe('injectSitemapLastmod', () => {
+  it('replaces an existing lastmod with the given date', () => {
+    const out = injectSitemapLastmod(BASE, '2026-08-15')
+    expect(out).toContain('<lastmod>2026-08-15</lastmod>')
+    expect(out).not.toContain('<lastmod>2026-07-21</lastmod>')
+  })
+
+  it('preserves loc, changefreq and priority when replacing', () => {
+    const out = injectSitemapLastmod(BASE, '2026-08-15')
+    expect(out).toContain('<loc>https://spa-rho-sandy.vercel.app/</loc>')
+    expect(out).toContain('<changefreq>weekly</changefreq>')
+    expect(out).toContain('<priority>1.0</priority>')
+  })
+
+  it('inserts a lastmod after <loc> when none exists, matching indentation', () => {
+    const noLastmod = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://spa-rho-sandy.vercel.app/</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>
+`
+    const out = injectSitemapLastmod(noLastmod, '2026-08-15')
+    expect(out).toContain(
+      '    <loc>https://spa-rho-sandy.vercel.app/</loc>\n    <lastmod>2026-08-15</lastmod>',
+    )
+  })
+
+  it('is idempotent — reapplying the same date yields identical output', () => {
+    const once = injectSitemapLastmod(BASE, '2026-08-15')
+    const twice = injectSitemapLastmod(once, '2026-08-15')
+    expect(twice).toBe(once)
+  })
+
+  it('never introduces a second lastmod element', () => {
+    const out = injectSitemapLastmod(BASE, '2026-08-15')
+    expect(out.match(/<lastmod>/g)?.length).toBe(1)
+  })
+})
+
+describe('buildDateISO', () => {
+  it('formats a date as date-only YYYY-MM-DD (W3C Datetime)', () => {
+    expect(buildDateISO(new Date('2026-08-15T23:45:12.000Z'))).toBe('2026-08-15')
+  })
+
+  it('produces a valid date-only string for the current date by default', () => {
+    expect(buildDateISO()).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('sitemapLastmodPlugin', () => {
+  it('only applies during build (the committed file is valid on its own)', () => {
+    expect(sitemapLastmodPlugin().apply).toBe('build')
+  })
+})

--- a/vite-plugin-sitemap-lastmod.ts
+++ b/vite-plugin-sitemap-lastmod.ts
@@ -1,0 +1,62 @@
+/**
+ * Vite plugin: stamp a build-time `<lastmod>` into sitemap.xml.
+ *
+ * public/sitemap.xml is copied verbatim into the build output, so its
+ * `<lastmod>` would freeze at whatever date is committed to the repo. Google
+ * has stated it *uses* `<lastmod>` to schedule recrawls but *ignores*
+ * `<changefreq>`/`<priority>` — a stale lastmod tells Google the page hasn't
+ * changed since that date, delaying recrawls after a deploy.
+ *
+ * This plugin rewrites the emitted `dist/sitemap.xml` in `closeBundle` (which
+ * runs after Vite copies the public dir) so the `<lastmod>` reflects the actual
+ * build/deploy date. The committed static file keeps a valid date so it is
+ * correct on its own in dev and for the source-level regression tests.
+ *
+ * The date is date-only W3C Datetime (`YYYY-MM-DD`) — the format Google's
+ * examples use — so it doesn't churn within a single deploy day.
+ */
+import type { Plugin } from 'vite'
+import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * Return `xml` with its `<lastmod>` set to `isoDate`.
+ *
+ * Pure and idempotent — exported for unit testing. If a `<lastmod>` already
+ * exists it is replaced (every occurrence); otherwise one is inserted directly
+ * after the first `<loc>`, preserving that line's indentation.
+ */
+export function injectSitemapLastmod(xml: string, isoDate: string): string {
+  const lastmodTag = `<lastmod>${isoDate}</lastmod>`
+  if (/<lastmod>[^<]*<\/lastmod>/.test(xml)) {
+    return xml.replace(/<lastmod>[^<]*<\/lastmod>/g, lastmodTag)
+  }
+  return xml.replace(
+    /([ \t]*)(<loc>[^<]*<\/loc>)/,
+    (_match, indent: string, loc: string) => `${indent}${loc}\n${indent}${lastmodTag}`,
+  )
+}
+
+/** Today's date as a date-only W3C Datetime string (`YYYY-MM-DD`). */
+export function buildDateISO(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10)
+}
+
+export default function sitemapLastmodPlugin(): Plugin {
+  let outDir = 'dist'
+  return {
+    name: 'lift-sitemap-lastmod',
+    apply: 'build', // The static committed file already carries a valid date.
+    configResolved(config) {
+      outDir = config.build.outDir
+    },
+    // closeBundle runs after Vite copies the public dir into the output.
+    closeBundle() {
+      const sitemapPath = resolve(outDir, 'sitemap.xml')
+      if (!existsSync(sitemapPath)) return
+      const xml = readFileSync(sitemapPath, 'utf-8')
+      const stamped = injectSitemapLastmod(xml, buildDateISO())
+      if (stamped !== xml) writeFileSync(sitemapPath, stamped)
+    },
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { readFileSync } from 'fs'
 import themeStripPlugin from './vite-plugin-theme-split'
 import preloadDefaultViewPlugin from './vite-plugin-preload-default-view'
+import sitemapLastmodPlugin from './vite-plugin-sitemap-lastmod'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
@@ -36,6 +37,7 @@ export default defineConfig({
     vue(),
     themeStripPlugin(),
     preloadDefaultViewPlugin(),
+    sitemapLastmodPlugin(),
     VitePWA({
       // Disable the service worker entirely for the native Capacitor build (#532).
       // WKWebView serves the web assets bundled in the .ipa and refreshes them via


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1001](https://github.com/aschung212/Lift/issues/1001)

Implement LIFT-1001: inject a build-time `<lastmod>` into `sitemap.xml` so Google can schedule recrawls accurately (Google uses `<lastmod>`, ignores `<changefreq>`/`<priority>`).

## Changes
- **`vite-plugin-sitemap-lastmod.ts` (new)** — Vite build plugin. Exposes a pure `injectSitemapLastmod(xml, isoDate)` helper (replaces an existing `<lastmod>` or inserts one after `<loc>`, idempotent) and `buildDateISO()` (date-only W3C Datetime). In `closeBundle` (runs after Vite copies `public/`), rewrites `dist/sitemap.xml` with the actual build date. `apply: 'build'` only.
- **`vite.config.js`** — import and register `sitemapLastmodPlugin()`.
- **`public/sitemap.xml`** — added `<lastmod>2026-07-21</lastmod>` so the committed file is valid on its own in dev and for source-level tests; the plugin refreshes it to the deploy date at build.
- **`src/lib/__tests__/sitemapLastmod.test.ts` (new)** — 8 tests for the pure helper (replace/insert/idempotent/no-double-element), `buildDateISO`, and `apply === 'build'`.
- **`src/lib/__tests__/seoStaticFiles.test.ts`** — assert the sitemap declares a valid W3C date-only `<lastmod>` that parses as a real date.
- **`src/lib/__tests__/buildConfigRegression.test.ts`** — assert the plugin is wired into the build.

## Verification
- Targeted tests: 22 passed (sitemapLastmod + seoStaticFiles + buildConfigRegression).
- `npm run build`: succeeded; confirmed `dist/sitemap.xml` emitted `<lastmod>2026-07-22</lastmod>` (UTC build date) while all other elements were preserved.
- `npm run lint`: clean.
- Post-commit adversarial review: REVIEW_CLEAN / MERGE.

## Screenshots
N/A — build-tooling / SEO metadata change, no UI surface.

## Commits
- [`401fcc3`](https://github.com/aschung212/Lift/commit/401fcc3) feat(LIFT-1001): stamp a build-time lastmod into sitemap.xml

## Test Results
- Before: 2886 passing
- After: 2896 passing (10 delta)

---
_Automated by overnight pipeline — Tue Jul 21 23:42:53 PDT 2026_

## Preview
Test on your phone: https://lift-68ku3axxm-aschung212-1101s-projects.vercel.app