### PR TITLE
test(LIFT-966): reset fake timers in global teardown to close cross-test leak

### DIFF
--- a/src/__tests__/globalTeardown.test.ts
+++ b/src/__tests__/globalTeardown.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression coverage for the global afterEach teardown in setup.ts (LIFT-966).
+ *
+ * The global hook exists so test isolation is the default rather than a per-file
+ * responsibility. These tests deliberately DIRTY shared state (localStorage,
+ * mock call history, fake timers) in one `it` and assert the *next* `it` starts
+ * clean — proving the teardown ran in between. If a future edit drops any line
+ * from the global afterEach, one of these ordered assertions fails.
+ *
+ * Ordering matters: Vitest runs `it` blocks in source order, so the "leave dirty"
+ * test must precede its "starts clean" partner.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+describe('global test teardown (setup.ts)', () => {
+  describe('localStorage isolation', () => {
+    it('writes a key without cleaning up', () => {
+      localStorage.setItem('leaked-key', 'dirty')
+      expect(localStorage.getItem('leaked-key')).toBe('dirty')
+    })
+
+    it('does not inherit the previous test\'s localStorage entry', () => {
+      expect(localStorage.getItem('leaked-key')).toBeNull()
+    })
+  })
+
+  describe('mock call-history isolation', () => {
+    const spy = vi.fn()
+
+    it('accumulates calls without clearing them', () => {
+      spy('a')
+      spy('b')
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('sees cleared call history in the next test', () => {
+      expect(spy).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('fake-timer isolation', () => {
+    it('arms fake timers and deliberately never restores them', () => {
+      vi.useFakeTimers()
+      expect(vi.isFakeTimers()).toBe(true)
+    })
+
+    it('starts the next test on real timers despite the leak above', () => {
+      expect(vi.isFakeTimers()).toBe(false)
+    })
+  })
+})

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -33,7 +33,16 @@ vi.mock('../lib/supabase', () => ({ supabase: null }))
 // unaffected. `clear?.()` tolerates the occasional file that swaps in its own
 // localStorage stub without a clear() method (e.g. migrate.test.ts); those
 // files reset their own store in beforeEach, so nothing leaks.
+//
+// useRealTimers() closes the one leak class clearAllMocks() can't: 21 files
+// call vi.useFakeTimers() (all in beforeEach), but a file that forgets the
+// matching vi.useRealTimers() leaves fake timers armed for whatever runs next
+// — real setTimeout/Date.now() then silently freeze. Restoring here makes the
+// teardown self-sufficient regardless of per-file discipline; it's a harmless
+// no-op when timers were never faked, and because every fake-timer file arms
+// them per-test in beforeEach, resetting between tests never strands a suite.
 afterEach(() => {
   localStorage.clear?.()
+  vi.useRealTimers()
   vi.clearAllMocks()
 })


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-966](https://github.com/aschung212/Lift/issues/966)

LIFT-966 asked for a global `afterEach` cleanup hook in the Vitest setup. On reading the code I found that exact hook (`localStorage.clear()` + `vi.clearAllMocks()`) was already present — silently bundled into commit `dedba3b` (PR #1007) without closing the issue. Rather than manufacture redundant work, I closed the remaining gap the issue's title actually names ("cross-test state leaks") that `clearAllMocks()` does **not** cover: **fake-timer state**.

## Changes
- **`src/__tests__/setup.ts`** — Added `vi.useRealTimers()` to the global `afterEach`. 21 test files call `vi.useFakeTimers()` (all in `beforeEach`); one (`useXPCeremony.test.ts`) never restores real timers and relies on per-file isolation. The global reset closes that leak class regardless of per-file discipline — a no-op when timers were never faked, and safe because every fake-timer file re-arms per-test. Documented the rationale in the comment.
- **`src/__tests__/globalTeardown.test.ts`** (new) — Regression test that dirties localStorage, mock call history, and fake timers in one ordered test and asserts the next test starts clean. Pins each line of the global teardown against silent removal.

## Verification
- `npm test` → 2907 passed (was 2901; +6 new cases), 1 skipped
- `npm run lint` → clean
- `npm run build` → succeeds
- Post-commit adversarial review → `REVIEW_CLEAN` / `MERGE`

## Screenshots
N/A — test-infrastructure change, no UI surface affected.

## Commits
- [`c9083cb`](https://github.com/aschung212/Lift/commit/c9083cb) test(LIFT-966): reset fake timers in global teardown to close cross-test leak

## Test Results
- Before: 2901 passing
- After: 2907 passing (6 delta)

---
_Automated by overnight pipeline — Mon Jul 27 23:15:48 PDT 2026_

## Preview
Test on your phone: https://lift-oyk52zcy7-aschung212-1101s-projects.vercel.app