### PR TITLE
feat(LIFT-1025): surface an in-app plateau/stall indicator on the exercise graph

### DIFF
--- a/src/components/ExerciseGraph.vue
+++ b/src/components/ExerciseGraph.vue
@@ -1,6 +1,17 @@
 <template>
   <div v-if="hasGraph" class="wtGraphWrap">
-    <p class="wtGraphTitle">{{ mode === 'prs' ? 'PR Progression' : 'Estimated 1RM Progress' }}</p>
+    <p class="wtGraphTitle">
+      {{ mode === 'prs' ? 'PR Progression' : 'Estimated 1RM Progress' }}
+      <span
+        v-if="plateau.isPlateau"
+        class="wtGraphPlateauBadge"
+        :aria-label="plateauLabel"
+        :title="plateauLabel"
+      >
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12" /></svg>
+        Plateau
+      </span>
+    </p>
 
     <!-- Time-range selector -->
     <div class="exGraphPeriodRow" role="group" aria-label="Chart time range">
@@ -135,6 +146,7 @@ import { useWeightUnit } from '../composables/useWeightUnit'
 import { usePRBaseline } from '../composables/usePRBaseline'
 import { useSVGTimeSeries, type TimeSeriesEntry } from '../composables/useSVGTimeSeries'
 import { useChartScrubber } from '../composables/useChartScrubber'
+import { detectPlateau } from '../lib/plateau'
 import type { Exercise } from '../stores/workout'
 
 const { weightUnit, displayWeight } = useWeightUnit()
@@ -183,6 +195,18 @@ const dailyBest = computed((): [string, number][] => {
   }
   return Object.entries(byDate).sort(([a], [b]) => a.localeCompare(b))
 })
+
+// Plateau/stall detection (LIFT-1025). Computed over the full daily-best e1RM
+// history (baseline-scoped, but independent of the graph's mode and the
+// selected time window) so the badge reflects genuine stagnation in the
+// current training block rather than an artifact of the chosen range.
+const plateau = computed(() =>
+  detectPlateau(dailyBest.value.map(([date, value]) => ({ date, value })))
+)
+
+const plateauLabel = computed(
+  () => `No new estimated 1RM best in the last ${plateau.value.sessionsStalled} sessions`
+)
 
 const prOnly = computed((): [string, number][] => {
   const entries = dailyBest.value

--- a/src/components/__tests__/ExerciseGraph.test.ts
+++ b/src/components/__tests__/ExerciseGraph.test.ts
@@ -282,6 +282,46 @@ describe('ExerciseGraph', () => {
     })
   })
 
