### PR TITLE
feat(LIFT-1039): sync per-exercise plateCountMode to Supabase

### DIFF
--- a/src/lib/__tests__/parseGuards.test.ts
+++ b/src/lib/__tests__/parseGuards.test.ts
@@ -14,6 +14,7 @@ import {
   parseExercises,
   parseBodyweightEntry,
   parseBodyweightEntries,
+  sanitizePlateCountMode,
 } from '../parseGuards'
 import { matchesGymFilter } from '../gyms'
 
@@ -149,6 +150,16 @@ describe('parseExercise', () => {
     expect(ex!.equipment).toBeUndefined()
   })
 
+  it('drops an unrecognized plateCountMode value (LIFT-1039)', () => {
+    const ex = parseExercise({ id: 'ex-1', name: 'Row', tags: [], sets: [], plateCountMode: 'sideways' })
+    expect(ex!.plateCountMode).toBeUndefined()
+  })
+
+  it('keeps a valid plateCountMode value', () => {
+    const ex = parseExercise({ id: 'ex-1', name: 'Row', tags: [], sets: [], plateCountMode: 'total' })
+    expect(ex!.plateCountMode).toBe('total')
+  })
+
   // parseExercise builds a fresh object from an allowlist of known fields, so any
   // field it forgets is silently dropped on every hydration. `gyms` (#961) landed
   // on master while this guard was in review and was nearly lost in the merge —
@@ -173,6 +184,19 @@ describe('parseExercise', () => {
   it('rejects an exercise missing id or name', () => {
     expect(parseExercise({ name: 'Row', tags: [], sets: [] })).toBeNull()
     expect(parseExercise({ id: 'ex-1', tags: [], sets: [] })).toBeNull()
+  })
+})
+
+describe('sanitizePlateCountMode', () => {
+  it('accepts the two valid modes', () => {
+    expect(sanitizePlateCountMode('per-side')).toBe('per-side')
+    expect(sanitizePlateCountMode('total')).toBe('total')
+  })
+
+  it('returns undefined for anything else', () => {
+    for (const bad of ['', 'PER-SIDE', 'both', 0, null, undefined, {}, ['total']]) {
+      expect(sanitizePlateCountMode(bad)).toBeUndefined()
+    }
   })
 })
 

--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -281,6 +281,22 @@ describe('replay allowlist (LIFT-785)', () => {
       })).toBe(true)
     })
 
