### PR TITLE
feat(LIFT-1019): add a progress/transformation shareable card

### DIFF
--- a/src/components/__tests__/WorkoutCompleteView.test.ts
+++ b/src/components/__tests__/WorkoutCompleteView.test.ts
@@ -25,6 +25,7 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     weekVolume: [0, 0, 0, 0, 0, 0, 0],
     priorWeekVolume: 0,
     streak: 2,
+    progress: null,
     unitLabel: 'lbs',
     ...overrides,
   }

--- a/src/components/share/__tests__/SharePickerSheet.test.ts
+++ b/src/components/share/__tests__/SharePickerSheet.test.ts
@@ -58,6 +58,7 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     weekVolume: [0, 0, 12000, 0, 0, 0, 0],
     priorWeekVolume: 10000,
     streak: 3,
+    progress: null,
     unitLabel: 'lbs',
     ...overrides,
   }

--- a/src/components/share/__tests__/cardHandle.test.ts
+++ b/src/components/share/__tests__/cardHandle.test.ts
@@ -34,6 +34,7 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     weekVolume: [0, 24850, 0, 0, 0, 0, 0],
     priorWeekVolume: 18200,
     streak: 4,
+    progress: null,
     unitLabel: 'lbs',
     ...overrides,
   }

--- a/src/components/share/__tests__/cardRegistry.test.ts
+++ b/src/components/share/__tests__/cardRegistry.test.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { eligibleSquareCards, eligibleStoryCards, findCard, resolveInitialCard, SQUARE_CARDS, STORY_CARDS } from '../cardRegistry'
-import type { SessionSummary } from '../../../lib/sessionSummary'
+import type { SessionSummary, SessionProgress } from '../../../lib/sessionSummary'
+
+function makeProgress(overrides: Partial<SessionProgress> = {}): SessionProgress {
+  return {
+    exerciseId: 'ex1',
+    name: 'Bench',
+    startE1RM: 135,
+    currentE1RM: 175,
+    delta: 40,
+    spanDays: 92,
+    spanLabel: '3 months',
+    ...overrides,
+  }
+}
 
 function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
@@ -17,14 +30,15 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     weekVolume: [0, 24850, 0, 0, 0, 0, 0],
     priorWeekVolume: 18200,
     streak: 4,
