### PR TITLE
fix(LIFT-836): allowlist duration/is_duration in the replay journal

### DIFF
--- a/src/lib/__tests__/duration.test.ts
+++ b/src/lib/__tests__/duration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatDuration,
+  parseDurationInput,
+  clampDuration,
+  sanitizeDuration,
+  MAX_DURATION_SECONDS,
+} from '../duration'
+
+describe('formatDuration', () => {
+  it('formats sub-minute durations as 0:SS', () => {
+    expect(formatDuration(0)).toBe('0:00')
+    expect(formatDuration(5)).toBe('0:05')
+    expect(formatDuration(45)).toBe('0:45')
+  })
+
+  it('formats minute:seconds with zero-padded seconds', () => {
+    expect(formatDuration(60)).toBe('1:00')
+    expect(formatDuration(90)).toBe('1:30')
+    expect(formatDuration(605)).toBe('10:05')
+  })
+
+  it('formats durations >= 1h as h:mm:ss', () => {
+    expect(formatDuration(3600)).toBe('1:00:00')
+    expect(formatDuration(3725)).toBe('1:02:05')
+    expect(formatDuration(86399)).toBe('23:59:59')
+  })
+
+  it('coerces negative / non-finite / fractional inputs', () => {
+    expect(formatDuration(-10)).toBe('0:00')
+    expect(formatDuration(Number.NaN)).toBe('0:00')
+    expect(formatDuration(Number.POSITIVE_INFINITY)).toBe('0:00')
+    expect(formatDuration(90.9)).toBe('1:30')
+  })
+})
+
+describe('parseDurationInput', () => {
+  it('parses a bare second count', () => {
+    expect(parseDurationInput('90')).toBe(90)
+    expect(parseDurationInput('0')).toBe(0)
+    expect(parseDurationInput('  45  ')).toBe(45)
+  })
+
+  it('parses m:ss and mm:ss', () => {
+    expect(parseDurationInput('1:30')).toBe(90)
+    expect(parseDurationInput('0:45')).toBe(45)
+    expect(parseDurationInput('10:05')).toBe(605)
+  })
+
+  it('parses h:mm:ss', () => {
+    expect(parseDurationInput('1:00:00')).toBe(3600)
+    expect(parseDurationInput('1:02:05')).toBe(3725)
+  })
+
+  it('rejects out-of-range sexagesimal fields', () => {
+    expect(parseDurationInput('1:90')).toBeNull()
+    expect(parseDurationInput('1:60:00')).toBeNull()
+    expect(parseDurationInput('1:00:75')).toBeNull()
+  })
+
+  it('rejects malformed input', () => {
+    expect(parseDurationInput('')).toBeNull()
+    expect(parseDurationInput('   ')).toBeNull()
+    expect(parseDurationInput('abc')).toBeNull()
+    expect(parseDurationInput('1:')).toBeNull()
+    expect(parseDurationInput(':30')).toBeNull()
+    expect(parseDurationInput('1:2:3:4')).toBeNull()
+    expect(parseDurationInput('1.5')).toBeNull()
+    expect(parseDurationInput('-5')).toBeNull()
+  })
+
+  it('clamps to the max duration', () => {
+    expect(parseDurationInput('999999')).toBe(MAX_DURATION_SECONDS)
+  })
+})
+
+describe('clampDuration', () => {
+  it('clamps into [0, MAX]', () => {
+    expect(clampDuration(-1)).toBe(0)
+    expect(clampDuration(50)).toBe(50)
+    expect(clampDuration(90.7)).toBe(90)
+    expect(clampDuration(1e9)).toBe(MAX_DURATION_SECONDS)
+    expect(clampDuration(Number.NaN)).toBe(0)
+  })
+})
+
+describe('sanitizeDuration', () => {
+  it('accepts positive numbers and numeric strings', () => {
+    expect(sanitizeDuration(90)).toBe(90)
+    expect(sanitizeDuration('120')).toBe(120)
+    expect(sanitizeDuration(90.9)).toBe(90)
+  })
+
+  it('returns null for non-duration values', () => {
+    expect(sanitizeDuration(0)).toBeNull()
+    expect(sanitizeDuration(-5)).toBeNull()
+    expect(sanitizeDuration(null)).toBeNull()
+    expect(sanitizeDuration(undefined)).toBeNull()
+    expect(sanitizeDuration('abc')).toBeNull()
+    expect(sanitizeDuration(Number.NaN)).toBeNull()
+    expect(sanitizeDuration({})).toBeNull()
+  })
+
+  it('clamps to the max', () => {
+    expect(sanitizeDuration(1e9)).toBe(MAX_DURATION_SECONDS)
+  })
+})

