### PR TITLE
test(LIFT-1010): drive sync pipeline through the real syncQueue end-to-end

### DIFF
--- a/src/__tests__/syncPipelineIntegration.test.ts
+++ b/src/__tests__/syncPipelineIntegration.test.ts
@@ -1,14 +1,25 @@
 /**
- * Sync Pipeline Integration Tests (LIFT-654)
+ * Sync Pipeline Integration Tests (LIFT-654 / LIFT-1010)
  *
  * Verifies the connected pipeline: logSet → store mutation → localStorage
  * persist → syncQueue enqueue → Supabase upsert payload shape. Also covers
  * deleteSet → tombstone → enqueueDelete → soft-delete payload.
  *
- * Existing coverage gap: workout.test.ts mocks syncQueue entirely,
- * syncFuzz.test.ts focuses on the READ path. This test is the first to
- * verify that store WRITE actions produce correct Supabase payloads
- * through the real enqueue wiring.
+ * LIFT-1010: earlier this file replaced `lib/syncQueue` with a synchronous
+ * invoke stub, so it verified the store→payload shape but bypassed the actual
+ * debounce, rate limiter, and circuit breaker the architecture calls out as
+ * core behavior — the exact places batching bugs and duplicate-write
+ * regressions hide. Those mechanisms lived only in isolated unit tests
+ * (syncQueue.test.ts), so nothing exercised store mutations flowing through the
+ * REAL queue's timing and backpressure.
+ *
+ * This suite now drives the store through the real singleton `syncQueue`
+ * (1s debounce) against an in-memory Supabase fake, advancing the debounce
+ * window with fake timers (LIFT-895). The payload-shape assertions are kept;
+ * the enqueue stub is gone. New blocks assert that rapid mutations are
+ * debounced/batched into a single flush, same-key writes dedupe last-write-wins,
+ * the rate limiter defers overflow into the next window, and the delete circuit
+ * breaker trips against a delete storm.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -75,39 +86,38 @@ vi.mock('../lib/supabase', () => ({
   isPreviewMode: { value: false },
 }))
 
-// Synchronous syncQueue — invoke ops immediately so we can assert payloads
-vi.mock('../lib/syncQueue', () => {
-  const invoke = (_key: string, op: () => PromiseLike<unknown>) => {
-    Promise.resolve(op()).catch(() => {})
-  }
-  return {
-    syncQueue: {
-      enqueue: vi.fn(invoke),
-      enqueueDelete: vi.fn(invoke),
-      clear: vi.fn(),
-    },
-    syncStatus: { value: 'synced' as const },
-    _resetRateLimit: vi.fn(),
-    _resetCircuitBreaker: vi.fn(),
-  }
-})
+// The real syncQueue journals descriptors to IndexedDB, which isn't available
+// in happy-dom and isn't the subject under test here — stub it so the queue's
+// timing/backpressure logic runs unchanged while its durable side effects are
+// inert. (crossTabSync is left real: BroadcastChannel is safe under happy-dom
+// and both the queue and the store depend on several of its exports.) (LIFT-1010)
+vi.mock('../lib/durableStorage', () => ({
+  backupToIDB: vi.fn(),
+  restoreFromIDB: vi.fn(() => Promise.resolve(null)),
+}))
 
 vi.mock('../lib/logger', () => ({
   logError: vi.fn(), logWarn: vi.fn(), logInfo: vi.fn(),
 }))
 
-// Imports after mocks
+// Imports after mocks — NOTE: syncQueue is the REAL module now (LIFT-1010).
 import { useWorkoutStore } from '../stores/workout'
-import { syncQueue } from '../lib/syncQueue'
+import {
+  syncQueue,
+  syncStatus,
+  _resetRateLimit,
+  _resetCircuitBreaker,
+  _getCircuitBreakerState,
+} from '../lib/syncQueue'
 import { isTombstoned, _resetTombstones } from '../lib/tombstones'
 
 const localStorageMock = getLocalStorageMock()
-// Flush pending timers + the microtask chains kicked off by the synchronous
-// syncQueue mock. Driven by fake timers (not a real setTimeout) so tests don't
-// burn wall-clock time or flake under CI load (LIFT-895).
+// Flush pending timers + the microtask chains the real queue kicks off. Driven
+// by fake timers (not a real setTimeout) so tests don't burn wall-clock time or
+// flake under CI load (LIFT-895).
 const tick = () => vi.runAllTimersAsync()
 
-describe('Sync Pipeline Integration (LIFT-654)', () => {
+describe('Sync Pipeline Integration (LIFT-654 / LIFT-1010)', () => {
   const TEST_USER = 'user-integration-test'
 
   beforeEach(() => {
@@ -115,15 +125,26 @@ describe('Sync Pipeline Integration (LIFT-654)', () => {
     localStorageMock.clear()
     fakeSupabase.reset()
     _resetTombstones()
+    // Reset the shared singleton queue + its module-scope backpressure state so
+    // no timing/rate/breaker state leaks between tests (LIFT-1010).
+    syncQueue.clear()
+    _resetRateLimit()
+    _resetCircuitBreaker()
+    syncStatus.value = 'synced'
     vi.clearAllMocks()
+    // Spy on the real enqueue methods, calling through — preserves the
+    // "was called with this key" assertions without stubbing out the queue.
+    vi.spyOn(syncQueue, 'enqueue')
+    vi.spyOn(syncQueue, 'enqueueDelete')
     setActivePinia(createPinia())
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 
-  // ── logSet → syncQueue.enqueue → Supabase upsert ──────────────
+  // ── logSet → real syncQueue debounce → Supabase upsert ─────────
   describe('logSet pipeline', () => {
     it('persists to localStorage and enqueues an upsert with correct payload', async () => {
       const store = useWorkoutStore()
@@ -149,7 +170,7 @@ describe('Sync Pipeline Integration (LIFT-654)', () => {
       expect(storedExercise.sets).toHaveLength(1)
       expect(storedExercise.sets[0].weight).toBe(225)
 
-      // 3. syncQueue.enqueue was called
+      // 3. syncQueue.enqueue was called (real method, spied)
       expect(syncQueue.enqueue).toHaveBeenCalledOnce()
       const enqueueKey = (syncQueue.enqueue as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(enqueueKey).toBe(`set:${set.id}`)
@@ -170,9 +191,33 @@ describe('Sync Pipeline Integration (LIFT-654)', () => {
       expect(payload).toHaveProperty('estimated_1rm')
       expect(payload).not.toHaveProperty('estimated1RM')
     })
+
+    it('holds the upsert until the debounce window elapses (real queue timing)', async () => {
+      const store = useWorkoutStore()
+      await store.init(TEST_USER)
+      const exerciseId = store.addExercise('Bench Press', ['Push'])!
+      await tick() // drain the exercise-creation upsert
+      fakeSupabase.reset()
+      vi.clearAllMocks()
+
+      store.logSet(exerciseId, 135, 8)
+
+      // Enqueued, but the 1s debounce means nothing has hit Supabase yet.
+      expect(syncQueue.pending).toBe(1)
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(0)
+
+      // Just short of the window — still pending.
+      await vi.advanceTimersByTimeAsync(999)
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(0)
+
+      // Crossing the window flushes it.
+      await vi.advanceTimersByTimeAsync(1)
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(1)
+      expect(syncQueue.pending).toBe(0)
+    })
   })
 
-  // ── deleteSet → tombstone → syncQueue.enqueueDelete → soft-delete ─
+  // ── deleteSet → tombstone → real enqueueDelete → soft-delete ─────
   describe('deleteSet pipeline', () => {
     it('creates tombstone and enqueues a soft-delete update', async () => {
       const store = useWorkoutStore()
@@ -199,7 +244,7 @@ describe('Sync Pipeline Integration (LIFT-654)', () => {
       const storedExercise = stored.find((e: { id: string }) => e.id === exerciseId)
       expect(storedExercise.sets).toHaveLength(0)
 
-      // 4. syncQueue.enqueueDelete was called
+      // 4. syncQueue.enqueueDelete was called (real method, spied)
       expect(syncQueue.enqueueDelete).toHaveBeenCalledOnce()
       const deleteKey = (syncQueue.enqueueDelete as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(deleteKey).toBe(`set:${setId}`)
@@ -215,6 +260,131 @@ describe('Sync Pipeline Integration (LIFT-654)', () => {
         id: setId,
         user_id: TEST_USER,
       })
+    })
+  })
+
+  // ── debounce/batching: rapid mutations coalesce into one flush ───
+  describe('debounce & batching', () => {
+    it('coalesces rapid successive logSets into a single flush batch', async () => {
+      const store = useWorkoutStore()
+      await store.init(TEST_USER)
+      const exerciseId = store.addExercise('Bench Press', ['Push'])!
+      await tick() // drain the exercise-creation upsert
+      fakeSupabase.reset()
+      vi.clearAllMocks()
+      const flushSpy = vi.spyOn(syncQueue, 'flush')
+
+      // Three sets logged within the debounce window, each resetting the timer.
+      store.logSet(exerciseId, 100, 5)
+      await vi.advanceTimersByTimeAsync(400)
+      store.logSet(exerciseId, 105, 5)
+      await vi.advanceTimersByTimeAsync(400)
+      store.logSet(exerciseId, 110, 5)
+
+      // Debounced: three distinct set:* keys queued, nothing flushed yet.
+      expect(syncQueue.pending).toBe(3)
+      expect(flushSpy).not.toHaveBeenCalled()
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(0)
+
+      await tick()
+
+      // A single flush drained all three into one Supabase batch.
+      expect(flushSpy).toHaveBeenCalledTimes(1)
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(3)
+      expect(syncQueue.pending).toBe(0)
+    })
+
+    it('dedupes same-key writes to a single last-write-wins upsert', async () => {
+      const store = useWorkoutStore()
+      await store.init(TEST_USER)
+      const exerciseId = store.addExercise('Bench Press', ['Push'])!
+      store.logSet(exerciseId, 135, 5)
+      await tick()
+      const setId = store.exercises.find(e => e.id === exerciseId)!.sets[0].id
+      fakeSupabase.reset()
+      vi.clearAllMocks()
+
+      // Two edits to the SAME set before the window elapses share key set:<id>.
+      store.updateSet(exerciseId, setId, 150, 6)
+      store.updateSet(exerciseId, setId, 200, 8)
+
+      // Deduped in the queue — one pending op, not two.
+      expect(syncQueue.pending).toBe(1)
+
+      await tick()
+
+      const upserts = fakeSupabase.upsertsFor('sets')
+      expect(upserts).toHaveLength(1)
+      const payload = upserts[0].data as Record<string, unknown>
+      // Last write wins: the final edit's values, not the first.
+      expect(payload).toMatchObject({ id: setId, weight: 200, reps: 8 })
+    })
+  })
+
+  // ── rate limiter: overflow defers into the next window ───────────
+  describe('rate limiting', () => {
+    it('defers operations past the per-window cap, then releases them', async () => {
+      const OVER_LIMIT = 201 // RATE_LIMIT_MAX is 200
+      const makeUpsert = (i: number) => () =>
+        fakeSupabase.from('sets').upsert({
+          id: `rl-${i}`, user_id: TEST_USER, exercise_id: 'x',
+          date: '2026-07-22T23:59:00Z', weight: 100, reps: 5, estimated_1rm: 100,
+        })
+
+      for (let i = 0; i < OVER_LIMIT; i++) {
+        syncQueue.enqueue(`set:rl-${i}`, makeUpsert(i))
+      }
+
+      // 200 admitted to the live queue, the 201st held in the deferred bucket.
+      expect(syncQueue.pending).toBe(OVER_LIMIT)
+
+      // Flush the admitted batch — the deferred op is still held back.
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(200)
+      expect(syncQueue.pending).toBe(1)
+
+      // The rate window resets after 60s, releasing the deferred op.
+      await vi.advanceTimersByTimeAsync(60_000)
+      await tick()
+      expect(fakeSupabase.upsertsFor('sets')).toHaveLength(OVER_LIMIT)
+      expect(syncQueue.pending).toBe(0)
+    })
+  })
+
+  // ── circuit breaker: a delete storm trips the SEV1 guard ─────────
+  describe('delete circuit breaker', () => {
+    it('trips after a burst of distinct-key deletes and blocks the overflow', async () => {
+      const store = useWorkoutStore()
+      await store.init(TEST_USER)
+      const exerciseId = store.addExercise('Squat', ['Legs'])!
+      // Log 21 sets so we can drive 21 distinct-key soft-deletes.
+      for (let i = 0; i < 21; i++) store.logSet(exerciseId, 100 + i, 5)
+      await tick()
+      const setIds = store.exercises.find(e => e.id === exerciseId)!.sets.map(s => s.id)
+      fakeSupabase.reset()
+      vi.clearAllMocks()
+      syncStatus.value = 'synced'
+
+      // CIRCUIT_BREAKER_THRESHOLD is 20 within a 10s window: the first 20
+      // deletes are admitted, the 21st trips the breaker and is blocked.
+      for (const setId of setIds) store.deleteSet(exerciseId, setId)
+
+      // Assert the trip BEFORE the debounce flush fires — the breaker flips the
+      // status to 'error' synchronously on the 21st delete, but the subsequent
+      // successful flush of the 20 admitted deletes resets it back to 'synced'.
+      const state = _getCircuitBreakerState()
+      expect(state.tripCount).toBe(1)
+      expect(state.openUntil).toBeGreaterThan(0)
+      expect(syncStatus.value).toBe('error')
+
+      await tick()
+
+      // 20 soft-deletes reached Supabase; the blocked one never enqueued.
+      expect(fakeSupabase.updatesFor('sets')).toHaveLength(20)
+
+      // Local-first: every set is still removed from the store regardless of the
+      // breaker — only the server sync of the overflow delete is suppressed.
+      expect(store.exercises.find(e => e.id === exerciseId)!.sets).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1010](https://github.com/aschung212/Lift/issues/1010)

Implement **LIFT-1010** — the sync "integration" test (`syncPipelineIntegration.test.ts`) replaced `lib/syncQueue` with a synchronous invoke stub, so it verified store→payload shape but bypassed the real debounce, rate limiter, and circuit breaker. I removed the stub and drove the store through the **real** singleton `syncQueue` against the in-memory Supabase fake, advancing the 1s debounce with fake timers.

## Changes
- `src/__tests__/syncPipelineIntegration.test.ts`
  - Deleted the `vi.mock('../lib/syncQueue', …)` synchronous stub; the store now enqueues into the real singleton queue.
  - Stubbed `durableStorage` (no IndexedDB in happy-dom); left `crossTabSync` real (BroadcastChannel is safe; both the queue and store depend on it).
  - `beforeEach` resets the shared singleton + rate-limit + circuit-breaker module state and spies (call-through) on the real `enqueue`/`enqueueDelete` to preserve key assertions.
  - Kept existing payload-shape + gating tests (now genuinely end-to-end); added: debounce timing hold, rapid-mutation batching into a single flush, same-key last-write-wins dedup, rate-limit overflow deferral/release, and a 21-delete circuit-breaker trip.

## Verification
- `npx vitest run src/__tests__/syncPipelineIntegration.test.ts` → 8/8 pass
- `npm test` → 2891 passed | 1 skipped (was 2886; +5)
- `npm run lint` → clean
- `npm run build` → success
- Post-commit adversarial review → REVIEW_CLEAN / MERGE

## Discovery
ISSUE_DISCOVER: `syncPipelineIntegration.test.ts` and `syncQueue.test.ts` each hand-roll their own in-memory Supabase fake (the file-local `FakeSupabase` here vs. `syncQueue.test.ts`'s op mocks), which is exactly the mock-drift problem LIFT-1009 (run3, unmerged) set out to solve with a shared fake. Once LIFT-1009's shared, contract-checked Supabase fake lands on master, this file's local `FakeSupabase` class should be migrated onto it so the queue-level batching assertions run against the same double as the store-level ones.

## Commits
- [`192c52c`](https://github.com/aschung212/Lift/commit/192c52c) test(LIFT-1010): drive sync pipeline through the real syncQueue end-to-end

## Test Results
- Before: 2886 passing
- After: 2891 passing (5 delta)

---
_Automated by overnight pipeline — Thu Jul 23 00:03:30 PDT 2026_

## Preview
Test on your phone: https://lift-qn9dhv8g8-aschung212-1101s-projects.vercel.app