+    progress: null,
     unitLabel: 'lbs',
     ...overrides,
   }
 }
 
 describe('cardRegistry', () => {
-  it('exposes 8 square cards and 3 story cards', () => {
-    expect(SQUARE_CARDS).toHaveLength(8)
+  it('exposes 9 square cards and 3 story cards', () => {
+    expect(SQUARE_CARDS).toHaveLength(9)
     expect(STORY_CARDS).toHaveLength(3)
   })
 
@@ -43,14 +57,29 @@ describe('cardRegistry', () => {
     expect(cards.find((c) => c.id === 'pr-focus')).toBeUndefined()
   })
 
-  it('returns 7 squares when no PR (the 8th is PR Focus)', () => {
-    const cards = eligibleSquareCards(makeSummary({ prs: 0 }))
+  it('returns 7 squares when no PR and no progress (PR Focus + Progress hidden)', () => {
+    const cards = eligibleSquareCards(makeSummary({ prs: 0, progress: null }))
     expect(cards).toHaveLength(7)
   })
 
-  it('returns all 8 squares when there is a PR', () => {
-    const cards = eligibleSquareCards(makeSummary({ prs: 1 }))
+  it('returns 8 squares when there is a PR but no progress', () => {
+    const cards = eligibleSquareCards(makeSummary({ prs: 1, progress: null }))
     expect(cards).toHaveLength(8)
+  })
+
+  it('hides Progress when there is no progress story', () => {
+    const cards = eligibleSquareCards(makeSummary({ progress: null }))
+    expect(cards.find((c) => c.id === 'progress')).toBeUndefined()
+  })
+
+  it('shows Progress when a progress story is present', () => {
+    const cards = eligibleSquareCards(makeSummary({ progress: makeProgress() }))
+    expect(cards.find((c) => c.id === 'progress')).toBeDefined()
+  })
+
+  it('returns all 9 squares when both a PR and a progress story exist', () => {
+    const cards = eligibleSquareCards(makeSummary({ prs: 1, progress: makeProgress() }))
+    expect(cards).toHaveLength(9)
   })
 
   it('preserves the original ordering of the non-PR cards when promoting', () => {

--- a/src/components/share/cardRegistry.ts
+++ b/src/components/share/cardRegistry.ts
@@ -36,6 +36,13 @@ export const SQUARE_CARDS: CardEntry[] = [
   { id: 'receipt', label: 'Receipt', format: 'square', loader: () => import('./cards/ReceiptCard.vue') },
   { id: 'week-chart', label: 'Week', format: 'square', loader: () => import('./cards/WeekChartCard.vue') },
   { id: 'best-set', label: 'Best set', format: 'square', loader: () => import('./cards/BestSetCard.vue') },
+  {
+    id: 'progress',
+    label: 'Progress',
+    format: 'square',
+    loader: () => import('./cards/ProgressCard.vue'),
+    eligible: (s) => s.progress !== null,
+  },
   { id: 'stat-grid', label: 'Stats', format: 'square', loader: () => import('./cards/StatGridCard.vue') },
   { id: 'daily-ring', label: 'Ring', format: 'square', loader: () => import('./cards/DailyRingCard.vue') },
   { id: 'ticket-stub', label: 'Ticket', format: 'square', loader: () => import('./cards/TicketStubCard.vue') },

--- a/src/components/share/cards/ProgressCard.vue
+++ b/src/components/share/cards/ProgressCard.vue
@@ -1,0 +1,215 @@
+<template>
+  <div class="pgRoot">
+    <div class="pgHead">
+      <div class="pgEyebrow">Progress</div>
+      <div v-if="p" class="pgSpan">in {{ p.spanLabel }}</div>
+    </div>
+
+    <div v-if="p" class="pgHero">
+      <div class="pgName">{{ p.name }}</div>
+      <div class="pgDelta">
+        <span class="pgDeltaSign">+</span>{{ p.delta }}
+        <span class="pgDeltaUnit">{{ summary.unitLabel }}</span>
+      </div>
+      <div class="pgJourney">
+        <span class="pgFrom">{{ p.startE1RM }}</span>
+        <span class="pgArrow" aria-hidden="true">&rarr;</span>
+        <span class="pgTo">{{ p.currentE1RM }}</span>
+        <span class="pgMetric">{{ summary.unitLabel }} e1RM</span>
+      </div>
+    </div>
+
+    <div class="pgFoot">
+      <div class="pgTagline">Estimated 1-rep max</div>
+      <div class="pgBrand">
+        <span class="pgMark">LIFT</span>
+        <span class="pgHandle">{{ SHARE_CARD_HANDLE }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { SessionSummary } from '../../../lib/sessionSummary'
+import { SHARE_CARD_HANDLE } from '../../../lib/shareImage'
+
+const props = defineProps<{ summary: SessionSummary }>()
+
+const p = computed(() => props.summary.progress)
+</script>
+
+<style scoped>
+.pgRoot {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-primary);
+  background-image: var(--mesh);
+  color: var(--text-primary);
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-family: var(--ff);
+}
+
+.pgHead {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.pgEyebrow {
+  font-family: var(--ff-mono);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.pgSpan {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.pgHero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.pgName {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 28px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.pgDelta {
+  margin-top: 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 88px;
+  line-height: 0.9;
+  letter-spacing: -0.05em;
+  font-variant-numeric: tabular-nums;
+  color: var(--accent);
+  text-shadow: 0 0 60px var(--accent-subtle);
+}
+
+.pgDeltaSign {
+  font-size: 56px;
+  letter-spacing: -0.02em;
+}
+
+.pgDeltaUnit {
+  font-family: var(--ff-mono);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pgJourney {
+  margin-top: 20px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.pgFrom {
+  font-family: var(--ff-display);
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--text-muted);
+}
+
+.pgArrow {
+  font-family: var(--ff-display);
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--text-secondary);
+}
+
+.pgTo {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: 32px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+}
+
+.pgMetric {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 10px;
+  line-height: 1;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.pgFoot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.pgTagline {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.pgBrand {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.pgMark {
+  font-family: var(--ff-mono);
+  font-weight: 700;
+  font-size: 11px;
+  line-height: 1;
+  letter-spacing: 0.22em;
+  color: var(--accent);
+}
+
+.pgHandle {
+  font-family: var(--ff-mono);
+  font-weight: 500;
+  font-size: 9px;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+</style>

--- a/src/composables/__tests__/useWorkoutShare.test.ts
+++ b/src/composables/__tests__/useWorkoutShare.test.ts
@@ -48,6 +48,7 @@ function makeSummary(overrides: Partial<SessionSummary> = {}): SessionSummary {
     weekVolume: [0, 0, 12000, 0, 0, 0, 0],
     priorWeekVolume: 10000,
     streak: 3,
+    progress: null,
     unitLabel: 'lbs',
     ...overrides,
   }

--- a/src/lib/__tests__/sessionSummary.test.ts
+++ b/src/lib/__tests__/sessionSummary.test.ts
@@ -4,6 +4,7 @@ import {
   formatSessionDate,
   weekRange,
   formatDuration,
+  formatSpanLabel,
 } from '../sessionSummary'
 import type { Exercise } from '../../stores/workout'
 import type { SetXPEntry } from '../../stores/progression'
@@ -305,5 +306,126 @@ describe('buildSessionSummary', () => {
     expect(summary.unitLabel).toBe('kg')
     expect(summary.bestSet?.weight).toBeCloseTo(102.1, 1)
     expect(summary.totalVolume).toBeCloseTo(510.3, 1)
+  })
+})
+
+describe('formatSpanLabel', () => {
+  it('renders short spans in weeks', () => {
+    expect(formatSpanLabel(7)).toBe('1 week')
+    expect(formatSpanLabel(14)).toBe('2 weeks')
+    expect(formatSpanLabel(55)).toBe('8 weeks')
+  })
+
+  it('renders medium spans in months (floored at 2)', () => {
+    expect(formatSpanLabel(56)).toBe('2 months')
+    expect(formatSpanLabel(91)).toBe('3 months')
+    expect(formatSpanLabel(365)).toBe('12 months')
+  })
+
+  it('renders long spans in years with one decimal', () => {
+    expect(formatSpanLabel(548)).toBe('1.5 years')
+    expect(formatSpanLabel(730)).toBe('2 years')
+  })
+})
+
+describe('buildSessionSummary progress story (#1019)', () => {
+  it('is null when the trained exercise has only one recorded day', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 's1', weight: 175, reps: 1, date: '2026-04-21T15:00:00Z' },
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.progress).toBeNull()
+  })
+
+  it('builds a first-day → peak transformation for a trained exercise', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 'p1', weight: 135, reps: 1, date: '2026-01-20T15:00:00Z' }, // e1RM 135
+        { id: 's1', weight: 175, reps: 1, date: '2026-04-21T15:00:00Z' }, // e1RM 175 (today, peak)
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.progress).not.toBeNull()
+    expect(summary.progress?.name).toBe('Bench')
+    expect(summary.progress?.startE1RM).toBe(135)
+    expect(summary.progress?.currentE1RM).toBe(175)
+    expect(summary.progress?.delta).toBe(40)
+    expect(summary.progress?.spanDays).toBe(91)
+    expect(summary.progress?.spanLabel).toBe('3 months')
+  })
+
+  it('is null when the gain is below the meaningful threshold', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 'p1', weight: 135, reps: 1, date: '2026-01-20T15:00:00Z' },
+        { id: 's1', weight: 138, reps: 1, date: '2026-04-21T15:00:00Z' }, // +3 lb only
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.progress).toBeNull()
+  })
+
+  it('is null when the span is too short to read as a journey', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 'p1', weight: 135, reps: 1, date: '2026-04-10T15:00:00Z' },
+        { id: 's1', weight: 175, reps: 1, date: '2026-04-21T15:00:00Z' }, // +40 lb but 11 days
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.progress).toBeNull()
+  })
+
+  it('picks the biggest gainer among the exercises trained today', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 'b1', weight: 135, reps: 1, date: '2026-01-20T15:00:00Z' },
+        { id: 'b2', weight: 175, reps: 1, date: '2026-04-21T15:00:00Z' }, // +40
+      ]),
+      makeExercise('Squat', 'ex2', [
+        { id: 'q1', weight: 205, reps: 1, date: '2026-01-20T15:00:00Z' },
+        { id: 'q2', weight: 315, reps: 1, date: '2026-04-21T15:00:00Z' }, // +110
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.progress?.name).toBe('Squat')
+    expect(summary.progress?.delta).toBe(110)
+  })
+
+  it('ignores an exercise not trained today even if its gain is larger', () => {
+    const exercises = [
+      // Huge gain, but the last set was days ago — not part of today's session.
+      makeExercise('Deadlift', 'ex1', [
+        { id: 'd1', weight: 135, reps: 1, date: '2026-01-20T15:00:00Z' },
+        { id: 'd2', weight: 405, reps: 1, date: '2026-04-15T15:00:00Z' }, // +270, not today
+      ]),
+      makeExercise('Bench', 'ex2', [
+        { id: 'b1', weight: 135, reps: 1, date: '2026-01-20T15:00:00Z' },
+        { id: 'b2', weight: 175, reps: 1, date: '2026-04-21T15:00:00Z' }, // +40, today
+      ]),
+    ]
+    const summary = buildSessionSummary({ rawDate: '2026-04-21', exercises })
+    expect(summary.progress?.name).toBe('Bench')
+    expect(summary.progress?.delta).toBe(40)
+  })
+
+  it('routes the progress e1RM values through toDisplayUnits', () => {
+    const exercises = [
+      makeExercise('Bench', 'ex1', [
+        { id: 'p1', weight: 135, reps: 1, date: '2026-01-20T15:00:00Z' },
+        { id: 's1', weight: 175, reps: 1, date: '2026-04-21T15:00:00Z' },
+      ]),
+    ]
+    const summary = buildSessionSummary({
+      rawDate: '2026-04-21',
+      exercises,
+      unitLabel: 'kg',
+      toDisplayUnits: (lb) => +(lb * 0.453592).toFixed(1),
+    })
+    expect(summary.progress?.startE1RM).toBeCloseTo(61.2, 1)
+    expect(summary.progress?.currentE1RM).toBeCloseTo(79.4, 1)
+    expect(summary.progress?.delta).toBeCloseTo(18.2, 1)
   })
 })

--- a/src/lib/sessionSummary.ts
+++ b/src/lib/sessionSummary.ts
@@ -9,7 +9,7 @@
 
 import type { Exercise, WorkoutSet } from '../stores/workout'
 import type { SetXPEntry } from '../stores/progression'
-import { toLocalDateKey, localDateKey } from './dates'
+import { toLocalDateKey, localDateKey, daysBetweenISO } from './dates'
 
 export interface SessionHighlight {
   exerciseId: string
@@ -30,6 +30,26 @@ export interface SessionBestSet {
   isPR: boolean
 }
 
+/**
+ * A single "transformation" story (#1019): the biggest strength gain, over a
+ * meaningful span, among the exercises trained today. Turns an exercise's
+ * history into one aspirational "X → Y" narrative for a shareable card.
+ */
+export interface SessionProgress {
+  exerciseId: string
+  name: string
+  /** Best e1RM on the exercise's first recorded day, in display units. */
+  startE1RM: number
+  /** All-time best e1RM for the exercise, in display units. */
+  currentE1RM: number
+  /** currentE1RM − startE1RM, in display units (always > 0). */
+  delta: number
+  /** Whole days from the first recorded day to the peak-e1RM day. */
+  spanDays: number
+  /** Human span label for the delta, e.g. '3 months'. */
+  spanLabel: string
+}
+
 export interface SessionSummary {
   rawDate: string             // YYYY-MM-DD (key used everywhere internally)
   date: string                // 'Tue, Apr 22' formatted for display
@@ -45,8 +65,33 @@ export interface SessionSummary {
   /** Sum of the previous Mon→Sun week, in display units. Used for the % delta on the WeekChart card. */
   priorWeekVolume: number
   streak: number              // weeks
+  /** Biggest strength-progress story among today's exercises, or null. */
+  progress: SessionProgress | null
   /** Display unit label for any weight field — 'lbs' or 'kg'. */
   unitLabel: string
+}
+
+/**
+ * A progress story must clear both bars to be worth sharing: a real strength
+ * gain (not measurement noise) achieved over enough time to read as a journey
+ * rather than a single good day. Thresholds are checked in pounds, before unit
+ * conversion, so they mean the same thing for lbs and kg users.
+ */
+const MIN_PROGRESS_DELTA_LB = 5
+const MIN_PROGRESS_SPAN_DAYS = 14
+
+/** Human-friendly span label for a day count, e.g. '3 weeks' / '5 months' / '1.5 years'. */
+export function formatSpanLabel(days: number): string {
+  if (days < 56) {
+    const w = Math.max(1, Math.round(days / 7))
+    return `${w} week${w === 1 ? '' : 's'}`
+  }
+  if (days < 548) {
+    const m = Math.max(2, Math.round(days / 30.44))
+    return `${m} months`
+  }
+  const y = Math.round((days / 365.25) * 10) / 10
+  return `${y} year${y === 1 ? '' : 's'}`
 }
 
 export interface SessionSummaryInput {
@@ -213,6 +258,58 @@ export function buildSessionSummary(input: SessionSummaryInput): SessionSummary 
 
   highlights.sort((a, b) => b.volume - a.volume)
 
+  // Progress / transformation story (#1019): among the exercises trained today,
+  // find the one with the biggest e1RM gain from its first recorded day to its
+  // all-time peak, over a meaningful span. Only today's exercises are eligible
+  // so the card celebrates something the user just worked — "you benched today;
+  // here's how far your bench has come".
+  let progress: SessionProgress | null = null
+  let bestProgressDeltaLb = 0
+  for (const { ex } of todaysByExercise.values()) {
+    // Best e1RM per calendar day across the whole history of this exercise.
+    const bestByDay = new Map<string, number>()
+    for (const s of ex.sets) {
+      const k = toLocalDateKey(s.date)
+      const prev = bestByDay.get(k) ?? -1
+      if (s.estimated1RM > prev) bestByDay.set(k, s.estimated1RM)
+    }
+    if (bestByDay.size < 2) continue
+
+    const dayKeys = [...bestByDay.keys()].sort()
+    const startKey = dayKeys[0]
+    const startLb = bestByDay.get(startKey)!
+    // Peak endpoint: the highest e1RM day; earliest such day for a stable span.
+    let peakKey = startKey
+    let peakLb = startLb
+    for (const k of dayKeys) {
+      const v = bestByDay.get(k)!
+      if (v > peakLb) {
+        peakLb = v
+        peakKey = k
+      }
+    }
+
+    const deltaLb = peakLb - startLb
+    if (deltaLb < MIN_PROGRESS_DELTA_LB) continue
+    const spanDays = daysBetweenISO(startKey, peakKey)
+    if (spanDays < MIN_PROGRESS_SPAN_DAYS) continue
+
+    if (deltaLb > bestProgressDeltaLb) {
+      bestProgressDeltaLb = deltaLb
+      const startE1RM = cv(startLb)
+      const currentE1RM = cv(peakLb)
+      progress = {
+        exerciseId: ex.id,
+        name: ex.name,
+        startE1RM,
+        currentE1RM,
+        delta: Math.round((currentE1RM - startE1RM) * 10) / 10,
+        spanDays,
+        spanLabel: formatSpanLabel(spanDays),
+      }
+    }
+  }
+
   // Duration: span between earliest and latest *real-time* timestamps on the date.
   // End-of-day jitter timestamps (bulk-add / legacy) are excluded entirely —
   // including them in the max would inflate duration to ~all day when a user
@@ -267,6 +364,7 @@ export function buildSessionSummary(input: SessionSummaryInput): SessionSummary 
     weekVolume,
     priorWeekVolume,
     streak: streakWeeks,
+    progress,
     unitLabel,
   }
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1019](https://github.com/aschung212/Lift/issues/1019)

Implement LIFT-1019: a progress/transformation shareable card ("+40 lb bench in 3 months"). Reuse the existing single-session share pipeline (cardRegistry → SharePickerSheet → shareImage) rather than building a parallel flow — compute a progress story inside `buildSessionSummary` (which already has full exercise history), expose it as `summary.progress`, and add one new eligible square card.

## Changes
- **`src/lib/sessionSummary.ts`** — new `SessionProgress` interface + `summary.progress` field. `buildSessionSummary` now derives, among the exercises trained *today*, the one with the biggest e1RM gain from its first recorded day to its all-time peak. Gated by meaningful thresholds (≥5 lb gain, ≥14 day span, checked in pounds before unit conversion so lbs/kg users get identical behavior). Added exported `formatSpanLabel` (weeks / months / years).
- **`src/components/share/cards/ProgressCard.vue`** — new card rendering the "+delta unit · start → current e1RM · in {span}" transformation story. Fully themeable (all `var(--color-*)`, type scale, tabular-nums), brand handle in the footer outside the data guard.
- **`src/components/share/cardRegistry.ts`** — registered `progress` card, eligible when `summary.progress !== null`, slotted after Best set.
- **Tests** — progress-computation coverage (first-day→peak, delta/span thresholds, biggest-gainer selection, today-only scoping, unit conversion), `formatSpanLabel` cases, registry eligibility, and updated 5 `SessionSummary` fixtures for the new required field.

## Verification
- Pre-commit ESLint hook: passed (`--max-warnings 5`).
- Adversarial review (Sonnet): `REVIEW_CLEAN / MERGE`.
- Local `vitest`/`npm` runs were gated behind interactive approval in this session, so test execution is delegated to CI (pipeline runs build + tests before opening the PR). New/updated tests were written to match existing fixture and eligibility conventions; card-count assertions were updated (8→9) and no other test hardcodes the card count.

## Screenshots
Not captured — card renders through the existing offscreen rasterizer; no interactive UI surface changed. Visual is a themeable static export card consistent with the existing BestSet/PrFocus card language.

## Commits
- [`398eaad`](https://github.com/aschung212/Lift/commit/398eaad) feat(LIFT-1019): add a progress/transformation shareable card

## Test Results
- Before: 2901 passing
- After: 2915 passing (14 delta)

---
_Automated by overnight pipeline — Thu Jul 23 23:30:50 PDT 2026_

## Preview
Test on your phone: https://lift-12fdwda0k-aschung212-1101s-projects.vercel.app