### PR TITLE
fix(LIFT-1000): normalize sitemap loc to match canonical/og:url (closes #1000)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://spa-rho-sandy.vercel.app/</loc>
+    <loc>https://spa-rho-sandy.vercel.app</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/src/lib/__tests__/seoRegression.test.ts
+++ b/src/lib/__tests__/seoRegression.test.ts
@@ -12,6 +12,7 @@ import { resolve } from 'path'
  */
 
 const publicDir = resolve(__dirname, '../../../public')
+const rootDir = resolve(__dirname, '../../..')
 const DEPLOYMENT_DOMAIN = 'spa-rho-sandy.vercel.app'
 
 describe('SEO file regression tests', () => {
@@ -76,6 +77,36 @@ describe('SEO file regression tests', () => {
     it('does not reference liftracker.app (competitor domain)', () => {
       const content = readFileSync(sitemapPath, 'utf-8')
       expect(content).not.toContain('liftracker.app')
+    })
+  })
+
+  /**
+   * The homepage advertises its own URL in three self-referential places:
+   * the <link rel="canonical">, the og:url meta, and the sitemap <loc>.
+   * Search engines treat a trailing-slash and non-trailing-slash form as the
+   * same page, but inconsistent self-referential signals dilute canonicalization
+   * and can split link equity (LIFT-1000). These three must be byte-identical.
+   */
+  describe('self-referential canonical URL consistency (LIFT-1000)', () => {
+    const html = readFileSync(resolve(rootDir, 'index.html'), 'utf-8')
+    const sitemap = readFileSync(resolve(publicDir, 'sitemap.xml'), 'utf-8')
+
+    const canonical = html.match(/<link rel="canonical" href="([^"]+)"/)?.[1]
+    const ogUrl = html.match(/<meta property="og:url" content="([^"]+)"/)?.[1]
+    const sitemapLoc = sitemap.match(/<loc>([^<]+)<\/loc>/)?.[1]
+
+    it('canonical, og:url, and sitemap <loc> are all present', () => {
+      expect(canonical).toBeDefined()
+      expect(ogUrl).toBeDefined()
+      expect(sitemapLoc).toBeDefined()
+    })
+
+    it('canonical and og:url are byte-identical', () => {
+      expect(ogUrl).toBe(canonical)
+    })
+
+    it('sitemap <loc> is byte-identical to the canonical URL', () => {
+      expect(sitemapLoc).toBe(canonical)
     })
   })
 })

--- a/src/lib/__tests__/seoStaticFiles.test.ts
+++ b/src/lib/__tests__/seoStaticFiles.test.ts
@@ -45,7 +45,7 @@ describe('sitemap.xml', () => {
 
   it('contains root URL with real deployment domain', () => {
     const content = readFileSync(sitemapPath, 'utf-8')
-    expect(content).toContain(`<loc>https://${DEPLOYMENT_DOMAIN}/</loc>`)
+    expect(content).toContain(`<loc>https://${DEPLOYMENT_DOMAIN}</loc>`)
   })
 
   it('does not reference liftracker.app', () => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1000](https://github.com/aschung212/Lift/issues/1000)

Implement LIFT-1000: make the three self-referential homepage URLs (canonical, og:url, sitemap `<loc>`) byte-identical to stop diluting canonicalization / splitting link equity. Chose to align the outlier (sitemap trailing slash) to the already-declared canonical (no trailing slash) so the live canonical/og:url SEO signals stay untouched.

## Changes
- `public/sitemap.xml` — `<loc>` changed from `https://spa-rho-sandy.vercel.app/` to `https://spa-rho-sandy.vercel.app`, matching canonical and og:url.
- `src/lib/__tests__/seoStaticFiles.test.ts` — updated the root-URL assertion to the no-trailing-slash form.
- `src/lib/__tests__/seoRegression.test.ts` — added a cross-file consistency block (LIFT-1000) that reads index.html + sitemap.xml and asserts canonical === og:url === sitemap `<loc>`, so the three can never drift again.

## Verification
- SEO tests: 3 files / 30 tests pass (`seoRegression`, `seoStaticFiles`, `metaRegression`).
- `npm run build` succeeds (PWA precache generated, no errors).
- Post-commit adversarial review: REVIEW_CLEAN / REVIEW_VERDICT:MERGE.
- Unrelated pre-existing working-tree changes (`src/__tests__/setup.ts`, `useTheme.test.ts`) were deliberately left out of the commit.

## Screenshots
N/A — no rendered UI change (static SEO metadata only).

## Commits
- [`be73f11`](https://github.com/aschung212/Lift/commit/be73f11) fix(LIFT-1000): normalize sitemap loc to match canonical/og:url (closes #1000)

## Test Results
- Before: 2886 passing
- After: 2889 passing (3 delta)

---
_Automated by overnight pipeline — Tue Jul 21 23:56:33 PDT 2026_

## Preview
Test on your phone: https://lift-kboe76p6u-aschung212-1101s-projects.vercel.app