### PR TITLE
test(LIFT-1009): extract one shared, configurable Supabase test double

### DIFF
--- a/src/__tests__/fakeSupabase.contract.test.ts
+++ b/src/__tests__/fakeSupabase.contract.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Contract check for the shared Supabase test double (LIFT-1009).
+ *
+ * The four sync test files used to hand-roll divergent fakes; they now share
+ * `createFakeSupabase`. That only removes mock-drift risk if the shared fake's
+ * method set is kept in lockstep with the query surface the stores ACTUALLY use
+ * against the real client. This test enforces that link two ways:
+ *
+ *   1. The fake's builder exposes every method the store source invokes on a
+ *      `supabase.from(...)` chain — scanned straight out of the store files, so
+ *      a store adopting a new method (e.g. `.limit()`) fails here until the fake
+ *      grows to match, instead of silently passing against a stale shape.
+ *   2. Each mode (`ok` / `reject` / `apiError`) honors the documented behavioral
+ *      contract the sync tests depend on.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { createFakeSupabase, FAKE_SUPABASE_CHAIN_METHODS } from './fakeSupabase'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const storesDir = resolve(here, '../stores')
+
+const STORE_FILES = ['workout.ts', 'bodyweight.ts', 'progression.ts', 'preferences.ts']
+
+/**
+ * Extract the chain methods invoked after a `supabase...from(...)` in a store
+ * file. Matches `.method(` tokens so a new query verb shows up here the moment
+ * a store starts using it.
+ */
+function chainMethodsUsedIn(source: string): Set<string> {
+  const used = new Set<string>()
+  // Only consider lines that touch the supabase client chain, to avoid picking
+  // up Array.prototype.filter/map/etc. We look for the query verbs by name.
+  const verbPattern = /\.(select|upsert|update|delete|insert|eq|is|order|single|maybeSingle|limit|in|neq|gte|lte|match|not|filter|range|contains|overlaps|textSearch)\(/g
+  for (const line of source.split('\n')) {
+    if (!/supabase|\bq\b|\.from\(/.test(line)) continue
+    let m: RegExpExecArray | null
+    while ((m = verbPattern.exec(line)) !== null) {
+      // `.filter(` is an Array method too; only count it when the line is clearly
+      // a query builder chain (has .from/.eq/.is/.update/.select on it).
+      if (m[1] === 'filter' && !/\.(from|eq|is|update|select|upsert)\(/.test(line)) continue
+      used.add(m[1])
+    }
+  }
+  return used
+}
+
+describe('createFakeSupabase contract (LIFT-1009)', () => {
+  const builder = createFakeSupabase().from('sets') as unknown as Record<string, unknown>
+
+  it('exposes every chain method the fake advertises via FAKE_SUPABASE_CHAIN_METHODS', () => {
+    for (const method of FAKE_SUPABASE_CHAIN_METHODS) {
+      expect(typeof builder[method], `builder.${method} should be a function`).toBe('function')
+    }
+  })
+
+  it('the builder is a thenable (awaitable) query', () => {
+    expect(typeof builder.then).toBe('function')
+  })
+
+  it('covers every query method the stores invoke on the supabase chain', () => {
+    const used = new Set<string>()
+    for (const file of STORE_FILES) {
+      const source = readFileSync(resolve(storesDir, file), 'utf-8')
+      for (const method of chainMethodsUsedIn(source)) used.add(method)
+    }
+    // `filter` is the JS array method, never a PostgREST verb we mock — drop it
+    // if it leaked through despite the guard above.
+    used.delete('filter')
+
+    // Sanity: the scan actually found the core verbs (guards against a regex
+    // that silently matches nothing and makes this test pass vacuously).
+    for (const core of ['select', 'upsert', 'update', 'eq', 'is', 'order']) {
+      expect(used, `store scan should detect .${core}(`).toContain(core)
+    }
+
+    const missing = [...used].filter(m => typeof builder[m] !== 'function')
+    expect(
+      missing,
+      `The shared fake is missing chain method(s) the stores use: ${missing.join(', ')}. ` +
+        `Add them to FakeBuilder in src/__tests__/fakeSupabase.ts.`,
+    ).toEqual([])
+  })
+})
+
+describe('createFakeSupabase modes (LIFT-1009)', () => {
+  it("'ok' mode seeds, reads, upserts and soft-deletes in-memory", async () => {
+    const fake = createFakeSupabase({ mode: 'ok' })
+    fake.seed('sets', [
+      { id: 's-1', user_id: 'u1', deleted_at: null, weight: 100 },
+      { id: 's-2', user_id: 'u1', deleted_at: '2026-01-01T00:00:00Z', weight: 200 },
+    ])
+
+    // .is(deleted_at, null) matches NULL-or-missing only
+    const active = await fake.from('sets').select('*').eq('user_id', 'u1').is('deleted_at', null).order('id')
+    expect((active.data as Array<{ id: string }>).map(r => r.id)).toEqual(['s-1'])
+
+    // upsert merges by id and is recorded
+    await fake.from('sets').upsert({ id: 's-1', weight: 150 })
+    expect(fake.tables.sets.find(r => r.id === 's-1')!.weight).toBe(150)
+    expect(fake.upsertsFor('sets')).toHaveLength(1)
+
+    // update matches filters and mutates in place (soft delete)
+    await fake.from('sets').update({ deleted_at: 'now' }).eq('id', 's-1').eq('user_id', 'u1')
+    expect(fake.tables.sets.find(r => r.id === 's-1')!.deleted_at).toBe('now')
+    expect(fake.updatesFor('sets')[0].filters).toMatchObject({ id: 's-1', user_id: 'u1' })
+  })
+
+  it("'ok' mode .single() returns the first match or null", async () => {
+    const fake = createFakeSupabase({ mode: 'ok' })
+    fake.seed('user_progression', [{ id: 'p1', user_id: 'u1', total_xp: 42 }])
+
+    const hit = await fake.from('user_progression').select('*').eq('user_id', 'u1').single()
+    expect((hit.data as { total_xp: number }).total_xp).toBe(42)
+
+    const miss = await fake.from('user_progression').select('*').eq('user_id', 'nobody').single()
+    expect(miss.data).toBeNull()
+  })
+
+  it("'reject' mode rejects every query", async () => {
+    const fake = createFakeSupabase({ mode: 'reject' })
+    await expect(fake.from('sets').select('*').eq('user_id', 'u1')).rejects.toThrow('Network request failed')
+  })
+
+  it("'apiError' mode resolves { data: null, error } without throwing", async () => {
+    const fake = createFakeSupabase({ mode: 'apiError' })
+    const res = await fake.from('exercises').select('*').eq('user_id', 'u1')
+    expect(res.data).toBeNull()
+    expect(res.error).toMatchObject({ code: '42501' })
+    // The call is still recorded even in error mode.
+    expect(fake.selectsFor('exercises')).toHaveLength(1)
+  })
+
+  it('reset() clears seeded tables and recorded calls', async () => {
+    const fake = createFakeSupabase({ mode: 'ok' })
+    fake.seed('sets', [{ id: 's-1', user_id: 'u1' }])
+    await fake.from('sets').select('*')
+    fake.reset()
+    expect(fake.tables.sets).toEqual([])
+    expect(fake.calls).toEqual([])
+  })
+})

--- a/src/__tests__/fakeSupabase.ts
+++ b/src/__tests__/fakeSupabase.ts
@@ -1,0 +1,245 @@
+/**
+ * Shared, configurable Supabase test double (LIFT-1009).
+ *
+ * Before this existed, every sync test (`supabaseApiError`,
+ * `supabaseFetchResilience`, `syncPipelineIntegration`, `syncFuzz`) hand-rolled
+ * its own chainable PostgREST fake, each implementing a *different* subset of
+ * `select/eq/is/order/single/upsert/update/delete/then`. That is the classic
+ * mock-drift red flag for a local-first app whose entire durability story runs
+ * through these queries: a real client API change could be reflected in one fake
+ * but not another, letting a store pass against a shape production no longer has.
+ *
+ * `createFakeSupabase({ mode })` is the single source of truth for what the
+ * Supabase client contract looks like in tests. It implements the full chain
+ * surface the stores actually use in ONE place, with per-test behavior selected
+ * by a `mode` option rather than copy-pasted chains:
+ *
+ *   - `'ok'`       — in-memory tables. Records every call; `seed()` rows, then
+ *                    reads/upserts/updates/deletes them like a real backend.
+ *                    This is the superset used by the read-path fuzz + write-path
+ *                    integration tests.
+ *   - `'reject'`   — every query rejects (network/offline simulation). Stores
+ *                    must preserve local data and never throw out of `init()`.
+ *   - `'apiError'` — every query resolves `{ data: null, error }` (a non-throwing
+ *                    API/RLS error). Stores must check `.error` and bail out.
+ *
+ * The set of methods on the builder is asserted against the stores' real usage
+ * by `fakeSupabase.contract.test.ts`, so a new query method in a store fails the
+ * contract check until the fake grows to match it.
+ */
+
+/** The method names a store may invoke on a `supabase.from(...)` query chain. */
+export const FAKE_SUPABASE_CHAIN_METHODS = [
+  'select',
+  'upsert',
+  'update',
+  'delete',
+  'eq',
+  'is',
+  'order',
+  'single',
+  'then',
+] as const
+
+export type FakeSupabaseMode = 'ok' | 'reject' | 'apiError'
+
+export interface FakeSupabaseError {
+  message: string
+  code?: string
+}
+
+export interface FakeSupabaseOptions {
+  /** Selects per-query behavior. Defaults to `'ok'`. */
+  mode?: FakeSupabaseMode
+  /** Error object returned in `'apiError'` mode (defaults to an RLS 42501 denial). */
+  error?: FakeSupabaseError
+  /** Error thrown in `'reject'` mode (defaults to a network failure). */
+  rejectionError?: Error
+}
+
+interface Row {
+  id: string
+  [k: string]: unknown
+}
+
+type Op = 'select' | 'delete' | 'upsert' | 'update'
+
+interface RecordedCall {
+  op: Op
+  table: string
+  filters: Record<string, unknown>
+  data?: unknown
+}
+
+/** Sentinel wrapping a `.is(col, val)` filter so it can match NULL-or-missing. */
+interface IsFilter {
+  __is: unknown
+}
+
+function isIsFilter(v: unknown): v is IsFilter {
+  return v !== null && typeof v === 'object' && '__is' in (v as object)
+}
+
+const DEFAULT_API_ERROR: FakeSupabaseError = {
+  message: 'permission denied for table exercises',
+  code: '42501',
+}
+
+export class FakeSupabase {
+  readonly mode: FakeSupabaseMode
+  private readonly _apiError: FakeSupabaseError
+  private readonly _rejectionError: Error
+
+  /** In-memory rows keyed by table name (populated via `seed()`; `'ok'` mode). */
+  tables: Record<string, Row[]> = {
+    exercises: [],
+    sets: [],
+    bodyweight_entries: [],
+    user_progression: [],
+    user_preferences: [],
+  }
+
+  /** Every query recorded in call order, across all modes. */
+  calls: RecordedCall[] = []
+
+  constructor(options: FakeSupabaseOptions = {}) {
+    this.mode = options.mode ?? 'ok'
+    this._apiError = options.error ?? DEFAULT_API_ERROR
+    this._rejectionError = options.rejectionError ?? new Error('Network request failed')
+  }
+
+  reset() {
+    this.tables = {
+      exercises: [],
+      sets: [],
+      bodyweight_entries: [],
+      user_progression: [],
+      user_preferences: [],
+    }
+    this.calls = []
+  }
+
+  seed(table: string, rows: Row[]) {
+    this.tables[table] = rows.map(r => ({ ...r }))
+  }
+
+  from(table: string) {
+    return new FakeBuilder(this, table)
+  }
+
+  callsFor(op: Op, table: string) {
+    return this.calls.filter(c => c.op === op && c.table === table)
+  }
+
+  selectsFor(table: string) {
+    return this.callsFor('select', table)
+  }
+
+  deletesFor(table: string) {
+    return this.callsFor('delete', table)
+  }
+
+  upsertsFor(table: string) {
+    return this.callsFor('upsert', table)
+  }
+
+  updatesFor(table: string) {
+    return this.callsFor('update', table)
+  }
+
+  /** @internal — records the call and, in `'ok'` mode, mutates/reads the store. */
+  _resolve(
+    op: Op,
+    table: string,
+    filters: Record<string, unknown>,
+    data: unknown,
+    single: boolean,
+  ): { data: unknown; error: FakeSupabaseError | null } {
+    this.calls.push({ op, table, filters: { ...filters }, data })
+
+    if (this.mode === 'apiError') {
+      return { data: null, error: this._apiError }
+    }
+
+    const rows = this._query(op, table, filters, data)
+    return { data: single ? (rows[0] ?? null) : rows, error: null }
+  }
+
+  /** @internal — the throwing branch for `'reject'` mode. */
+  get _rejection(): Error {
+    return this._rejectionError
+  }
+
+  private _query(op: Op, table: string, filters: Record<string, unknown>, data: unknown): Row[] {
+    const rows = this.tables[table] || (this.tables[table] = [])
+    const matches = rows.filter(r =>
+      Object.entries(filters).every(([k, v]) => {
+        if (isIsFilter(v)) {
+          const target = v.__is
+          if (target === null) return r[k] == null
+          return r[k] === target
+        }
+        return r[k] === v
+      }),
+    )
+
+    if (op === 'select') return matches
+    if (op === 'delete') {
+      const ids = new Set(matches.map(r => r.id))
+      this.tables[table] = rows.filter(r => !ids.has(r.id))
+      return matches
+    }
+    if (op === 'upsert') {
+      const records = Array.isArray(data) ? (data as Row[]) : [data as Row]
+      for (const rec of records) {
+        const idx = rows.findIndex(r => r.id === rec.id)
+        if (idx >= 0) rows[idx] = { ...rows[idx], ...rec }
+        else rows.push({ ...rec })
+      }
+      return records
+    }
+    if (op === 'update') {
+      for (const m of matches) Object.assign(m, data as Row)
+      return matches
+    }
+    return []
+  }
+}
+
+class FakeBuilder implements PromiseLike<{ data: unknown; error: FakeSupabaseError | null }> {
+  private _op: Op = 'select'
+  private _filters: Record<string, unknown> = {}
+  private _data: unknown = null
+  private _single = false
+
+  constructor(private _parent: FakeSupabase, private _table: string) {}
+
+  select(_cols?: string) { this._op = 'select'; return this }
+  delete() { this._op = 'delete'; return this }
+  upsert(data: unknown) { this._op = 'upsert'; this._data = data; return this }
+  update(data: unknown) { this._op = 'update'; this._data = data; return this }
+  eq(col: string, val: unknown) { this._filters[col] = val; return this }
+  is(col: string, val: null | boolean) { this._filters[col] = { __is: val }; return this }
+  order(_col: string) { return this }
+  single() { this._single = true; return this }
+
+  then<TResult1 = { data: unknown; error: FakeSupabaseError | null }, TResult2 = never>(
+    onfulfilled?: (v: { data: unknown; error: FakeSupabaseError | null }) => TResult1 | PromiseLike<TResult1>,
+    onrejected?: (reason: unknown) => TResult2 | PromiseLike<TResult2>,
+  ): PromiseLike<TResult1 | TResult2> {
+    if (this._parent.mode === 'reject') {
+      return Promise.reject(this._parent._rejection).then(onfulfilled, onrejected)
+    }
+    const result = this._parent._resolve(this._op, this._table, this._filters, this._data, this._single)
+    return Promise.resolve(result).then(onfulfilled, onrejected)
+  }
+}
+
+/**
+ * Build a shared Supabase test double. Pass `{ mode }` to select behavior; the
+ * returned instance is what a `vi.mock('.../lib/supabase')` factory should
+ * expose as `supabase`.
+ */
+export function createFakeSupabase(options: FakeSupabaseOptions = {}): FakeSupabase {
+  return new FakeSupabase(options)
+}

--- a/src/__tests__/syncPipelineIntegration.test.ts
+++ b/src/__tests__/syncPipelineIntegration.test.ts
@@ -15,61 +15,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { getLocalStorageMock } from './helpers'
 
-// ── Fake Supabase (chainable, thenable, in-memory) ─────────────
-const { fakeSupabase } = vi.hoisted(() => {
-  interface Row { id: string; [k: string]: unknown }
-
-  class FakeSupabase {
-    calls: Array<{
-      op: 'upsert' | 'update' | 'select'
-      table: string
-      filters: Record<string, unknown>
-      data?: unknown
-    }> = []
-
-    reset() { this.calls = [] }
-
-    from(table: string) { return new FakeBuilder(this, table) }
-
-    upsertsFor(table: string) {
-      return this.calls.filter(c => c.op === 'upsert' && c.table === table)
-    }
-
-    updatesFor(table: string) {
-      return this.calls.filter(c => c.op === 'update' && c.table === table)
-    }
-  }
-
-  class FakeBuilder implements PromiseLike<{ data: Row[]; error: null }> {
-    private _op: 'upsert' | 'update' | 'select' = 'select'
-    private _filters: Record<string, unknown> = {}
-    private _data: unknown = null
-
-    constructor(private _parent: FakeSupabase, private _table: string) {}
-
-    select(_cols: string) { this._op = 'select'; return this }
-    upsert(data: unknown) { this._op = 'upsert'; this._data = data; return this }
-    update(data: unknown) { this._op = 'update'; this._data = data; return this }
-    eq(col: string, val: unknown) { this._filters[col] = val; return this }
-    is(col: string, val: null | boolean) { this._filters[col] = val; return this }
-    order(_col: string) { return this }
-
-    then<T1 = { data: Row[]; error: null }, T2 = never>(
-      onfulfilled?: (v: { data: Row[]; error: null }) => T1 | PromiseLike<T1>,
-      _onrejected?: (r: unknown) => T2 | PromiseLike<T2>,
-    ): PromiseLike<T1 | T2> {
-      this._parent.calls.push({
-        op: this._op, table: this._table,
-        filters: { ...this._filters }, data: this._data,
-      })
-      return Promise.resolve({ data: [] as Row[], error: null as const }).then(onfulfilled)
-    }
-  }
-
-  return { fakeSupabase: new FakeSupabase() }
+// ── Shared Supabase test double (LIFT-1009) ────────────────────
+// One configurable fake, imported via async vi.hoisted so the vi.mock factory
+// below can reference the same instance the tests seed/assert against.
+const { fakeSupabase } = await vi.hoisted(async () => {
+  const { createFakeSupabase } = await import('./fakeSupabase')
+  return { fakeSupabase: createFakeSupabase({ mode: 'ok' }) }
 })
 
-// Wire FakeSupabase as the supabase module export
+// Wire the shared fake as the supabase module export
 vi.mock('../lib/supabase', () => ({
   supabase: fakeSupabase,
   isPreviewMode: { value: false },

--- a/src/stores/__tests__/supabaseApiError.test.ts
+++ b/src/stores/__tests__/supabaseApiError.test.ts
@@ -16,26 +16,18 @@ import { getLocalStorageMock } from '../../__tests__/helpers'
 
 const localStorageMock = getLocalStorageMock()
 
-// ── Supabase mock: resolves with error object (no throw) ────────────
-vi.mock('../../lib/supabase', () => {
-  function errorChain(): Record<string, unknown> {
-    const result = { data: null, error: { message: 'permission denied for table exercises', code: '42501' } }
-    const chain: Record<string, unknown> = {
-      select: () => chain,
-      eq: () => chain,
-      is: () => chain,
-      order: () => chain,
-      single: () => chain,
-      then: (resolve: (val: typeof result) => void) => Promise.resolve(result).then(resolve),
-    }
-    return chain
-  }
-
-  return {
-    supabase: { from: () => errorChain() },
-    isPreviewMode: { value: false },
-  }
+// ── Shared Supabase test double (LIFT-1009), apiError mode ──────────
+// Every query resolves { data: null, error } (a non-throwing RLS/API error),
+// matching what the real supabase-js client does for 500s/RLS denials.
+const { fakeSupabase } = await vi.hoisted(async () => {
+  const { createFakeSupabase } = await import('../../__tests__/fakeSupabase')
+  return { fakeSupabase: createFakeSupabase({ mode: 'apiError' }) }
 })
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: fakeSupabase,
+  isPreviewMode: { value: false },
+}))
 
 vi.mock('../../lib/syncQueue', () => ({
   syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },

--- a/src/stores/__tests__/supabaseFetchResilience.test.ts
+++ b/src/stores/__tests__/supabaseFetchResilience.test.ts
@@ -11,28 +11,18 @@ import { getLocalStorageMock } from '../../__tests__/helpers'
 
 const localStorageMock = getLocalStorageMock()
 
-// ── Supabase mock: rejects all queries ──────────────────────────────
-vi.mock('../../lib/supabase', () => {
-  function rejectingChain(): Record<string, unknown> {
-    const chain: Record<string, unknown> = {
-      select: () => chain,
-      eq: () => chain,
-      is: () => chain,
-      order: () => chain,
-      single: () => chain,
-      then: (_resolve: unknown, reject: (err: Error) => void) => {
-        const err = new Error('Network request failed')
-        return Promise.reject(err).catch(reject || ((e: unknown) => { throw e }))
-      },
-    }
-    return chain
-  }
-
-  return {
-    supabase: { from: () => rejectingChain() },
-    isPreviewMode: { value: false },
-  }
+// ── Shared Supabase test double (LIFT-1009), reject mode ─────────────
+// Every query rejects (offline / auth expired / DNS failure). Stores must
+// preserve locally-cached data rather than replacing it with empty state.
+const { fakeSupabase } = await vi.hoisted(async () => {
+  const { createFakeSupabase } = await import('../../__tests__/fakeSupabase')
+  return { fakeSupabase: createFakeSupabase({ mode: 'reject' }) }
 })
+
+vi.mock('../../lib/supabase', () => ({
+  supabase: fakeSupabase,
+  isPreviewMode: { value: false },
+}))
 
 vi.mock('../../lib/syncQueue', () => ({
   syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn() },

--- a/src/stores/__tests__/syncFuzz.test.ts
+++ b/src/stores/__tests__/syncFuzz.test.ts
@@ -18,120 +18,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 
-// ── Fake Supabase client ─────────────────────────────────────────
-// Chainable, thenable, in-memory. Records every call for assertions.
-// Defined inside vi.hoisted so it's available to the vi.mock factory
-// below (which runs before imports).
-
-const { fakeSupabase } = vi.hoisted(() => {
-  interface Row { id: string; [k: string]: unknown }
-
-  class FakeSupabase {
-    tables: Record<string, Row[]> = {
-      exercises: [],
-      sets: [],
-      bodyweight_entries: [],
-    }
-    calls: Array<{
-      op: 'select' | 'delete' | 'upsert' | 'update'
-      table: string
-      filters: Record<string, unknown>
-      data?: unknown
-    }> = []
-
-    reset() {
-      this.tables = { exercises: [], sets: [], bodyweight_entries: [] }
-      this.calls = []
-    }
-
-    seed(table: string, rows: Row[]) {
-      this.tables[table] = rows.map(r => ({ ...r }))
-    }
-
-    from(table: string) {
-      return new FakeBuilder(this, table)
-    }
-
-    deletesFor(table: string) {
-      return this.calls.filter(c => c.op === 'delete' && c.table === table)
-    }
-
-    upsertsFor(table: string) {
-      return this.calls.filter(c => c.op === 'upsert' && c.table === table)
-    }
-
-    updatesFor(table: string) {
-      return this.calls.filter(c => c.op === 'update' && c.table === table)
-    }
-
-    _exec(
-      op: FakeSupabase['calls'][number]['op'],
-      table: string,
-      filters: Record<string, unknown>,
-      data?: unknown,
-    ): Row[] {
-      this.calls.push({ op, table, filters: { ...filters }, data })
-      const rows = this.tables[table] || (this.tables[table] = [])
-      const matches = rows.filter(r =>
-        Object.entries(filters).every(([k, v]) => {
-          // .is(col, null) sentinel: match NULL or missing
-          if (v !== null && typeof v === 'object' && v !== undefined && '__is' in v) {
-            const target = (v as { __is: unknown }).__is
-            if (target === null) return r[k] == null
-            return r[k] === target
-          }
-          return r[k] === v
-        }),
-      )
-
-      if (op === 'select') return matches
-      if (op === 'delete') {
-        const ids = new Set(matches.map(r => r.id))
-        this.tables[table] = rows.filter(r => !ids.has(r.id))
-        return matches
-      }
-      if (op === 'upsert') {
-        const records = Array.isArray(data) ? data : [data as Row]
-        for (const rec of records) {
-          const idx = rows.findIndex(r => r.id === rec.id)
-          if (idx >= 0) rows[idx] = { ...rows[idx], ...rec }
-          else rows.push({ ...rec })
-        }
-        return records
-      }
-      if (op === 'update') {
-        for (const m of matches) Object.assign(m, data as Row)
-        return matches
-      }
-      return []
-    }
-  }
-
-  class FakeBuilder implements PromiseLike<{ data: Row[]; error: null }> {
-    private _op: 'select' | 'delete' | 'upsert' | 'update' = 'select'
-    private _filters: Record<string, unknown> = {}
-    private _data: unknown = null
-
-    constructor(private _parent: FakeSupabase, private _table: string) {}
-
-    select(_cols: string) { this._op = 'select'; return this }
-    delete() { this._op = 'delete'; return this }
-    upsert(data: unknown) { this._op = 'upsert'; this._data = data; return this }
-    update(data: unknown) { this._op = 'update'; this._data = data; return this }
-    eq(col: string, val: unknown) { this._filters[col] = val; return this }
-    is(col: string, val: null | boolean) { this._filters[col] = { __is: val }; return this }
-    order(_col: string) { return this }
-
-    then<TResult1 = { data: Row[]; error: null }, TResult2 = never>(
-      onfulfilled?: (v: { data: Row[]; error: null }) => TResult1 | PromiseLike<TResult1>,
-      _onrejected?: (r: unknown) => TResult2 | PromiseLike<TResult2>,
-    ): PromiseLike<TResult1 | TResult2> {
-      const data = this._parent._exec(this._op, this._table, this._filters, this._data)
-      return Promise.resolve({ data, error: null as const }).then(onfulfilled)
-    }
-  }
-
-  return { fakeSupabase: new FakeSupabase() }
+// ── Shared Supabase test double (LIFT-1009) ──────────────────────
+// Chainable, thenable, in-memory. Records every call for assertions and mutates
+// seeded rows like a real backend. Imported via async vi.hoisted so the vi.mock
+// factory below can reference the same instance the tests seed/assert against.
+const { fakeSupabase } = await vi.hoisted(async () => {
+  const { createFakeSupabase } = await import('../../__tests__/fakeSupabase')
+  return { fakeSupabase: createFakeSupabase({ mode: 'ok' }) }
 })
 
 // Override the global setup.ts mock (supabase: null) with our fake


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1009](https://github.com/aschung212/Lift/issues/1009)

Implement **LIFT-1009** — extract one shared, configurable Supabase test double so the four sync test files stop each hand-rolling a divergent PostgREST fake (mock-drift risk for a local-first sync app). Migrate all four onto it and add a contract check that ties the fake's surface to the stores' real query usage.

## Changes
- **`src/__tests__/fakeSupabase.ts`** (new) — `createFakeSupabase({ mode })` single source of truth for the client contract in tests. Modes: `'ok'` (in-memory tables + call recording + `.is()` NULL-sentinel matching, a superset of the fuzz/integration fakes), `'reject'` (every query rejects), `'apiError'` (resolves `{ data: null, error }`). Full chain surface — `from/select/upsert/update/delete/eq/is/order/single/then` — in one place. Behavior is a constructor option, not a copy-pasted chain.
- **`src/__tests__/fakeSupabase.contract.test.ts`** (new) — scans the store source (`workout/bodyweight/progression/preferences.ts`) for every method invoked on the supabase chain and asserts the fake supports each, so a store adopting a new verb (e.g. `.limit()`) fails the contract until the fake grows to match. Plus per-mode behavioral checks and a vacuous-scan guard.
- Migrated **`syncPipelineIntegration.test.ts`**, **`syncFuzz.test.ts`**, **`supabaseApiError.test.ts`**, **`supabaseFetchResilience.test.ts`** onto the shared double via async `vi.hoisted` (keeps the same instance the vi.mock factory and the tests share). Removed ~200 lines of copy-pasted fake code.

## Verification
- `npm run lint` — clean
- `npm run build` — typecheck + Vite build pass
- Full suite: **2894 passed | 1 skipped** (was 2886 + a reported error before; the 8 new contract tests land and the prior error is gone)
- Post-commit adversarial review: `REVIEW_CLEAN` / `MERGE`

## Screenshots
N/A — test-infrastructure change only, no UI surface touched.

## Commits
- [`2dbc6d8`](https://github.com/aschung212/Lift/commit/2dbc6d8) test(LIFT-1009): extract one shared, configurable Supabase test double

## Test Results
- Before: 2886 passing
- After: 2894 passing (8 delta)

---
_Automated by overnight pipeline — Wed Jul 22 23:41:08 PDT 2026_

## Preview
Test on your phone: https://lift-qwz6vmzwe-aschung212-1101s-projects.vercel.app