--- a/src/lib/__tests__/parseGuards.test.ts
+++ b/src/lib/__tests__/parseGuards.test.ts
@@ -81,6 +81,17 @@ describe('parseWorkoutSet', () => {
     expect(set?.estimated1RM).toBe(100)
   })
 
+  it('preserves a valid duration on a duration set (LIFT-836)', () => {
+    const set = parseWorkoutSet({ id: 's-1', date: '2026-05-01', weight: 0, reps: 0, estimated1RM: 0, duration: 90 })
+    expect(set?.duration).toBe(90)
+  })
+
+  it('drops an invalid duration but keeps the set as a plain weight×reps entry', () => {
+    const set = parseWorkoutSet({ id: 's-1', date: '2026-05-01', weight: 100, reps: 5, estimated1RM: 116, duration: 'oops' })
+    expect(set).not.toBeNull()
+    expect('duration' in set!).toBe(false)
+  })
+
   it('rejects a set missing weight or reps', () => {
     expect(parseWorkoutSet({ id: 's-1', date: '2026-05-01', reps: 5 })).toBeNull()
     expect(parseWorkoutSet({ id: 's-1', date: '2026-05-01', weight: 100 })).toBeNull()
@@ -147,6 +158,16 @@ describe('parseExercise', () => {
   it('drops an unrecognized equipment value', () => {
     const ex = parseExercise({ id: 'ex-1', name: 'Row', tags: [], sets: [], equipment: 'laser-beam' })
     expect(ex!.equipment).toBeUndefined()
+  })
+
+  it('preserves the isDuration flag (LIFT-836)', () => {
+    const ex = parseExercise({ id: 'ex-1', name: 'Plank', tags: [], sets: [], isDuration: true })
+    expect(ex!.isDuration).toBe(true)
+  })
+
+  it('leaves isDuration unset for a normal exercise', () => {
+    const ex = parseExercise({ id: 'ex-1', name: 'Squat', tags: [], sets: [] })
+    expect(ex!.isDuration).toBeUndefined()
   })
 
   // parseExercise builds a fresh object from an allowlist of known fields, so any

--- a/src/lib/__tests__/syncQueueJournal.test.ts
+++ b/src/lib/__tests__/syncQueueJournal.test.ts
@@ -281,6 +281,23 @@ describe('replay allowlist (LIFT-785)', () => {
       })).toBe(true)
     })
 
+    it('accepts a duration set upsert and the is_duration exercise flag (LIFT-836)', () => {
+      // Both new columns are ALWAYS sent by their upserts (duration: null for a
+      // normal set, is_duration: false for a normal exercise), so they must be
+      // allowlisted or EVERY set/exercise descriptor is rejected on rehydrate().
+      expect(isReplayableDescriptor({
+        op: 'upsert', table: 'sets',
+        row: {
+          id: 's1', user_id: 'u1', exercise_id: 'e1', date: '2026-07-20T23:59:30.000Z',
+          weight: 0, reps: 0, estimated_1rm: 0, duration: 90, created_at: '2026-07-20T18:45:00.000Z',
+        },
+      })).toBe(true)
+      expect(isReplayableDescriptor({
+        op: 'upsert', table: 'exercises',
+        row: { id: 'e1', user_id: 'u1', name: 'Plank', is_duration: true },
+      })).toBe(true)
+    })
+
     it('tolerates retired-but-dormant DB columns so legacy offline writes still replay', () => {
       // warmup_scheme was retired in #770 but the column still exists in the DB.
       // An offline write journaled by a pre-#770 client must not be dropped.

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -77,6 +77,7 @@ export type Database = {
           id: string
           input_mode: string | null
           intensity_max_reps: number | null
+          is_duration: boolean | null
           name: string
           tags: string[]
           updated_at: string | null
@@ -93,6 +94,7 @@ export type Database = {
           id?: string
           input_mode?: string | null
           intensity_max_reps?: number | null
+          is_duration?: boolean | null
           name: string
           tags?: string[]
           updated_at?: string | null
@@ -109,6 +111,7 @@ export type Database = {
           id?: string
           input_mode?: string | null
           intensity_max_reps?: number | null
+          is_duration?: boolean | null
           name?: string
           tags?: string[]
           updated_at?: string | null
@@ -161,6 +164,7 @@ export type Database = {
           created_at: string
           date: string
           deleted_at: string | null
+          duration: number | null
           estimated_1rm: number
           exercise_id: string
           id: string
@@ -173,6 +177,7 @@ export type Database = {
           created_at?: string
           date: string
           deleted_at?: string | null
+          duration?: number | null
           estimated_1rm: number
           exercise_id: string
           id?: string
@@ -185,6 +190,7 @@ export type Database = {
           created_at?: string
           date?: string
           deleted_at?: string | null
+          duration?: number | null
           estimated_1rm?: number
           exercise_id?: string
           id?: string

--- a/src/lib/duration.ts
+++ b/src/lib/duration.ts
@@ -1,0 +1,92 @@
+/**
+ * Duration-set helpers (LIFT-836).
+ *
+ * Timed strength movements (planks, dead hangs, loaded carries, isometric
+ * holds) are logged as a number of SECONDS rather than weight × reps. This
+ * module is the single source of truth for turning that raw second count into a
+ * display string and for parsing the user's typed input back into seconds.
+ *
+ * Storage convention: a duration set stores its seconds in `WorkoutSet.duration`
+ * and carries `weight`/`reps`/`estimated1RM` as 0 so it is naturally excluded
+ * from 1RM/PR math (which maxes over `estimated1RM`). See docs / CLAUDE.md.
+ *
+ * Everything here is pure and side-effect free.
+ */
+
+/** 23:59:59 — a single set longer than a day is a typo, not a hold. */
+export const MAX_DURATION_SECONDS = 86399
+
+/**
+ * Format a second count as a compact clock string:
+ *   45      → "0:45"
+ *   90      → "1:30"
+ *   3600    → "1:00:00"
+ *   3725    → "1:02:05"
+ * Minutes/seconds are zero-padded; the leading unit is not. Negative,
+ * non-finite, or fractional inputs are coerced to a sane non-negative integer.
+ */
+export function formatDuration(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) totalSeconds = 0
+  const s = Math.floor(totalSeconds)
+  const hours = Math.floor(s / 3600)
+  const minutes = Math.floor((s % 3600) / 60)
+  const seconds = s % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  if (hours > 0) return `${hours}:${pad(minutes)}:${pad(seconds)}`
+  return `${minutes}:${pad(seconds)}`
+}
+
+/**
+ * Parse a user-typed duration into whole seconds, or `null` when the input
+ * can't be read as a duration. Accepts:
+ *   - bare seconds:            "90"     → 90
+ *   - m:ss / mm:ss:            "1:30"   → 90
+ *   - h:mm:ss:                 "1:02:05"→ 3725
+ * Colon-separated minute/second fields must be in [0, 59]; a bare number is
+ * treated as a raw second count. The result is clamped to
+ * [0, MAX_DURATION_SECONDS]. Empty/whitespace input returns `null`.
+ */
+export function parseDurationInput(raw: string): number | null {
+  const str = raw.trim()
+  if (str === '') return null
+
+  if (str.includes(':')) {
+    const parts = str.split(':')
+    if (parts.length < 2 || parts.length > 3) return null
+    const nums: number[] = []
+    for (const part of parts) {
+      if (!/^\d+$/.test(part)) return null
+      nums.push(Number(part))
+    }
+    // The seconds field, and the minutes field when hours are present, must be
+    // a valid sexagesimal digit — "1:90" is a mistype, not 150 seconds.
+    const seconds = nums[nums.length - 1]
+    const minutes = nums[nums.length - 2]
+    if (seconds > 59) return null
+    if (nums.length === 3 && minutes > 59) return null
+    let total = 0
+    for (const n of nums) total = total * 60 + n
+    return clampDuration(total)
+  }
+
+  if (!/^\d+$/.test(str)) return null
+  return clampDuration(Number(str))
+}
+
+/** Clamp a raw second count into the valid stored range. */
+export function clampDuration(seconds: number): number {
+  if (!Number.isFinite(seconds) || seconds < 0) return 0
+  return Math.min(MAX_DURATION_SECONDS, Math.floor(seconds))
+}
+
+/**
+ * Boundary sanitizer for a persisted/synced `duration` value (localStorage or
+ * Supabase). Returns a valid positive second count, or `null` for anything that
+ * isn't a usable duration (missing, zero, negative, non-finite, non-numeric) —
+ * so a set only counts as a duration set when it carries a real hold time.
+ */
+export function sanitizeDuration(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+  if (!Number.isFinite(n) || n <= 0) return null
+  return clampDuration(n)
+}

--- a/src/lib/parseGuards.ts
+++ b/src/lib/parseGuards.ts
@@ -18,6 +18,7 @@ import type { Exercise, WorkoutSet, ExerciseInputMode, PlateCountMode } from '..
 import type { BodyweightEntry } from '../stores/bodyweight'
 import { epley } from './epley'
 import { sanitizeIntensityMaxReps } from './intensityTable'
+import { sanitizeDuration } from './duration'
 import { sanitizeExerciseEquipment } from './coachAnalytics'
 import { sanitizeExerciseGyms } from './gyms'
 import { logWarn } from './logger'
@@ -69,6 +70,11 @@ export function parseWorkoutSet(value: unknown): WorkoutSet | null {
     reps: o.reps,
     estimated1RM: isFiniteNumber(o.estimated1RM) ? o.estimated1RM : epley(o.weight, o.reps),
   }
+  // Duration-mode sets (LIFT-836). sanitizeDuration returns null for anything
+  // that isn't a real positive hold time, so a bad value simply degrades the
+  // set to a plain weight×reps entry rather than dropping it.
+  const duration = sanitizeDuration(o.duration)
+  if (duration !== null) set.duration = duration
   if (typeof o.createdAt === 'string') set.createdAt = o.createdAt
   return set
 }
@@ -103,6 +109,7 @@ export function parseExercise(value: unknown): Exercise | null {
   if (isFiniteNumber(o.barWeight)) ex.barWeight = o.barWeight
   if (o.plateCountMode === 'per-side' || o.plateCountMode === 'total') ex.plateCountMode = o.plateCountMode as PlateCountMode
   if (o.intensityMaxReps !== undefined) ex.intensityMaxReps = sanitizeIntensityMaxReps(o.intensityMaxReps)
+  if (o.isDuration === true) ex.isDuration = true
   if (o.equipment !== undefined) {
     const eq = sanitizeExerciseEquipment(o.equipment)
     if (eq) ex.equipment = eq

--- a/src/lib/syncQueue.ts
+++ b/src/lib/syncQueue.ts
@@ -86,6 +86,9 @@ const REPLAYABLE_COLUMNS: Record<string, ReadonlySet<string>> = {
   exercises: new Set([
     'id', 'user_id', 'name', 'tags', 'archived_at',
     'input_mode', 'bar_weight', 'intensity_max_reps', 'deleted_at',
+    // Duration/time-based exercise flag (LIFT-836), always sent by the exercise
+    // upsert — must be allowlisted or every journaled exercise write is dropped.
+    'is_duration',
     // Retired in #770 but the DB column still exists (left dormant, never
     // dropped). Tolerated so an offline write journaled by a pre-#770 client
     // still replays after an upgrade instead of being silently dropped.
@@ -100,6 +103,11 @@ const REPLAYABLE_COLUMNS: Record<string, ReadonlySet<string>> = {
     // descriptor is dropped on rehydrate() — defeating the durable queue for the
     // exact offline-then-sync case it exists for.
     'created_at',
+    // Seconds held for a duration set (LIFT-836), always sent by the set upsert
+    // (null for weight×reps). Same allowlist requirement as created_at above —
+    // without it isAllowedColumnMap rejects EVERY set descriptor, silently
+    // dropping all journaled offline set writes on rehydrate().
+    'duration',
   ]),
 }
 

--- a/src/stores/__tests__/workoutDuration.test.ts
+++ b/src/stores/__tests__/workoutDuration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * LIFT-836 — duration/time-based set support at the store boundary.
+ *
+ * Duration exercises (planks, dead hangs, loaded carries, isometric holds) log
+ * a number of SECONDS held instead of weight × reps. This suite pins the store
+ * contract:
+ *   - logDurationSet stores `duration` and zeroes weight/reps/estimated1RM
+ *   - a duration set is excluded from getExercisePR (estimated1RM is 0)
+ *   - addExercise({ isDuration }) and setExerciseIsDuration flip the flag, and
+ *     the exercise upsert row always carries is_duration
+ *   - the set upsert row carries duration; a normal set sends duration: null
+ *   - duration round-trips through localStorage and the Supabase fetch mapping
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { getLocalStorageMock } from '../../__tests__/helpers'
+
+const localStorageMock = getLocalStorageMock()
+
+let mockExercises: Record<string, unknown>[] = []
+let mockSets: Record<string, unknown>[] = []
+
+vi.mock('../../lib/supabase', () => {
+  function resolvingChain(getData: () => Record<string, unknown>[]): Record<string, unknown> {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      is: () => chain,
+      order: () => chain,
+      upsert: () => Promise.resolve({ error: null }),
+      then: (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+        Promise.resolve({ data: getData(), error: null }).then(resolve, reject),
+    }
+    return chain
+  }
+  return {
+    supabase: {
+      from: (table: string) =>
+        resolvingChain(() => (table === 'sets' ? mockSets : mockExercises)),
+    },
+    isPreviewMode: { value: false },
+  }
+})
+
+vi.mock('../../lib/syncQueue', () => ({
+  syncQueue: { enqueue: vi.fn(), enqueueDelete: vi.fn(), clear: vi.fn(), rehydrate: vi.fn() },
+}))
+
+vi.mock('../../lib/logger', () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}))
+
+import { useWorkoutStore } from '../workout'
+import { syncQueue } from '../../lib/syncQueue'
+
+/** Most recent journaled upsert descriptor row for a table + id. */
+function upsertRow(table: 'sets' | 'exercises', id: string): Record<string, unknown> | undefined {
+  const enqueue = syncQueue.enqueue as unknown as { mock: { calls: unknown[][] } }
+  let row: Record<string, unknown> | undefined
+  for (const call of enqueue.mock.calls) {
+    const descriptor = call[2] as { table?: string; row?: Record<string, unknown> } | undefined
+    if (descriptor?.table === table && descriptor.row?.id === id) row = descriptor.row
+  }
+  return row
+}
+
+describe('LIFT-836 duration sets', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+    mockExercises = []
+    mockSets = []
+    vi.clearAllMocks()
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('logDurationSet stores seconds and zeroes weight/reps/estimated1RM', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Plank', [], { isDuration: true })!
+    store.logDurationSet(id, 90, '2026-07-20')
+
+    const set = store.exercises[0].sets[0]
+    expect(set.duration).toBe(90)
+    expect(set.weight).toBe(0)
+    expect(set.reps).toBe(0)
+    expect(set.estimated1RM).toBe(0)
+    expect(set.date).toMatch(/^2026-07-20T23:59:/)
+  })
+
+  it('clamps and rejects invalid durations', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Dead Hang', [], { isDuration: true })!
+    store.logDurationSet(id, 0) // rejected
+    store.logDurationSet(id, -5) // rejected
+    expect(store.exercises[0].sets).toHaveLength(0)
+    store.logDurationSet(id, 999999) // clamped to max
+    expect(store.exercises[0].sets[0].duration).toBe(86399)
+  })
+
+  it('excludes a duration set from getExercisePR', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Weighted Plank', [], { isDuration: true })!
+    store.logDurationSet(id, 120)
+    expect(store.getExercisePR(id)).toBe(0)
+  })
+
+  it('addExercise({ isDuration }) sets the flag and the upsert carries is_duration', async () => {
+    const store = useWorkoutStore()
+    await store.init('user-1')
+    const id = store.addExercise('Farmer Carry', [], { isDuration: true })!
+    expect(store.exercises[0].isDuration).toBe(true)
+    const row = upsertRow('exercises', id)
+    expect(row!.is_duration).toBe(true)
+  })
+
+  it('setExerciseIsDuration toggles the flag and clears it on false', async () => {
+    const store = useWorkoutStore()
+    await store.init('user-1')
+    const id = store.addExercise('Hold')!
+    store.setExerciseIsDuration(id, true)
+    expect(store.exercises[0].isDuration).toBe(true)
+    store.setExerciseIsDuration(id, false)
+    expect(store.exercises[0].isDuration).toBeUndefined()
+    expect(upsertRow('exercises', id)!.is_duration).toBe(false)
+  })
+
+  it('duration set upsert row carries duration; a normal set sends null', async () => {
+    const store = useWorkoutStore()
+    await store.init('user-1')
+    const durId = store.addExercise('Plank', [], { isDuration: true })!
+    store.logDurationSet(durId, 60)
+    const durSetId = store.exercises.find(e => e.id === durId)!.sets[0].id
+    expect(upsertRow('sets', durSetId)!.duration).toBe(60)
+
+    const wtId = store.addExercise('Squat')!
+    store.logSet(wtId, 225, 5)
+    const wtSetId = store.exercises.find(e => e.id === wtId)!.sets[0].id
+    expect(upsertRow('sets', wtSetId)!.duration).toBeNull()
+  })
+
+  it('round-trips duration + isDuration through localStorage', () => {
+    const store = useWorkoutStore()
+    const id = store.addExercise('Plank', [], { isDuration: true })!
+    store.logDurationSet(id, 75)
+
+    setActivePinia(createPinia())
+    const reloaded = useWorkoutStore()
+    expect(reloaded.exercises[0].isDuration).toBe(true)
+    expect(reloaded.exercises[0].sets[0].duration).toBe(75)
+  })
+
+  it('surfaces sets.duration and exercises.is_duration from the fetch', async () => {
+    mockExercises = [
+      { id: 'ex-1', name: 'Plank', tags: [], is_duration: true, created_at: '2026-06-20T00:00:00.000Z', updated_at: '2026-06-20T00:00:00.000Z', deleted_at: null },
+    ]
+    mockSets = [
+      { id: 's-1', exercise_id: 'ex-1', date: '2026-06-20T23:59:30.000Z', weight: 0, reps: 0, estimated_1rm: 0, duration: 90, created_at: '2026-06-20T18:45:00.000Z', deleted_at: null },
+    ]
+    const store = useWorkoutStore()
+    await store.init('user-1')
+    const ex = store.exercises.find(e => e.id === 'ex-1')!
+    expect(ex.isDuration).toBe(true)
+    expect(ex.sets[0].duration).toBe(90)
+  })
+})

--- a/src/stores/workout.ts
+++ b/src/stores/workout.ts
@@ -14,6 +14,7 @@ import { loadJSON, isPlainObject } from '../lib/storage'
 import { persistStoreData, loadStoreData } from '../lib/storePersistence'
 import { parseExercises, parseStringArray, parseNumberRecord } from '../lib/parseGuards'
 import { sanitizeIntensityMaxReps } from '../lib/intensityTable'
+import { sanitizeDuration } from '../lib/duration'
 import { sanitizeExerciseEquipment, type ExerciseEquipment } from '../lib/coachAnalytics'
 import { sanitizeExerciseGyms } from '../lib/gyms'
 import { isAuthError, ensureFreshSession } from '../lib/sessionHealth'
@@ -29,6 +30,13 @@ export interface WorkoutSet {
   weight: number
   reps: number
   estimated1RM: number
+  /**
+   * Seconds held, for duration/time-based exercises (planks, dead hangs, loaded
+   * carries, isometric holds) (LIFT-836). Present only on sets of a
+   * duration-mode exercise; `weight`/`reps`/`estimated1RM` are then 0 so the set
+   * is naturally excluded from 1RM/PR math (which maxes over `estimated1RM`).
+   */
+  duration?: number
   /**
    * Real timestamp the set was logged (ISO 8601), distinct from `date` (which is
    * stamped end-of-day and carries no time). Optional and currently unpopulated —
@@ -52,6 +60,7 @@ export interface Exercise {
   barWeight?: number               // bar weight in lbs, default 45
   plateCountMode?: PlateCountMode  // how plates are counted, default 'per-side'
   intensityMaxReps?: number        // rep rows shown in the Intensity lens; undefined = default (10) (#770)
+  isDuration?: boolean             // true = time-based sets (seconds held) instead of weight×reps (LIFT-836)
   equipment?: ExerciseEquipment    // explicit Coach classification; undefined = name heuristic (#931 phase C)
   gyms?: string[]                  // gym membership; empty/undefined = shows under every gym filter (#961)
   updated_at?: string              // ISO 8601, used for last-write-wins merge
@@ -275,6 +284,9 @@ export const useWorkoutStore = defineStore('workout', () => {
       equipment: exercise.equipment ?? null,
       // Same always-send rule: clearing gym membership must propagate (#961).
       gyms: exercise.gyms ?? [],
+      // Always send is_duration (LIFT-836) — a duration exercise reverting to
+      // weight×reps must clear server-side, same rationale as intensity_max_reps.
+      is_duration: exercise.isDuration ?? false,
     }
   }
 
@@ -305,7 +317,7 @@ export const useWorkoutStore = defineStore('workout', () => {
 
   /** Durable set upsert with a journaled descriptor (LIFT-706). */
   function _enqueueSetUpsert(
-    set: { id: string; date: string; weight: number; reps: number; estimated1RM: number; createdAt?: string },
+    set: { id: string; date: string; weight: number; reps: number; estimated1RM: number; duration?: number; createdAt?: string },
     exerciseId: string,
     userId: string,
   ) {
@@ -313,6 +325,9 @@ export const useWorkoutStore = defineStore('workout', () => {
       id: set.id, user_id: userId, exercise_id: exerciseId,
       date: set.date, weight: set.weight, reps: set.reps,
       estimated_1rm: set.estimated1RM,
+      // Seconds held for a duration-mode set; null for a normal weight×reps set
+      // so switching an exercise's mode clears any stale value server-side (LIFT-836).
+      duration: set.duration ?? null,
       // Persist the real log-time timestamp so an offline set logged at 6pm but
       // synced hours later keeps its training time instead of the DB insert-time
       // default (#846). Omitted when absent so editing a legacy set (no local
@@ -443,6 +458,7 @@ export const useWorkoutStore = defineStore('workout', () => {
         const gyms = sanitizeExerciseGyms(ex.gyms)
         if (gyms.length > 0) exercise.gyms = gyms
       }
+      if (ex.is_duration) exercise.isDuration = true
       if (ex.archived_at) exercise.archived_at = ex.archived_at
       return exercise
     })
@@ -459,7 +475,7 @@ export const useWorkoutStore = defineStore('workout', () => {
       }
       const exerciseId = s.exercise_id
       if (!remoteSetsMap.has(exerciseId)) remoteSetsMap.set(exerciseId, [])
-      remoteSetsMap.get(exerciseId)!.push({
+      const mappedSet: WorkoutSet = {
         id: s.id,
         date: s.date,
         weight: s.weight,
@@ -468,7 +484,10 @@ export const useWorkoutStore = defineStore('workout', () => {
         // Surface the server insert timestamp so historical/synced sets carry a
         // real time-of-day + within-workout order for the AI Coach payload (#846).
         createdAt: s.created_at,
-      })
+      }
+      const dur = sanitizeDuration(s.duration)
+      if (dur !== null) mappedSet.duration = dur
+      remoteSetsMap.get(exerciseId)!.push(mappedSet)
     }
     remoteExercises.forEach(ex => {
       ex.sets = remoteSetsMap.get(ex.id) || []
@@ -637,7 +656,7 @@ export const useWorkoutStore = defineStore('workout', () => {
   function addExercise(
     name: string,
     tags: string[] = [],
-    { sync = true, gyms = [] }: { sync?: boolean; gyms?: string[] } = {},
+    { sync = true, gyms = [], isDuration = false }: { sync?: boolean; gyms?: string[]; isDuration?: boolean } = {},
   ): string | null {
     const trimmed = name.trim()
     if (!trimmed) return null
@@ -647,7 +666,7 @@ export const useWorkoutStore = defineStore('workout', () => {
     if (existing) return existing.id
     const id = uuid()
     const sanitizedGyms = sanitizeExerciseGyms(gyms)
-    const exercise: Exercise = { id, name: trimmed, tags: [...tags], sets: [], updated_at: new Date().toISOString(), ...(sanitizedGyms.length > 0 ? { gyms: sanitizedGyms } : {}), ...(!sync ? { sample: true } : {}) }
+    const exercise: Exercise = { id, name: trimmed, tags: [...tags], sets: [], updated_at: new Date().toISOString(), ...(sanitizedGyms.length > 0 ? { gyms: sanitizedGyms } : {}), ...(isDuration ? { isDuration: true } : {}), ...(!sync ? { sample: true } : {}) }
     exercises.value.push(exercise)
     triggerRef(exercises)
     _persist()
@@ -759,6 +778,27 @@ export const useWorkoutStore = defineStore('workout', () => {
     }
   }
 
+  /**
+   * Flip an exercise between weight×reps and duration/time-based logging (LIFT-836).
+   * Stored only when true; `false` deletes the field so the default (weight mode)
+   * applies again. Existing sets are left untouched — a mode change only affects
+   * how new sets are logged and how the list renders.
+   */
+  function setExerciseIsDuration(exerciseId: string, isDuration: boolean) {
+    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
+    if (!exercise) return
+    if (exercise.sample) _adoptExercise(exercise)
+    if (isDuration) exercise.isDuration = true
+    else delete exercise.isDuration
+    exercise.updated_at = new Date().toISOString()
+    triggerRef(exercises)
+    _persist()
+
+    if (supabase && _userId) {
+      _enqueueExerciseUpsert(exercise, _userId)
+    }
+  }
+
   function logSet(exerciseId: string, weight: number, reps: number, dateStr?: string, { sync = true }: { sync?: boolean } = {}) {
     const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
     if (!exercise) return
@@ -785,6 +825,32 @@ export const useWorkoutStore = defineStore('workout', () => {
 
     if (sync && supabase && !isPreviewMode.value && _userId) {
       _enqueueSetUpsert({ id, date, weight, reps, estimated1RM, createdAt }, exerciseId, _userId)
+    }
+  }
+
+  /**
+   * Log a duration/time-based set (planks, holds, carries) (LIFT-836). Stores
+   * the held seconds in `duration` and carries weight/reps/estimated1RM as 0 so
+   * the set is excluded from 1RM/PR math. Mirrors `logSet`'s date-stamping,
+   * sample-adoption and durable-upsert behavior.
+   */
+  function logDurationSet(exerciseId: string, durationSeconds: number, dateStr?: string, { sync = true }: { sync?: boolean } = {}) {
+    const exercise = exercises.value.find((e: Exercise) => e.id === exerciseId)
+    if (!exercise) return
+    const seconds = sanitizeDuration(durationSeconds)
+    if (seconds === null) return
+    const wasAdopted = sync && !!exercise.sample
+    if (wasAdopted) _adoptExercise(exercise)
+    const date = dateStr ? endOfDayISO(dateStr) : new Date().toISOString()
+    const id = uuid()
+    const createdAt = new Date().toISOString()
+    exercise.sets.push({ id, date, weight: 0, reps: 0, estimated1RM: 0, duration: seconds, createdAt })
+    exercise.updated_at = new Date().toISOString()
+    triggerRef(exercises)
+    _persist()
+
+    if (sync && supabase && !isPreviewMode.value && _userId) {
+      _enqueueSetUpsert({ id, date, weight: 0, reps: 0, estimated1RM: 0, duration: seconds, createdAt }, exerciseId, _userId)
     }
   }
 
@@ -1509,7 +1575,9 @@ export const useWorkoutStore = defineStore('workout', () => {
     setExerciseIntensityMaxReps,
     setExerciseEquipment,
     setExerciseGyms,
+    setExerciseIsDuration,
     logSet,
+    logDurationSet,
     updateSet,
     deleteSet,
     restoreSet,

--- a/supabase/migrations/20260729000000_add_duration_set_type.sql
+++ b/supabase/migrations/20260729000000_add_duration_set_type.sql
@@ -1,0 +1,20 @@
+-- Add duration/time-based set support (LIFT-836)
+--
+-- Timed strength movements (planks, dead hangs, loaded carries, isometric
+-- holds) are logged as a number of SECONDS held rather than weight × reps.
+-- Two additive columns support this:
+--
+--   sets.duration          integer  — seconds held for a duration-mode set.
+--                                      NULL for a normal weight×reps set, so
+--                                      switching an exercise's mode clears any
+--                                      stale value. A set with a duration carries
+--                                      weight/reps/estimated_1rm as 0, so it is
+--                                      naturally excluded from 1RM/PR math.
+--   exercises.is_duration  boolean  — the exercise logs time-based sets.
+--                                      NULL/false = default weight×reps mode.
+--
+-- Purely additive: every existing query keeps working, and the NULL defaults
+-- mean existing rows behave exactly as before.
+
+alter table sets add column if not exists duration integer;
+alter table exercises add column if not exists is_duration boolean;


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-836](https://github.com/aschung212/Lift/issues/836)



## Changes




## Commits
- [`4d18ac9`](https://github.com/aschung212/Lift/commit/4d18ac9) fix(LIFT-836): allowlist duration/is_duration in the replay journal
- [`12d9aaa`](https://github.com/aschung212/Lift/commit/12d9aaa) feat(LIFT-836): add duration/time-based set data layer

## Test Results
- Before: 2901 passing
- After: 2928 passing (27 delta)

---
_Automated by overnight pipeline — Wed Jul 29 02:01:10 PDT 2026_

## Preview
Test on your phone: https://lift-jz4eczu49-aschung212-1101s-projects.vercel.app