### PR TITLE
ci(LIFT-1011): fail loudly when the Supabase service_role key is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,15 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         run: |
           echo "url=http://127.0.0.1:54321" >> "$GITHUB_OUTPUT"
-          SERVICE_ROLE_KEY=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY // .service_role_key')
+          # `// empty` (not the raw key path) so a missing key yields an empty
+          # string, never the literal "null" — which the test's env-var gate
+          # would treat as present and pass to createClient, producing cryptic
+          # auth failures instead of a loud, actionable CI error.
+          SERVICE_ROLE_KEY=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY // .service_role_key // empty')
+          if [ -z "$SERVICE_ROLE_KEY" ]; then
+            echo "::error::Could not extract the Supabase service_role key from 'supabase status'."
+            exit 1
+          fi
           echo "service_role_key=$SERVICE_ROLE_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,99 @@ jobs:
           path: .lighthouseci/
           retention-days: 7
 
+  # Real-DB schema-drift gate (LIFT-1011). supabaseIntegration.test.ts is the
+  # only suite that runs against a real Postgres/PostgREST instance, and the
+  # only defense against column renames, type changes, or RLS tightening. It
+  # used to run in the nightly integration.yml ONLY, so a schema-breaking change
+  # could merge green through PR CI and auto-deploy to Vercel hours before the
+  # 06:00 UTC run caught it — a data-integrity blind spot for a sync app. This
+  # job brings that gate into PR CI so drift fails the merge, not the morning.
+  #
+  # Cost control: booting Supabase adds ~1-2 min, so the heavy steps only run
+  # when a change actually touches the DB contract — a migration, the generated
+  # DB types, the JSON-column parsers / client config, the stores that build the
+  # PostgREST query shapes, or the integration test/config itself (this workflow
+  # is in the trigger set so edits to this job re-validate themselves). When
+  # nothing relevant changed, the detect step short-circuits and the job reports
+  # success WITHOUT booting Supabase — so the job always reports a status and is
+  # safe to mark as a required check (a skipped job would report "skipped", not
+  # "success", and gate merges inconsistently). The nightly run stays as the
+  # full safety net that fires regardless of which paths changed.
+  schema-drift:
+    name: Schema-drift integration (real DB)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [lint, typecheck]
+    if: github.event_name == 'pull_request'
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # Full history so the base..HEAD diff below can reach the merge-base.
+          fetch-depth: 0
+
+      # Only pay for Supabase when the DB contract could have drifted. Diff the
+      # PR's changes (merge-base of base..HEAD) against the contract surface.
+      - name: Detect DB-contract changes
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD)
+          echo "Changed files in this PR:"
+          echo "$CHANGED"
+          PATTERN='^(supabase/migrations/|src/lib/(database\.types|jsonColumns|supabase)\.ts$|src/stores/(workout|bodyweight)\.ts$|src/stores/__tests__/supabaseIntegration\.test\.ts$|vitest\.integration\.config\.js$|\.github/workflows/ci\.yml$)'
+          if echo "$CHANGED" | grep -Eq "$PATTERN"; then
+            echo "DB contract touched — running the real-DB integration suite."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No DB-contract changes — skipping Supabase boot."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        if: steps.detect.outputs.changed == 'true'
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Restore node_modules
+        if: steps.detect.outputs.changed == 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v2
+        if: steps.detect.outputs.changed == 'true'
+        with:
+          version: latest
+
+      - name: Start local Supabase
+        if: steps.detect.outputs.changed == 'true'
+        run: supabase start
+
+      - name: Extract Supabase credentials
+        id: supabase
+        if: steps.detect.outputs.changed == 'true'
+        run: |
+          echo "url=http://127.0.0.1:54321" >> "$GITHUB_OUTPUT"
+          SERVICE_ROLE_KEY=$(supabase status --output json | jq -r '.SERVICE_ROLE_KEY // .service_role_key')
+          echo "service_role_key=$SERVICE_ROLE_KEY" >> "$GITHUB_OUTPUT"
+
+      - name: Run integration tests
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          SUPABASE_INT_URL: ${{ steps.supabase.outputs.url }}
+          SUPABASE_INT_SERVICE_ROLE_KEY: ${{ steps.supabase.outputs.service_role_key }}
+        run: npm run test:integration
+
+      - name: Stop local Supabase
+        if: always() && steps.detect.outputs.changed == 'true'
+        run: supabase stop
+
   build-and-test:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test]