+    it('accepts a full-fidelity exercise upsert (every column _buildExerciseUpsert sends)', () => {
+      // Regression for LIFT-1039: the allowlist had drifted behind the producer.
+      // `_buildExerciseUpsert` always sends `equipment` (#931), `gyms` (#961) and
+      // now `plate_count_mode` (LIFT-1039) — none of which were allowlisted — so
+      // isReplayableDescriptor rejected EVERY journaled exercise upsert, silently
+      // dropping offline exercise writes on rehydrate(). Assert the exact shape.
+      expect(isReplayableDescriptor({
+        op: 'upsert', table: 'exercises',
+        row: {
+          id: 'e1', user_id: 'u1', name: 'Bench', tags: ['Push'], archived_at: null,
+          input_mode: 'plates', bar_weight: 45, plate_count_mode: 'total',
+          intensity_max_reps: null, equipment: 'free_weight', gyms: ['Home'],
+        },
+      })).toBe(true)
+    })
+
     it('tolerates retired-but-dormant DB columns so legacy offline writes still replay', () => {
       // warmup_scheme was retired in #770 but the column still exists in the DB.
       // An offline write journaled by a pre-#770 client must not be dropped.

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -78,6 +78,7 @@ export type Database = {
           input_mode: string | null
           intensity_max_reps: number | null
           name: string
+          plate_count_mode: string | null
           tags: string[]
           updated_at: string | null
           user_id: string
@@ -94,6 +95,7 @@ export type Database = {
           input_mode?: string | null
           intensity_max_reps?: number | null
           name: string
+          plate_count_mode?: string | null
           tags?: string[]
           updated_at?: string | null
           user_id: string
@@ -110,6 +112,7 @@ export type Database = {
           input_mode?: string | null
           intensity_max_reps?: number | null
           name?: string
+          plate_count_mode?: string | null
           tags?: string[]
           updated_at?: string | null
           user_id?: string

--- a/src/lib/parseGuards.ts
+++ b/src/lib/parseGuards.ts
@@ -30,6 +30,16 @@ function isFiniteNumber(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v)
 }
 
+/**
+ * Validate a plate-counting mode from any untrusted boundary (localStorage or
+ * Supabase). Returns the enum value or `undefined` so callers leave the field
+ * unset and fall back to the 'per-side' default rather than trusting a stray
+ * string (LIFT-1039).
+ */
+export function sanitizePlateCountMode(value: unknown): PlateCountMode | undefined {
+  return value === 'per-side' || value === 'total' ? value : undefined
+}
+
 /** Keep only the string elements of an array; drop anything else. */
 export function parseStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return []
@@ -101,7 +111,8 @@ export function parseExercise(value: unknown): Exercise | null {
   }
   if (o.inputMode === 'numpad' || o.inputMode === 'plates') ex.inputMode = o.inputMode as ExerciseInputMode
   if (isFiniteNumber(o.barWeight)) ex.barWeight = o.barWeight
-  if (o.plateCountMode === 'per-side' || o.plateCountMode === 'total') ex.plateCountMode = o.plateCountMode as PlateCountMode
+  const plateCountMode = sanitizePlateCountMode(o.plateCountMode)
+  if (plateCountMode) ex.plateCountMode = plateCountMode
   if (o.intensityMaxReps !== undefined) ex.intensityMaxReps = sanitizeIntensityMaxReps(o.intensityMaxReps)
   if (o.equipment !== undefined) {
     const eq = sanitizeExerciseEquipment(o.equipment)

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -85,7 +85,14 @@ const JOURNAL_KEY = 'lift-sync-journal'
 const REPLAYABLE_COLUMNS: Record<string, ReadonlySet<string>> = {
   exercises: new Set([
     'id', 'user_id', 'name', 'tags', 'archived_at',
-    'input_mode', 'bar_weight', 'intensity_max_reps', 'deleted_at',
+    'input_mode', 'bar_weight', 'plate_count_mode', 'intensity_max_reps',
+    // `equipment` (#931) and `gyms` (#961) are always present in the
+    // `_buildExerciseUpsert` row, so an exercise upsert descriptor journaled
+    // for offline replay carries them. They were missing here — meaning every
+    // journaled exercise write was silently rejected on rehydrate() (an empty
+    // subset would never match). Kept in lockstep with the producer per the
+    // note above (LIFT-1039).
+    'equipment', 'gyms', 'deleted_at',
     // Retired in #770 but the DB column still exists (left dormant, never
     // dropped). Tolerated so an offline write journaled by a pre-#770 client
     // still replays after an upgrade instead of being silently dropped.

--- a/src/stores/__tests__/workout.test.ts
+++ b/src/stores/__tests__/workout.test.ts
@@ -1254,4 +1254,52 @@ describe('workout store', () => {
       expect(store.exercises[1].equipment).toBe('machine')
     })
   })
+
+  // ── setExercisePlateCountMode (LIFT-1039) ───────────────────────
+  describe('setExercisePlateCountMode', () => {
+    it('stores the mode and persists it to localStorage', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Dumbbell Press', [])
+      store.setExercisePlateCountMode(id, 'total')
+
+      expect(store.exercises[0].plateCountMode).toBe('total')
+      const persisted = JSON.parse(localStorageMock.getItem('workout-exercises')!)
+      expect(persisted[0].plateCountMode).toBe('total')
+    })
+
+    it('stamps a fresh updated_at so the change wins last-write-wins merges', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Smith Squat', [])
+      // Seed a stale timestamp so the setter's fresh stamp is observably newer,
+      // without depending on sub-millisecond wall-clock resolution.
+      store.exercises[0].updated_at = '2000-01-01T00:00:00.000Z'
+      store.setExercisePlateCountMode(id, 'total')
+      expect(store.exercises[0].updated_at! > '2000-01-01T00:00:00.000Z').toBe(true)
+    })
+
+    it('round-trips through the localStorage boundary', () => {
+      const store = useWorkoutStore()
+      const id = store.addExercise('Leg Press', [])
+      store.setExercisePlateCountMode(id, 'total')
+      setActivePinia(createPinia())
+      const reloaded = useWorkoutStore()
+      expect(reloaded.exercises.find(e => e.id === id)!.plateCountMode).toBe('total')
+    })
+
+    it('drops a corrupt persisted plateCountMode on load', () => {
+      localStorageMock.setItem('workout-exercises', JSON.stringify([
+        { id: 'e1', name: 'Bench', tags: [], sets: [], plateCountMode: 'sideways' },
+        { id: 'e2', name: 'Squat', tags: [], sets: [], plateCountMode: 'total' },
+      ]))
+      setActivePinia(createPinia())
+      const store = useWorkoutStore()
+      expect('plateCountMode' in store.exercises[0]).toBe(false)
+      expect(store.exercises[1].plateCountMode).toBe('total')
+    })
+
+    it('is a no-op for an unknown exercise id', () => {
+      const store = useWorkoutStore()
+      expect(() => store.setExercisePlateCountMode('nope', 'total')).not.toThrow()
+    })
+  })
 })

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -12,7 +12,7 @@ import { epley } from '../lib/epley'
 import { todayISO, setDayKey } from '../lib/dates'
 import { loadJSON, isPlainObject } from '../lib/storage'
 import { persistStoreData, loadStoreData } from '../lib/storePersistence'
-import { parseExercises, parseStringArray, parseNumberRecord } from '../lib/parseGuards'
+import { parseExercises, parseStringArray, parseNumberRecord, sanitizePlateCountMode } from '../lib/parseGuards'
 import { sanitizeIntensityMaxReps } from '../lib/intensityTable'
 import { sanitizeExerciseEquipment, type ExerciseEquipment } from '../lib/coachAnalytics'
 import { sanitizeExerciseGyms } from '../lib/gyms'
@@ -267,6 +267,10 @@ export const useWorkoutStore = defineStore('workout', () => {
       archived_at: exercise.archived_at ?? null,
       ...(exercise.inputMode ? { input_mode: exercise.inputMode } : {}),
       ...(exercise.barWeight != null ? { bar_weight: exercise.barWeight } : {}),
+      // Always send plate_count_mode (null when unset) so switching back to the
+      // 'per-side' default propagates instead of leaving a stale 'total' on the
+      // server (LIFT-1039).
+      plate_count_mode: exercise.plateCountMode ?? null,
       // Always send intensity_max_reps (null when unset) so "reset to default"
       // actually clears the override server-side — omitting it would leave a
       // stale value that re-applies on the next fetch.
@@ -434,6 +438,10 @@ export const useWorkoutStore = defineStore('workout', () => {
       }
       if (ex.input_mode) exercise.inputMode = ex.input_mode as ExerciseInputMode
       if (ex.bar_weight != null) exercise.barWeight = ex.bar_weight
+      if (ex.plate_count_mode != null) {
+        const mode = sanitizePlateCountMode(ex.plate_count_mode)
+        if (mode) exercise.plateCountMode = mode
+      }
       if (ex.intensity_max_reps != null) exercise.intensityMaxReps = sanitizeIntensityMaxReps(ex.intensity_max_reps)
       if (ex.equipment != null) {
         const eq = sanitizeExerciseEquipment(ex.equipment)
@@ -661,9 +669,15 @@ export const useWorkoutStore = defineStore('workout', () => {
   function setExercisePlateCountMode(exerciseId: string, mode: PlateCountMode) {
     const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
     if (!exercise) return
+    if (exercise.sample) _adoptExercise(exercise)
     exercise.plateCountMode = mode
+    exercise.updated_at = new Date().toISOString()
     triggerRef(exercises)
     _persist()
+
+    if (supabase && _userId) {
+      _enqueueExerciseUpsert(exercise, _userId)
+    }
   }
 
   function setExerciseBarWeight(exerciseId: string, barWeight: number) {

--- a/supabase/migrations/20260728010000_add_plate_count_mode_to_exercises.sql
+++ b/supabase/migrations/20260728010000_add_plate_count_mode_to_exercises.sql
@@ -1,0 +1,15 @@
+-- Add plate_count_mode to exercises (LIFT-1039)
+--
+-- Per-exercise plate-counting convention for the plate calculator:
+--   'per-side' → plates are counted per side of the bar (default)
+--   'total'    → plates are counted as the total load (loadable dumbbells,
+--                Smith/machine setups where you add plates at a single point)
+--   NULL       → unset; the client falls back to 'per-side'.
+--
+-- This setting existed on the client `Exercise` model but was only ever
+-- persisted to localStorage — it never synced, so it diverged across devices
+-- (LIFT-1039, split from LIFT-783). A plain text column, same additive pattern
+-- as bar_weight / intensity_max_reps / equipment: existing rows get NULL and
+-- behave exactly as before.
+
+alter table exercises add column if not exists plate_count_mode text;


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1039](https://github.com/aschung212/Lift/issues/1039)

Implement **LIFT-1039** — make the per-exercise `plateCountMode` (plate-calculator per-side vs total convention) sync to Supabase instead of living only in localStorage, which diverged the setting across devices.

## Changes
- **New migration** `supabase/migrations/20260728010000_add_plate_count_mode_to_exercises.sql` — additive `plate_count_mode text` column (same pattern as `bar_weight`/`intensity_max_reps`/`equipment`).
- **`src/lib/database.types.ts`** — added `plate_count_mode: string | null` to the exercises Row/Insert/Update.
- **`src/stores/workout.ts`**:
  - `_buildExerciseUpsert` now always sends `plate_count_mode` (null when unset, so reverting to the `per-side` default propagates).
  - Fetch path maps + sanitizes the column.
  - `setExercisePlateCountMode` now adopts sample exercises, stamps `updated_at`, and enqueues the upsert — it was the only exercise-field setter that silently skipped syncing.
- **`src/lib/parseGuards.ts`** — added a shared `sanitizePlateCountMode` guard, reused at both the localStorage and Supabase boundaries (replacing the inline check).
- **`src/lib/syncQueue.ts`** — fixed latent `REPLAYABLE_COLUMNS.exercises` drift: `equipment` (#931), `gyms` (#961) and the new `plate_count_mode` are always in the journaled exercise upsert row but weren't allowlisted, so **every** journaled exercise write was rejected on `rehydrate()`. Without this, the new column's durable-replay path wouldn't work either.
- **Tests** — store setter (persist/round-trip/updated_at/corrupt-load/no-op), `sanitizePlateCountMode` unit + parse-guard coverage, and a `syncQueueJournal` regression pinning the full-fidelity exercise descriptor as replayable (would have caught the drift).

## Verification
- `npx vitest run` → 2911 passed, 1 skipped.
- `npm run typecheck` → clean; `npm run lint` → clean; `npm run build` → success.
- Post-commit adversarial review: `REVIEW_CLEAN` / `REVIEW_VERDICT:MERGE`.
- `git diff --stat origin/master...HEAD` confirms the branch contains only the 8 LIFT-1039 files.

## Commits
- [`3c2e908`](https://github.com/aschung212/Lift/commit/3c2e908) feat(LIFT-1039): sync per-exercise plateCountMode to Supabase

## Test Results
- Before: 2922 passing
- After: 2932 passing (10 delta)

---
_Automated by overnight pipeline — Tue Jul 28 23:50:24 PDT 2026_

## Preview
Test on your phone: https://lift-hin767nps-aschung212-1101s-projects.vercel.app