### PR TITLE
refactor(LIFT-1012): consolidate static-config guardrail tests behind one shared fixture

### DIFF
--- a/src/lib/__tests__/launchScreens.test.ts
+++ b/src/lib/__tests__/launchScreens.test.ts
@@ -1,7 +1,6 @@
 /// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync, existsSync } from 'fs'
-import { resolve } from 'path'
+import { readRootFile, readIndexHtml, publicFileExists } from './staticArtifacts'
 // @ts-expect-error - plain JS generator script, no type declarations
 import { DEVICES } from '../../../scripts/generate-launch-screens.js'
 
@@ -16,9 +15,7 @@ import { DEVICES } from '../../../scripts/generate-launch-screens.js'
  * device list — so a future edit can't silently drop or mistype a launch image.
  */
 
-const root = resolve(__dirname, '../../..')
-const html = readFileSync(resolve(root, 'index.html'), 'utf-8')
-const publicDir = resolve(root, 'public')
+const html = readIndexHtml()
 
 interface StartupLink {
   media: string
@@ -45,8 +42,7 @@ describe('iOS launch screen (apple-touch-startup-image) regression tests', () =>
   it('every link href references a file that exists in public/launch/', () => {
     for (const { href } of links) {
       expect(href.startsWith('/launch/')).toBe(true)
-      const filePath = resolve(publicDir, href.replace(/^\//, ''))
-      expect(existsSync(filePath), `${href} missing on disk`).toBe(true)
+      expect(publicFileExists(href.replace(/^\//, '')), `${href} missing on disk`).toBe(true)
     }
   })
 
@@ -77,7 +73,7 @@ describe('iOS launch screen (apple-touch-startup-image) regression tests', () =>
   })
 
   it('excludes launch screens from the Workbox precache (loaded by Safari, not the app)', () => {
-    const viteConfig = readFileSync(resolve(root, 'vite.config.js'), 'utf-8')
+    const viteConfig = readRootFile('vite.config.js')
     expect(viteConfig).toContain("'launch/*.png'")
   })
 })

--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -1,7 +1,6 @@
 /// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync, existsSync } from 'fs'
-import { resolve } from 'path'
+import { readRootFile, publicFileExists } from './staticArtifacts'
 
 /**
  * Regression tests for PWA manifest configuration.
@@ -9,10 +8,13 @@ import { resolve } from 'path'
  * Validates that the vite.config.js manifest includes required fields
  * for a richer PWA install experience (screenshots, categories) and
  * that referenced screenshot assets exist in public/.
+ *
+ * Reads route through the shared ./staticArtifacts fixture (LIFT-1012) so the
+ * same vite.config.js / index.html artifacts are read (and cached) once across
+ * the guardrail suites instead of each file re-implementing the boilerplate.
  */
 
-const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), 'utf-8')
-const publicDir = resolve(__dirname, '../../../public')
+const viteConfig = readRootFile('vite.config.js')
 
 describe('PWA manifest regression tests', () => {
   describe('manifest includes explicit id for stable install identity', () => {
@@ -28,7 +30,7 @@ describe('PWA manifest regression tests', () => {
   })
 
   describe('manifest description aligns with meta description and leads with differentiators', () => {
-    const indexHtml = readFileSync(resolve(__dirname, '../../../index.html'), 'utf-8')
+    const indexHtml = readRootFile('index.html')
 
     it('uses the unified discoverability-focused description', () => {
       expect(viteConfig).toContain(
@@ -89,7 +91,7 @@ describe('PWA manifest regression tests', () => {
 
     it('shortcuts reference existing icon files', () => {
       // All shortcuts use icon-192.png
-      expect(existsSync(resolve(publicDir, 'icon-192.png'))).toBe(true)
+      expect(publicFileExists('icon-192.png')).toBe(true)
     })
   })
 
@@ -103,7 +105,7 @@ describe('PWA manifest regression tests', () => {
     })
 
     it('offline.html exists in public/', () => {
-      expect(existsSync(resolve(publicDir, 'offline.html'))).toBe(true)
+      expect(publicFileExists('offline.html')).toBe(true)
     })
   })
 
@@ -125,15 +127,15 @@ describe('PWA manifest regression tests', () => {
     })
 
     it('mobile screenshot file exists in public/', () => {
-      expect(existsSync(resolve(publicDir, 'screenshot-mobile.png'))).toBe(true)
+      expect(publicFileExists('screenshot-mobile.png')).toBe(true)
     })
 
     it('detail screenshot file exists in public/', () => {
-      expect(existsSync(resolve(publicDir, 'screenshot-detail.png'))).toBe(true)
+      expect(publicFileExists('screenshot-detail.png')).toBe(true)
     })
 
     it('calendar screenshot file exists in public/', () => {
-      expect(existsSync(resolve(publicDir, 'screenshot-calendar.png'))).toBe(true)
+      expect(publicFileExists('screenshot-calendar.png')).toBe(true)
     })
   })
 

--- a/src/lib/__tests__/metaRegression.test.ts
+++ b/src/lib/__tests__/metaRegression.test.ts
@@ -1,9 +1,8 @@
 /// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { DEPLOYMENT_DOMAIN, readIndexHtml, expectNoUnownedDomains } from './staticArtifacts'
 
-const html = readFileSync(resolve(__dirname, '../../../index.html'), 'utf-8')
+const html = readIndexHtml()
 
 /**
  * Regression tests for index.html meta tags.
@@ -13,9 +12,11 @@ const html = readFileSync(resolve(__dirname, '../../../index.html'), 'utf-8')
  * URL. This reached production because no test, CI check, or code review layer
  * verified URLs against the known deployment domain. Every URL in index.html
  * that references our domain must point to the real deployment.
+ *
+ * The deployment domain and the unowned-domain deny list come from the shared
+ * ./staticArtifacts fixture (LIFT-1012) so this suite can no longer drift from
+ * the SEO/manifest guards that pin the same values.
  */
-
-const DEPLOYMENT_DOMAIN = 'spa-rho-sandy.vercel.app'
 
 describe('index.html meta tag regression tests', () => {
   describe('canonical and OG URLs point to actual deployment', () => {
@@ -65,8 +66,8 @@ describe('index.html meta tag regression tests', () => {
   })
 
   describe('no references to domains we do not own', () => {
-    it('does not reference liftracker.app (competitor domain)', () => {
-      expect(html).not.toContain('liftracker.app')
+    it('does not reference any domain we do not own', () => {
+      expectNoUnownedDomains(html)
     })
 
     it('all absolute URLs in meta tags use HTTPS', () => {

--- a/src/lib/__tests__/seoRegression.test.ts
+++ b/src/lib/__tests__/seoRegression.test.ts
@@ -1,35 +1,37 @@
 /// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync, existsSync } from 'fs'
-import { resolve } from 'path'
+import {
+  DEPLOYMENT_DOMAIN,
+  readPublicFile,
+  publicFileExists,
+  expectNoUnownedDomains,
+} from './staticArtifacts'
 
 /**
- * Regression tests for SEO files: robots.txt and sitemap.xml.
+ * Regression tests for the STRUCTURE of the SEO files: robots.txt and
+ * sitemap.xml. These files live in public/ and are served at the root.
  *
- * These files live in public/ and are served at the root. The sitemap URL
- * in robots.txt and the <loc> in sitemap.xml must reference the real
- * deployment domain — not a hallucinated or competitor domain.
+ * Scope split (LIFT-1012): this suite owns structural validity + the
+ * no-unowned-domain safety net; the exact canonical values (the literal
+ * Sitemap: line and root <loc>) are pinned once in seoStaticFiles.test.ts.
+ * Both share one cached reader and one domain source (./staticArtifacts) so
+ * the two suites can no longer drift apart.
  */
-
-const publicDir = resolve(__dirname, '../../../public')
-const DEPLOYMENT_DOMAIN = 'spa-rho-sandy.vercel.app'
 
 describe('SEO file regression tests', () => {
   describe('robots.txt', () => {
-    const robotsPath = resolve(publicDir, 'robots.txt')
-
     it('exists in public/', () => {
-      expect(existsSync(robotsPath)).toBe(true)
+      expect(publicFileExists('robots.txt')).toBe(true)
     })
 
     it('allows all user agents', () => {
-      const content = readFileSync(robotsPath, 'utf-8')
+      const content = readPublicFile('robots.txt')
       expect(content).toContain('User-agent: *')
       expect(content).toContain('Allow: /')
     })
 
     it('references sitemap with the real deployment domain', () => {
-      const content = readFileSync(robotsPath, 'utf-8')
+      const content = readPublicFile('robots.txt')
       const sitemapLine = content.match(/Sitemap:\s*(\S+)/)
       expect(sitemapLine).not.toBeNull()
       expect(sitemapLine![1]).toContain(DEPLOYMENT_DOMAIN)
@@ -37,34 +39,31 @@ describe('SEO file regression tests', () => {
       expect(sitemapLine![1]).toContain('sitemap.xml')
     })
 
-    it('does not reference liftracker.app (competitor domain)', () => {
-      const content = readFileSync(robotsPath, 'utf-8')
-      expect(content).not.toContain('liftracker.app')
+    it('does not reference any domain we do not own', () => {
+      expectNoUnownedDomains(readPublicFile('robots.txt'))
     })
   })
 
   describe('sitemap.xml', () => {
-    const sitemapPath = resolve(publicDir, 'sitemap.xml')
-
     it('exists in public/', () => {
-      expect(existsSync(sitemapPath)).toBe(true)
+      expect(publicFileExists('sitemap.xml')).toBe(true)
     })
 
     it('is valid XML with urlset namespace', () => {
-      const content = readFileSync(sitemapPath, 'utf-8')
+      const content = readPublicFile('sitemap.xml')
       expect(content).toContain('<?xml version="1.0"')
       expect(content).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"')
     })
 
     it('contains at least one <loc> entry', () => {
-      const content = readFileSync(sitemapPath, 'utf-8')
+      const content = readPublicFile('sitemap.xml')
       const locs = content.match(/<loc>[^<]+<\/loc>/g)
       expect(locs).not.toBeNull()
       expect(locs!.length).toBeGreaterThanOrEqual(1)
     })
 
     it('all <loc> entries use the real deployment domain with HTTPS', () => {
-      const content = readFileSync(sitemapPath, 'utf-8')
+      const content = readPublicFile('sitemap.xml')
       const locs = content.match(/<loc>([^<]+)<\/loc>/g) || []
       for (const loc of locs) {
         const url = loc.replace(/<\/?loc>/g, '')
@@ -73,9 +72,8 @@ describe('SEO file regression tests', () => {
       }
     })
 
-    it('does not reference liftracker.app (competitor domain)', () => {
-      const content = readFileSync(sitemapPath, 'utf-8')
-      expect(content).not.toContain('liftracker.app')
+    it('does not reference any domain we do not own', () => {
+      expectNoUnownedDomains(readPublicFile('sitemap.xml'))
     })
   })
 })

--- a/src/lib/__tests__/seoStaticFiles.test.ts
+++ b/src/lib/__tests__/seoStaticFiles.test.ts
@@ -1,63 +1,24 @@
 /// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync, existsSync } from 'fs'
-import { resolve } from 'path'
+import { DEPLOYMENT_ORIGIN, readPublicFile } from './staticArtifacts'
 
-const DEPLOYMENT_DOMAIN = 'spa-rho-sandy.vercel.app'
-const publicDir = resolve(__dirname, '../../../public')
-
-describe('robots.txt', () => {
-  const robotsPath = resolve(publicDir, 'robots.txt')
-
-  it('exists in public directory', () => {
-    expect(existsSync(robotsPath)).toBe(true)
+/**
+ * Exact-value pins for the shipped SEO artifacts (robots.txt, sitemap.xml).
+ *
+ * Scope split (LIFT-1012): this suite owns ONLY the literal canonical strings
+ * that must appear verbatim. Structural validity (namespace, HTTPS-only,
+ * exists, no-unowned-domain) lives in seoRegression.test.ts so no assertion is
+ * duplicated across the two suites. Both read through the shared cached reader
+ * and derive the domain from ./staticArtifacts — the single source of truth.
+ */
+describe('SEO static-file canonical values', () => {
+  it('robots.txt declares the canonical sitemap URL verbatim', () => {
+    expect(readPublicFile('robots.txt')).toContain(
+      `Sitemap: ${DEPLOYMENT_ORIGIN}/sitemap.xml`
+    )
   })
 
-  it('allows all user agents', () => {
-    const content = readFileSync(robotsPath, 'utf-8')
-    expect(content).toContain('User-agent: *')
-    expect(content).toContain('Allow: /')
-  })
-
-  it('references sitemap.xml with real deployment domain', () => {
-    const content = readFileSync(robotsPath, 'utf-8')
-    expect(content).toContain(`Sitemap: https://${DEPLOYMENT_DOMAIN}/sitemap.xml`)
-  })
-
-  it('does not reference liftracker.app', () => {
-    const content = readFileSync(robotsPath, 'utf-8')
-    expect(content).not.toContain('liftracker.app')
-  })
-})
-
-describe('sitemap.xml', () => {
-  const sitemapPath = resolve(publicDir, 'sitemap.xml')
-
-  it('exists in public directory', () => {
-    expect(existsSync(sitemapPath)).toBe(true)
-  })
-
-  it('is valid XML with urlset namespace', () => {
-    const content = readFileSync(sitemapPath, 'utf-8')
-    expect(content).toContain('<?xml version="1.0"')
-    expect(content).toContain('xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"')
-  })
-
-  it('contains root URL with real deployment domain', () => {
-    const content = readFileSync(sitemapPath, 'utf-8')
-    expect(content).toContain(`<loc>https://${DEPLOYMENT_DOMAIN}/</loc>`)
-  })
-
-  it('does not reference liftracker.app', () => {
-    const content = readFileSync(sitemapPath, 'utf-8')
-    expect(content).not.toContain('liftracker.app')
-  })
-
-  it('all loc URLs use HTTPS', () => {
-    const content = readFileSync(sitemapPath, 'utf-8')
-    const locs = content.match(/<loc>(.*?)<\/loc>/g) ?? []
-    for (const loc of locs) {
-      expect(loc).toMatch(/https:\/\//)
-    }
+  it('sitemap.xml pins the root URL verbatim', () => {
+    expect(readPublicFile('sitemap.xml')).toContain(`<loc>${DEPLOYMENT_ORIGIN}/</loc>`)
   })
 })

--- a/src/lib/__tests__/staticArtifacts.ts
+++ b/src/lib/__tests__/staticArtifacts.ts
@@ -1,0 +1,67 @@
+/// <reference types="node" />
+/**
+ * Shared fixtures for static-artifact guardrail tests (LIFT-1012).
+ *
+ * Several regression suites (metaRegression, seoRegression, manifestRegression,
+ * launchScreens, …) each independently `readFileSync` the same build artifacts
+ * (index.html, public/robots.txt, public/sitemap.xml) and re-declare the same
+ * deployment-domain / competitor-domain literals. That duplication is the
+ * maintenance surface LIFT-1012 flags: an infra change forces edits across a
+ * wall of near-identical files. This module is the single reconciliation point —
+ * one cached read per artifact, one domain allow/deny list, one set of shared
+ * assertions.
+ *
+ * DEPLOYMENT_DOMAIN is deliberately an INDEPENDENT literal, NOT imported from
+ * src/lib/appMeta. The whole point of these guards is to pin the shipped URLs
+ * against a known-good value the app code cannot silently redefine — comparing
+ * against APP_URL would make the guard tautologically pass when APP_URL is
+ * itself corrupted (the exact SEV1 class from 2026-04-02, see CLAUDE.md).
+ */
+import { readFileSync, existsSync } from 'fs'
+import { resolve } from 'path'
+import { expect } from 'vitest'
+
+/** The one and only valid production deployment host. */
+export const DEPLOYMENT_DOMAIN = 'spa-rho-sandy.vercel.app'
+export const DEPLOYMENT_ORIGIN = `https://${DEPLOYMENT_DOMAIN}`
+
+/** Domains we do NOT own — must never appear in any shipped artifact. */
+export const UNOWNED_DOMAINS = ['liftracker.app'] as const
+
+const ROOT = resolve(__dirname, '../../..')
+export const PUBLIC_DIR = resolve(ROOT, 'public')
+
+const readCache = new Map<string, string>()
+
+function readCached(absPath: string): string {
+  let content = readCache.get(absPath)
+  if (content === undefined) {
+    content = readFileSync(absPath, 'utf-8')
+    readCache.set(absPath, content)
+  }
+  return content
+}
+
+/** Read a repo-root-relative file (e.g. 'index.html', 'vite.config.js'). */
+export function readRootFile(relPath: string): string {
+  return readCached(resolve(ROOT, relPath))
+}
+
+/** Read a public/-relative file (e.g. 'robots.txt', 'sitemap.xml'). */
+export function readPublicFile(relPath: string): string {
+  return readCached(resolve(PUBLIC_DIR, relPath))
+}
+
+/** Whether a public/-relative file exists on disk. */
+export function publicFileExists(relPath: string): boolean {
+  return existsSync(resolve(PUBLIC_DIR, relPath))
+}
+
+export const readIndexHtml = (): string => readRootFile('index.html')
+
+/** Assert `content` references none of the domains we do not own. */
+export function expectNoUnownedDomains(content: string): void {
+  for (const domain of UNOWNED_DOMAINS) {
+    expect(content, `must not reference unowned domain ${domain}`).not.toContain(domain)
+  }
+}

--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -7,8 +7,7 @@
  * test in the same PR as the policy change.
  */
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { readRootFile } from './staticArtifacts'
 
 interface HeaderRule {
   source: string
@@ -27,9 +26,7 @@ interface VercelConfig {
 }
 
 function loadVercelConfig(): VercelConfig {
-  const path = resolve(__dirname, '../../../vercel.json')
-  const raw = readFileSync(path, 'utf8')
-  return JSON.parse(raw) as VercelConfig
+  return JSON.parse(readRootFile('vercel.json')) as VercelConfig
 }
 
 function findGlobalHeaderRule(config: VercelConfig): HeaderRule {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1012](https://github.com/aschung212/Lift/issues/1012)

Implement **LIFT-1012** — the static-config guardrail suites in `src/lib/__tests__/` each hand-rolled the same artifact reads and re-declared the `DEPLOYMENT_DOMAIN` / competitor-domain literals, the exact duplicated maintenance surface the issue flags. I introduced one shared fixture as the single reconciliation point and de-duplicated the two overlapping SEO suites.

## Changes
- **New `src/lib/__tests__/staticArtifacts.ts`** — single source of truth: cached per-artifact readers (`readRootFile`, `readPublicFile`, `readIndexHtml`, `publicFileExists`), one `DEPLOYMENT_DOMAIN`/`DEPLOYMENT_ORIGIN` literal, the `UNOWNED_DOMAINS` deny list, and a shared `expectNoUnownedDomains()`. The domain stays an **independent literal** (not imported from `appMeta`) so the guard can't tautologically pass when the app constant is itself corrupted (the SEV1 class from 2026-04-02).
- **De-duplicated the two overlapping SEO suites** — `seoRegression` now owns structural validity + the no-unowned-domain net; `seoStaticFiles` owns only the exact canonical-string pins. No assertion is duplicated across them, and both read through the fixture so they can't drift. (Deleting the redundant file was blocked by the sandbox, so it was repurposed to a distinct, non-overlapping responsibility instead.)
- **Migrated** `metaRegression`, `manifestRegression`, `launchScreens`, `vercelHeadersRegression` onto the shared reader/domain source, removing their local `readFileSync`/`resolve`/`DEPLOYMENT_DOMAIN` boilerplate.

## Verification
- `npm test` → 157 files pass, 2879 tests pass (1 skipped). Net −7 assertions from removing duplicated SEO checks; all green.
- `npm run lint` → clean.
- `npm run build` → succeeds.
- Post-commit adversarial review (Sonnet) → `REVIEW_CLEAN` / `MERGE`.
- No src coverage delta: the fixture lives under `__tests__`, excluded from the coverage denominator.

## Commits
- [`9d0e7ac`](https://github.com/aschung212/Lift/commit/9d0e7ac) refactor(LIFT-1012): consolidate static-config guardrail tests behind one shared fixture

## Test Results
- Before: 2886 passing
- After: 2879 passing (-7 delta)

---
_Automated by overnight pipeline — Thu Jul 23 00:22:57 PDT 2026_

## Preview
Test on your phone: https://lift-oi3sld4sg-aschung212-1101s-projects.vercel.app