--- a/src/stores/__tests__/supabaseIntegration.test.ts
+++ b/src/stores/__tests__/supabaseIntegration.test.ts
@@ -26,8 +26,15 @@
  *
  * ## Running in CI
  *
- * The nightly workflow starts a local Supabase instance and sets the env vars
- * automatically. See `.github/workflows/integration.yml`.
+ * Two workflows run this suite against a spun-up local Supabase:
+ *   - `.github/workflows/ci.yml` (the `schema-drift` job) — a REQUIRED PR check
+ *     that runs whenever a PR touches the DB contract (migrations, DB types,
+ *     the JSON-column parsers / client config, the workout/bodyweight stores,
+ *     or this test/config), so schema drift fails the merge rather than
+ *     slipping to production before the nightly run (LIFT-1011).
+ *   - `.github/workflows/integration.yml` — the nightly full-suite safety net
+ *     that runs regardless of which paths changed.
+ * Both start a local Supabase instance and set the env vars automatically.
  *
  * ## Design decisions
  *


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1011](https://github.com/aschung212/Lift/issues/1011)

Implement **LIFT-1011** — the real-DB integration suite (`supabaseIntegration.test.ts`) was the only defense against schema/RLS drift but ran nightly-only, so a schema-breaking change could merge green and auto-deploy to Vercel hours before the 06:00 UTC run caught it. I brought that gate into PR CI as a path-gated, always-reporting job so it's safe to mark required, while keeping the nightly run as the full-suite safety net.

## Changes
- `.github/workflows/ci.yml` — new `schema-drift` job (PR-only, `needs: [lint, typecheck]`). A `detect` step diffs `base..HEAD` and only boots Supabase when the DB contract actually changed (`supabase/migrations/**`, `database.types.ts`, `jsonColumns.ts`, `supabase.ts`, `workout.ts`/`bodyweight.ts` stores, the integration test/config, or `ci.yml` itself). When nothing relevant changed the job reports success without booting Supabase, so it always yields a green/red status. Credential extraction fails loudly (`// empty` + empty-check) instead of passing the literal `"null"` to the test.
- `src/stores/__tests__/supabaseIntegration.test.ts` — updated the "Running in CI" doc comment to document the new PR gate alongside the nightly run.

## Verification
- Reused only action SHAs already pinned elsewhere in the repo (checkout/setup-node/cache-restore/supabase-cli) — no fabricated identifiers.
- Post-commit adversarial review: first pass raised one P2 (cryptic-failure risk if the service_role key is absent) which I fixed; second pass returned `REVIEW_CLEAN` / `MERGE`.
- lint-staged/eslint ran clean on the touched test file at commit time. YAML mirrors existing job structure; the repo's `workflow-lint` (actionlint) job will validate it in CI. Local shell validation was blocked by the sandbox approval gate, so YAML was verified by structural review against the existing `integration.yml` pattern.
- This PR touches `ci.yml`, so the new `schema-drift` job will self-exercise end-to-end (boot Supabase + run the integration suite) on its own PR.

## Commits
- [`f92ebba`](https://github.com/aschung212/Lift/commit/f92ebba) ci(LIFT-1011): fail loudly when the Supabase service_role key is missing
- [`5f0af4b`](https://github.com/aschung212/Lift/commit/5f0af4b) ci(LIFT-1011): gate real-DB schema-drift suite as a required PR check

## Test Results
- Before: 2886 passing
- After: 2886 passing (0 delta)

---
_Automated by overnight pipeline — Thu Jul 23 00:37:50 PDT 2026_