+  describe('plateau badge (LIFT-1025)', () => {
+    it('does not render the badge while e1RM is progressing', () => {
+      const exercise = makeExercise([
+        makeSet(135, 5, '2026-01-01'),
+        makeSet(145, 5, '2026-01-08'),
+        makeSet(155, 5, '2026-01-15'),
+        makeSet(165, 5, '2026-01-22'),
+      ])
+      const wrapper = mount(ExerciseGraph, { props: { exercise } })
+      expect(wrapper.find('.wtGraphPlateauBadge').exists()).toBe(false)
+    })
+
+    it('renders the badge when best e1RM has stalled across recent sessions', () => {
+      const exercise = makeExercise([
+        makeSet(135, 5, '2026-01-01'),
+        makeSet(155, 5, '2026-01-08'), // peak
+        makeSet(150, 5, '2026-01-15'),
+        makeSet(150, 5, '2026-01-22'),
+        makeSet(152, 5, '2026-01-29'),
+      ])
+      const wrapper = mount(ExerciseGraph, { props: { exercise } })
+      const badge = wrapper.find('.wtGraphPlateauBadge')
+      expect(badge.exists()).toBe(true)
+      expect(badge.text()).toContain('Plateau')
+      expect(badge.attributes('aria-label')).toContain('3 sessions')
+    })
+
+    it('clears the badge once a new best is set on the latest session', () => {
+      const exercise = makeExercise([
+        makeSet(135, 5, '2026-01-01'),
+        makeSet(155, 5, '2026-01-08'),
+        makeSet(150, 5, '2026-01-15'),
+        makeSet(150, 5, '2026-01-22'),
+        makeSet(175, 5, '2026-01-29'), // breakthrough
+      ])
+      const wrapper = mount(ExerciseGraph, { props: { exercise } })
+      expect(wrapper.find('.wtGraphPlateauBadge').exists()).toBe(false)
+    })
+  })
+
   describe('same-day best aggregation', () => {
     it('uses the best e1RM per day, not every set', () => {
       // Two sets on the same day — only the better one should produce a point

--- a/src/index.css
+++ b/src/index.css
@@ -5996,6 +5996,29 @@ html.theme-fading .settingsSheet {
   letter-spacing: 0.7px;
   color: var(--text-muted);
   margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Plateau/stall badge (LIFT-1025) — subtle attention chip surfaced beside the
+   chart title when e1RM has stalled across recent sessions. */
+.wtGraphPlateauBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--danger-subtle);
+  color: var(--danger);
+  font-size: var(--font-caption2);
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  line-height: 1;
+}
+
+.wtGraphPlateauBadge svg {
+  flex-shrink: 0;
 }
 
 .wtGraphSvg {

--- a/src/lib/__tests__/plateau.test.ts
+++ b/src/lib/__tests__/plateau.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectPlateau,
+  PLATEAU_MIN_SESSIONS,
+  PLATEAU_STALL_SESSIONS,
+} from '../plateau'
+
+function series(...values: number[]): { date: string; value: number }[] {
+  return values.map((value, i) => ({
+    date: `2026-01-${String(i + 1).padStart(2, '0')}`,
+    value,
+  }))
+}
+
+describe('detectPlateau', () => {
+  it('returns no plateau below the minimum session count', () => {
+    // Flat but too short to claim a stall.
+    const result = detectPlateau(series(100, 100, 100))
+    expect(PLATEAU_MIN_SESSIONS).toBe(4)
+    expect(result.isPlateau).toBe(false)
+    expect(result.sessionsStalled).toBe(0)
+  })
+
+  it('flags a plateau when the peak is stallSessions sessions in the past', () => {
+    // Peak at index 1 (110), three sessions after it fail to beat it.
+    const result = detectPlateau(series(100, 110, 108, 105, 109))
+    expect(result.isPlateau).toBe(true)
+    expect(result.sessionsStalled).toBe(3)
+    expect(result.peakValue).toBe(110)
+  })
+
+  it('does not flag when progress is steadily increasing', () => {
+    const result = detectPlateau(series(100, 105, 110, 115, 120))
+    expect(result.isPlateau).toBe(false)
+    expect(result.sessionsStalled).toBe(0)
+    expect(result.peakValue).toBe(120)
+  })
+
+  it('does not flag when the most recent session set a new peak', () => {
+    // Long stall then a breakthrough on the last session.
+    const result = detectPlateau(series(100, 100, 100, 100, 112))
+    expect(result.isPlateau).toBe(false)
+    expect(result.sessionsStalled).toBe(0)
+  })
+
+  it('treats repeated ties as a stall (a tie is not progress)', () => {
+    // First peak at index 0; ties never advance the peak index.
+    const result = detectPlateau(series(120, 120, 120, 120))
+    expect(result.isPlateau).toBe(true)
+    expect(result.sessionsStalled).toBe(3)
+    expect(result.peakValue).toBe(120)
+  })
+
+  it('does not flag when only stallSessions-1 sessions trail the peak', () => {
+    // Peak at index 2, only two sessions after it.
+    const result = detectPlateau(series(100, 105, 120, 118, 119))
+    expect(PLATEAU_STALL_SESSIONS).toBe(3)
+    expect(result.isPlateau).toBe(false)
+    expect(result.sessionsStalled).toBe(2)
+  })
+
+  it('honors custom thresholds', () => {
+    const result = detectPlateau(series(100, 90, 90), {
+      minSessions: 3,
+      stallSessions: 2,
+    })
+    expect(result.isPlateau).toBe(true)
+    expect(result.sessionsStalled).toBe(2)
+  })
+
+  it('handles an empty series without throwing', () => {
+    const result = detectPlateau([])
+    expect(result.isPlateau).toBe(false)
+    expect(result.peakValue).toBe(0)
+  })
+})

--- a/src/lib/plateau.ts
+++ b/src/lib/plateau.ts
@@ -1,0 +1,77 @@
+/**
+ * Plateau / stall detection for an exercise's estimated-1RM trend (LIFT-1025).
+ *
+ * The #1 competitor complaint in 2026 reviews is "it records, it doesn't
+ * think" — loggers show a flat curve but never name the stall. Lift already
+ * computes `estimated1RM` per set; this pure helper reads the per-session
+ * daily-best e1RM sequence and flags when an exercise's best e1RM has not made
+ * a new high across the most recent N sessions.
+ *
+ * Local-first and always-on: it powers a subtle on-graph badge (visual over
+ * verbal, design principle #4) and reaches users who never opt into the
+ * server-side AI Coach weekly digest.
+ */
+
+export interface PlateauInput {
+  /** ISO-ish day key (YYYY-MM-DD…); only chronological order is used. */
+  date: string
+  /** Best estimated 1RM for that session. */
+  value: number
+}
+
+export interface PlateauResult {
+  /** True when the peak e1RM is at least `stallSessions` sessions in the past. */
+  isPlateau: boolean
+  /**
+   * Number of consecutive most-recent sessions that failed to beat the peak
+   * e1RM. Zero when the latest session itself set the peak.
+   */
+  sessionsStalled: number
+  /** The peak (best) e1RM across the analyzed sessions. */
+  peakValue: number
+}
+
+/** Minimum sessions of history required before a plateau can be claimed. */
+export const PLATEAU_MIN_SESSIONS = 4
+/** Trailing sessions without a new peak that constitute a stall. */
+export const PLATEAU_STALL_SESSIONS = 3
+
+const NO_PLATEAU: PlateauResult = { isPlateau: false, sessionsStalled: 0, peakValue: 0 }
+
+/**
+ * Detects an e1RM plateau over a chronologically-sorted daily-best sequence.
+ *
+ * Algorithm: find the first session that reached the maximum e1RM, then count
+ * how many sessions came after it. Those trailing sessions all failed to set a
+ * new high, so `trailing >= stallSessions` (with enough total history) is a
+ * stall. Using the *first* peak session as the anchor means a lifter who ties
+ * their best repeatedly is still counted as stalled — a tie is not progress.
+ *
+ * Requires `minSessions` of history so a brand-new exercise with two flat
+ * sessions is never mislabeled, and returns the raw `sessionsStalled` count so
+ * callers can phrase the nudge ("no new best in 4 sessions").
+ */
+export function detectPlateau(
+  entries: readonly PlateauInput[],
+  opts: { minSessions?: number; stallSessions?: number } = {},
+): PlateauResult {
+  const minSessions = opts.minSessions ?? PLATEAU_MIN_SESSIONS
+  const stallSessions = opts.stallSessions ?? PLATEAU_STALL_SESSIONS
+  if (entries.length < minSessions) return NO_PLATEAU
+
+  let peakValue = -Infinity
+  let peakIndex = 0
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].value > peakValue) {
+      peakValue = entries[i].value
+      peakIndex = i
+    }
+  }
+
+  const sessionsStalled = entries.length - 1 - peakIndex
+  return {
+    isPlateau: sessionsStalled >= stallSessions,
+    sessionsStalled,
+    peakValue,
+  }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1025](https://github.com/aschung212/Lift/issues/1025)



## Changes




## Commits
- [`3437b06`](https://github.com/aschung212/Lift/commit/3437b06) feat(LIFT-1025): surface an in-app plateau/stall indicator on the exercise graph

## Test Results
- Before: 2901 passing
- After: 2912 passing (11 delta)

---
_Automated by overnight pipeline — Mon Jul 27 23:34:05 PDT 2026_

## Preview
Test on your phone: https://lift-ozcmv05ar-aschung212-1101s-projects.vercel.app