### PR TITLE
test(LIFT-1049): verify generated SW behavior, not config source text

### DIFF
--- a/src/lib/__tests__/launchScreens.test.ts
+++ b/src/lib/__tests__/launchScreens.test.ts
@@ -4,6 +4,7 @@ import { readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
 // @ts-expect-error - plain JS generator script, no type declarations
 import { DEVICES } from '../../../scripts/generate-launch-screens.js'
+import { workboxOptions } from '../../../vite-plugin-pwa-config'
 
 /**
  * Regression tests for iOS PWA launch screens (apple-touch-startup-image).
@@ -77,7 +78,6 @@ describe('iOS launch screen (apple-touch-startup-image) regression tests', () =>
   })
 
   it('excludes launch screens from the Workbox precache (loaded by Safari, not the app)', () => {
-    const viteConfig = readFileSync(resolve(root, 'vite.config.js'), 'utf-8')
-    expect(viteConfig).toContain("'launch/*.png'")
+    expect(workboxOptions.globIgnores).toContain('launch/*.png')
   })
 })

--- a/src/lib/__tests__/manifestRegression.test.ts
+++ b/src/lib/__tests__/manifestRegression.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { resolve } from 'path'
+import { workboxOptions } from '../../../vite-plugin-pwa-config'
 
 /**
  * Regression tests for PWA manifest configuration.
@@ -9,6 +10,10 @@ import { resolve } from 'path'
  * Validates that the vite.config.js manifest includes required fields
  * for a richer PWA install experience (screenshots, categories) and
  * that referenced screenshot assets exist in public/.
+ *
+ * Manifest fields live inline in vite.config.js (asserted via source text);
+ * the Workbox service-worker config lives in ../../../vite-plugin-pwa-config.ts
+ * and is asserted against the exported object.
  */
 
 const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), 'utf-8')
@@ -95,11 +100,12 @@ describe('PWA manifest regression tests', () => {
 
   describe('workbox includes navigateFallback for offline navigation', () => {
     it('has navigateFallback set to index.html', () => {
-      expect(viteConfig).toContain("navigateFallback: 'index.html'")
+      expect(workboxOptions.navigateFallback).toBe('index.html')
     })
 
     it('has navigateFallbackDenylist to exclude API routes', () => {
-      expect(viteConfig).toContain('navigateFallbackDenylist:')
+      expect(Array.isArray(workboxOptions.navigateFallbackDenylist)).toBe(true)
+      expect(workboxOptions.navigateFallbackDenylist.length).toBeGreaterThan(0)
     })
 
     it('offline.html exists in public/', () => {
@@ -109,7 +115,7 @@ describe('PWA manifest regression tests', () => {
 
   describe('workbox enables navigation preload for faster navigations', () => {
     it('has navigationPreload: true in workbox config', () => {
-      expect(viteConfig).toContain('navigationPreload: true')
+      expect(workboxOptions.navigationPreload).toBe(true)
     })
   })
 
@@ -139,23 +145,23 @@ describe('PWA manifest regression tests', () => {
 
   describe('workbox globIgnores excludes non-essential large assets from precache', () => {
     it('excludes screenshot PNGs from precache', () => {
-      expect(viteConfig).toContain("'screenshot-*.png'")
+      expect(workboxOptions.globIgnores).toContain('screenshot-*.png')
     })
 
     it('excludes og-image.png from precache', () => {
-      expect(viteConfig).toContain("'og-image.png'")
+      expect(workboxOptions.globIgnores).toContain('og-image.png')
     })
 
     it('excludes icon-source.png from precache', () => {
-      expect(viteConfig).toContain("'icon-source.png'")
+      expect(workboxOptions.globIgnores).toContain('icon-source.png')
     })
 
     it('excludes og-preview.html from precache', () => {
-      expect(viteConfig).toContain("'og-preview.html'")
+      expect(workboxOptions.globIgnores).toContain('og-preview.html')
     })
 
     it('has globIgnores array in workbox config', () => {
-      expect(viteConfig).toContain('globIgnores:')
+      expect(Array.isArray(workboxOptions.globIgnores)).toBe(true)
     })
   })
 })

--- a/src/lib/__tests__/swBuildOutput.test.ts
+++ b/src/lib/__tests__/swBuildOutput.test.ts
@@ -1,0 +1,107 @@
+/// <reference types="node" />
+// @vitest-environment node
+import { describe, it, expect, beforeAll } from 'vitest'
+import { generateSW } from 'workbox-build'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { workboxOptions } from '../../../vite-plugin-pwa-config'
+
+/**
+ * Behavioral build-output test for the service worker.
+ *
+ * `workboxCacheRegression.test.ts` asserts the *shape* of the config object;
+ * this test asserts the config actually produces a working service worker. It
+ * runs the same `workbox-build` `generateSW` step VitePWA runs at build time —
+ * feeding it the real, shared `workboxOptions` — and inspects the generated
+ * `sw.js` source. This catches failures the config-shape tests can't:
+ *   - a Workbox version bump that changes/breaks code generation,
+ *   - a config field that is silently dropped or renamed by Workbox,
+ *   - a navigation fallback that never registers a NavigationRoute,
+ *   - a runtime cache whose route is never actually registered.
+ *
+ * We assert on substrings that survive minification (string-literal cache names
+ * and the un-mangled Workbox API property names), so the test is robust to
+ * production vs development output and to formatting changes.
+ */
+
+let sw = ''
+
+beforeAll(async () => {
+  // A minimal glob directory: generateSW precaches whatever it globs here.
+  // index.html must exist so `navigateFallback: 'index.html'` resolves to a
+  // real precache entry (Workbox otherwise warns/omits the fallback).
+  const dir = mkdtempSync(join(tmpdir(), 'lift-sw-'))
+  writeFileSync(join(dir, 'index.html'), '<!doctype html><title>Lift</title>')
+  const swDest = join(dir, 'sw.js')
+
+  try {
+    await generateSW({
+      ...workboxOptions,
+      globDirectory: dir,
+      swDest,
+      // Mirror the real production build so we verify the artifact that ships,
+      // not a dev-mode variant.
+      mode: 'production',
+    })
+    sw = readFileSync(swDest, 'utf-8')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}, 60000)
+
+describe('generated service worker (workbox-build output)', () => {
+  it('emits a non-empty service worker', () => {
+    expect(sw.length).toBeGreaterThan(0)
+  })
+
+  describe('runtime cache routes are registered', () => {
+    it('registers routes for every configured cache', () => {
+      for (const name of [
+        'supabase-sets',
+        'supabase-exercises',
+        'supabase-bodyweight',
+        'supabase-progression',
+        'supabase-api',
+        'supabase-auth',
+      ]) {
+        expect(sw).toContain(name)
+      }
+    })
+
+    it('uses StaleWhileRevalidate for the sets cache', () => {
+      expect(sw).toContain('StaleWhileRevalidate')
+    })
+
+    it('uses NetworkFirst for the exercises/api caches', () => {
+      expect(sw).toContain('NetworkFirst')
+    })
+
+    it('keeps auth as NetworkOnly (tokens never cached)', () => {
+      expect(sw).toContain('NetworkOnly')
+    })
+
+    it('actually calls registerRoute to wire the caches up', () => {
+      expect(sw).toContain('registerRoute')
+    })
+  })
+
+  describe('navigation fallback', () => {
+    it('registers a NavigationRoute bound to index.html', () => {
+      expect(sw).toContain('NavigationRoute')
+      expect(sw).toContain('createHandlerBoundToURL')
+      expect(sw).toContain('index.html')
+    })
+
+    it('carries the /api denylist so it does not intercept those paths', () => {
+      expect(sw).toContain('/^\\/api\\//')
+    })
+  })
+
+  describe('precache', () => {
+    it('precaches index.html so the SPA shell loads offline', () => {
+      expect(sw).toContain('precacheAndRoute')
+      expect(sw).toContain('index.html')
+    })
+  })
+})

--- a/src/lib/__tests__/workboxCacheRegression.test.ts
+++ b/src/lib/__tests__/workboxCacheRegression.test.ts
@@ -1,87 +1,90 @@
-/// <reference types="node" />
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import {
+  runtimeCaching,
+  workboxOptions,
+} from '../../../vite-plugin-pwa-config'
 
 /**
  * Regression tests for Workbox runtime cache configuration.
  *
- * Validates that endpoint-specific caches are defined with appropriate
- * strategies and capacities. Prevents regression to a single catch-all
- * cache that would evict entries for power users with large datasets.
+ * These assert against the exported config *object* (the single source of truth
+ * that `vite.config.js` and the SW build both consume), not a string-slice of
+ * the config file. They are the cheap first line: they prove the config is
+ * shaped correctly. `swBuildOutput.test.ts` complements them by proving that
+ * this config actually produces a working service worker.
+ *
+ * Purpose: prevent regression to a single catch-all cache that would evict
+ * entries for power users with large datasets, and keep the endpoint-specific
+ * strategies/capacities/ordering intact.
  */
 
-const viteConfig = readFileSync(resolve(__dirname, '../../../vite.config.js'), 'utf-8')
+/** Find the rule whose cacheName matches. */
+const ruleFor = (cacheName: string) =>
+  runtimeCaching.find((r) => r.options?.cacheName === cacheName)
 
 describe('Workbox runtime cache configuration', () => {
   describe('endpoint-specific caches exist', () => {
     it('has a dedicated sets cache with StaleWhileRevalidate strategy', () => {
-      expect(viteConfig).toContain("cacheName: 'supabase-sets'")
+      const rule = ruleFor('supabase-sets')
+      expect(rule).toBeDefined()
       // StaleWhileRevalidate: fast offline load + background refresh for new sets
-      const setsSection = viteConfig.slice(
-        viteConfig.indexOf("cacheName: 'supabase-sets'") - 200,
-        viteConfig.indexOf("cacheName: 'supabase-sets'") + 100
-      )
-      expect(setsSection).toContain("handler: 'StaleWhileRevalidate'")
+      expect(rule?.handler).toBe('StaleWhileRevalidate')
     })
 
     it('has a dedicated exercises cache with NetworkFirst strategy', () => {
-      expect(viteConfig).toContain("cacheName: 'supabase-exercises'")
-      const exercisesSection = viteConfig.slice(
-        viteConfig.indexOf("cacheName: 'supabase-exercises'") - 200,
-        viteConfig.indexOf("cacheName: 'supabase-exercises'") + 100
-      )
-      expect(exercisesSection).toContain("handler: 'NetworkFirst'")
+      const rule = ruleFor('supabase-exercises')
+      expect(rule).toBeDefined()
+      expect(rule?.handler).toBe('NetworkFirst')
     })
 
     it('has a dedicated bodyweight cache', () => {
-      expect(viteConfig).toContain("cacheName: 'supabase-bodyweight'")
+      expect(ruleFor('supabase-bodyweight')).toBeDefined()
     })
 
     it('has a dedicated progression cache', () => {
-      expect(viteConfig).toContain("cacheName: 'supabase-progression'")
+      expect(ruleFor('supabase-progression')).toBeDefined()
     })
 
     it('has a catch-all supabase-api cache for unknown endpoints', () => {
-      expect(viteConfig).toContain("cacheName: 'supabase-api'")
+      expect(ruleFor('supabase-api')).toBeDefined()
     })
 
     it('keeps auth as NetworkOnly (never cache tokens)', () => {
-      expect(viteConfig).toContain("cacheName: 'supabase-auth'")
-      const authSection = viteConfig.slice(
-        viteConfig.indexOf("cacheName: 'supabase-auth'") - 200,
-        viteConfig.indexOf("cacheName: 'supabase-auth'") + 100
-      )
-      expect(authSection).toContain("handler: 'NetworkOnly'")
+      const rule = ruleFor('supabase-auth')
+      expect(rule).toBeDefined()
+      expect(rule?.handler).toBe('NetworkOnly')
     })
   })
 
   describe('cache capacities are tuned for power users', () => {
     it('sets cache allows 500 entries (100+ exercises × multiple pages)', () => {
-      const setsSection = viteConfig.slice(
-        viteConfig.indexOf("cacheName: 'supabase-sets'"),
-        viteConfig.indexOf("cacheName: 'supabase-sets'") + 300
-      )
-      expect(setsSection).toContain('maxEntries: 500')
+      expect(ruleFor('supabase-sets')?.options?.expiration?.maxEntries).toBe(500)
     })
 
     it('exercises cache allows 200 entries', () => {
-      const exercisesSection = viteConfig.slice(
-        viteConfig.indexOf("cacheName: 'supabase-exercises'"),
-        viteConfig.indexOf("cacheName: 'supabase-exercises'") + 300
+      expect(ruleFor('supabase-exercises')?.options?.expiration?.maxEntries).toBe(
+        200
       )
-      expect(exercisesSection).toContain('maxEntries: 200')
     })
   })
 
   describe('cache ordering is specific-first', () => {
     it('specific endpoint caches appear before the catch-all', () => {
-      const setsPos = viteConfig.indexOf("cacheName: 'supabase-sets'")
-      const exercisesPos = viteConfig.indexOf("cacheName: 'supabase-exercises'")
-      const catchAllPos = viteConfig.indexOf("cacheName: 'supabase-api'")
+      const names = runtimeCaching.map((r) => r.options?.cacheName)
+      const setsPos = names.indexOf('supabase-sets')
+      const exercisesPos = names.indexOf('supabase-exercises')
+      const catchAllPos = names.indexOf('supabase-api')
       // Specific caches must come before catch-all so Workbox matches them first
+      expect(setsPos).toBeGreaterThanOrEqual(0)
+      expect(exercisesPos).toBeGreaterThanOrEqual(0)
       expect(setsPos).toBeLessThan(catchAllPos)
       expect(exercisesPos).toBeLessThan(catchAllPos)
+    })
+  })
+
+  describe('navigation fallback', () => {
+    it('serves index.html for navigations (SPA fallback)', () => {
+      expect(workboxOptions.navigateFallback).toBe('index.html')
     })
   })
 })

--- a/vite-plugin-pwa-config.ts
+++ b/vite-plugin-pwa-config.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared Workbox configuration for the PWA service worker.
+ *
+ * Extracted from `vite.config.js` so it is a single source of truth that both
+ * the build (VitePWA) and the test suite consume. Previously the SW config
+ * lived inline in `vite.config.js` and the only "tests" for it string-sliced
+ * the config file's source text (`workboxCacheRegression.test.ts`) — they
+ * asserted the *shape of the source*, never that the config actually produces a
+ * working service worker. Exporting the real object lets tests assert against
+ * the config directly and feed it through `workbox-build` to verify the
+ * *generated* SW output (see `swBuildOutput.test.ts`).
+ *
+ * Keep this a plain, side-effect-free data module: `vite.config.js` imports it
+ * at config-eval time and the test imports it in Node, so it must not touch the
+ * DOM, Vite internals, or any build-only globals.
+ */
+
+/** Workbox `runtimeCaching` rule (subset of the fields this app uses). */
+export interface RuntimeCachingRule {
+  urlPattern: RegExp
+  handler:
+    | 'StaleWhileRevalidate'
+    | 'NetworkFirst'
+    | 'NetworkOnly'
+    | 'CacheFirst'
+    | 'CacheOnly'
+  options?: {
+    cacheName?: string
+    networkTimeoutSeconds?: number
+    expiration?: { maxEntries?: number; maxAgeSeconds?: number }
+    cacheableResponse?: { statuses: number[] }
+  }
+}
+
+/**
+ * Endpoint-specific runtime caches, ordered specific-first so Workbox matches
+ * the narrow patterns (sets/exercises/…) before the catch-all `supabase-api`.
+ * The order is load-bearing and asserted in the regression tests.
+ */
+export const runtimeCaching: RuntimeCachingRule[] = [
+  {
+    // Sets collection grows as new sets are logged — StaleWhileRevalidate
+    // serves cached response instantly for offline/fast load while updating
+    // the cache in the background so new sets from other devices appear next load
+    urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/sets\b/i,
+    handler: 'StaleWhileRevalidate',
+    options: {
+      cacheName: 'supabase-sets',
+      expiration: {
+        maxEntries: 500,
+        maxAgeSeconds: 60 * 60 * 24 * 7, // 7 days
+      },
+      cacheableResponse: {
+        statuses: [0, 200],
+      },
+    },
+  },
+  {
+    // Exercises change infrequently (renames, tag edits) — NetworkFirst with generous capacity
+    urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/exercises\b/i,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'supabase-exercises',
+      expiration: {
+        maxEntries: 200,
+        maxAgeSeconds: 60 * 60 * 12, // 12 hours
+      },
+      networkTimeoutSeconds: 3,
+      cacheableResponse: {
+        statuses: [0, 200],
+      },
+    },
+  },
+  {
+    // Bodyweight entries — moderate churn, NetworkFirst
+    urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/bodyweight_entries\b/i,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'supabase-bodyweight',
+      expiration: {
+        maxEntries: 200,
+        maxAgeSeconds: 60 * 60 * 12, // 12 hours
+      },
+      networkTimeoutSeconds: 3,
+      cacheableResponse: {
+        statuses: [0, 200],
+      },
+    },
+  },
+  {
+    // Progression/XP data — small payload, short TTL
+    urlPattern:
+      /^https:\/\/.*\.supabase\.co\/rest\/v1\/(user_progression|xp_events|progression_snapshots)\b/i,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'supabase-progression',
+      expiration: {
+        maxEntries: 50,
+        maxAgeSeconds: 60 * 60 * 6, // 6 hours
+      },
+      networkTimeoutSeconds: 3,
+      cacheableResponse: {
+        statuses: [0, 200],
+      },
+    },
+  },
+  {
+    // Catch-all for any other Supabase REST endpoints
+    urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,
+    handler: 'NetworkFirst',
+    options: {
+      cacheName: 'supabase-api',
+      expiration: {
+        maxEntries: 50,
+        maxAgeSeconds: 60 * 60 * 24, // 24 hours
+      },
+      networkTimeoutSeconds: 3,
+      cacheableResponse: {
+        statuses: [0, 200],
+      },
+    },
+  },
+  {
+    urlPattern: /^https:\/\/.*\.supabase\.co\/auth\/v1\/.*/i,
+    handler: 'NetworkOnly',
+    options: {
+      cacheName: 'supabase-auth',
+    },
+  },
+]
+
+/**
+ * The full `workbox` option object passed to VitePWA. Typed loosely as a record
+ * so it can be spread into VitePWA's config and into `workbox-build.generateSW`
+ * without dragging either package's types into this shared module.
+ */
+export const workboxOptions = {
+  globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+  globIgnores: [
+    'screenshot-*.png',
+    'og-image.png',
+    'icon-source.png',
+    'og-preview.html',
+    // iOS launch screens are loaded by Safari at cold launch via <link>
+    // tags, not fetched by the app — precaching them only bloats the SW.
+    'launch/*.png',
+  ],
+  navigateFallback: 'index.html',
+  navigateFallbackDenylist: [/^\/api\//],
+  navigationPreload: true,
+  clientsClaim: true,
+  skipWaiting: true,
+  runtimeCaching,
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { sentryVitePlugin } from '@sentry/vite-plugin'
 import { readFileSync } from 'fs'
 import themeStripPlugin from './vite-plugin-theme-split'
 import preloadDefaultViewPlugin from './vite-plugin-preload-default-view'
+import { workboxOptions } from './vite-plugin-pwa-config'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
@@ -128,113 +129,11 @@ export default defineConfig({
           },
         ],
       },
-      workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
-        globIgnores: [
-          'screenshot-*.png',
-          'og-image.png',
-          'icon-source.png',
-          'og-preview.html',
-          // iOS launch screens are loaded by Safari at cold launch via <link>
-          // tags, not fetched by the app — precaching them only bloats the SW.
-          'launch/*.png',
-        ],
-        navigateFallback: 'index.html',
-        navigateFallbackDenylist: [/^\/api\//],
-        navigationPreload: true,
-        clientsClaim: true,
-        skipWaiting: true,
-        runtimeCaching: [
-          {
-            // Sets collection grows as new sets are logged — StaleWhileRevalidate
-            // serves cached response instantly for offline/fast load while updating
-            // the cache in the background so new sets from other devices appear next load
-            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/sets\b/i,
-            handler: 'StaleWhileRevalidate',
-            options: {
-              cacheName: 'supabase-sets',
-              expiration: {
-                maxEntries: 500,
-                maxAgeSeconds: 60 * 60 * 24 * 7, // 7 days
-              },
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            // Exercises change infrequently (renames, tag edits) — NetworkFirst with generous capacity
-            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/exercises\b/i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'supabase-exercises',
-              expiration: {
-                maxEntries: 200,
-                maxAgeSeconds: 60 * 60 * 12, // 12 hours
-              },
-              networkTimeoutSeconds: 3,
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            // Bodyweight entries — moderate churn, NetworkFirst
-            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/bodyweight_entries\b/i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'supabase-bodyweight',
-              expiration: {
-                maxEntries: 200,
-                maxAgeSeconds: 60 * 60 * 12, // 12 hours
-              },
-              networkTimeoutSeconds: 3,
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            // Progression/XP data — small payload, short TTL
-            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/(user_progression|xp_events|progression_snapshots)\b/i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'supabase-progression',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 6, // 6 hours
-              },
-              networkTimeoutSeconds: 3,
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            // Catch-all for any other Supabase REST endpoints
-            urlPattern: /^https:\/\/.*\.supabase\.co\/rest\/v1\/.*/i,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'supabase-api',
-              expiration: {
-                maxEntries: 50,
-                maxAgeSeconds: 60 * 60 * 24, // 24 hours
-              },
-              networkTimeoutSeconds: 3,
-              cacheableResponse: {
-                statuses: [0, 200],
-              },
-            },
-          },
-          {
-            urlPattern: /^https:\/\/.*\.supabase\.co\/auth\/v1\/.*/i,
-            handler: 'NetworkOnly',
-            options: {
-              cacheName: 'supabase-auth',
-            },
-          },
-        ],
-      },
+      // Workbox config lives in ./vite-plugin-pwa-config.ts as a single source
+      // of truth shared with the SW build-output test (swBuildOutput.test.ts),
+      // so the generated service worker is verified against the same object the
+      // build consumes — not a string-slice of this file.
+      workbox: workboxOptions,
     }),
     // Upload source maps to Sentry on production builds
     // Requires SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT env vars


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1049](https://github.com/aschung212/Lift/issues/1049)

Implement **LIFT-1049**: the PWA test suite only validated config *source text* (string-slicing `vite.config.js`), never the *generated* service worker. A Workbox version bump, a silently dropped/renamed config field, or a broken navigation fallback would leave every test green while shipping a broken SW. Fix by extracting the Workbox config to a shared module and asserting against the real generated SW output.

## Changes
- **`vite-plugin-pwa-config.ts`** (new) — extracted the full Workbox `runtimeCaching` + navigation/precache config into a single side-effect-free source of truth shared by the build and the tests.
- **`vite.config.js`** — imports `workboxOptions` from the shared module instead of inlining the config (~100 lines → one reference).
- **`src/lib/__tests__/swBuildOutput.test.ts`** (new) — the behavioral layer: runs the real `workbox-build` `generateSW` over the shared config and asserts the *generated* `sw.js` actually registers every runtime-cache route, the `NavigationRoute` + `/api` denylist, the correct strategies, and precaches the SPA shell.
- **`workboxCacheRegression.test.ts`** — rewritten to assert against the exported config object (structural) rather than string-slicing the config file.
- **`manifestRegression.test.ts`** / **`launchScreens.test.ts`** — repointed their workbox assertions (`navigateFallback`, `navigationPreload`, `globIgnores`) at the shared object, since those moved out of `vite.config.js`.

## Verification
- `npm run build` — succeeds, `dist/sw.js` still contains `supabase-sets`, `NavigationRoute`, `denylist` (config extraction is behavior-preserving).
- `npm run lint` — clean.
- `npm run typecheck` — clean.
- `npx vitest run` (full suite) — **161 passed | 1 skipped**, 2935 tests pass (up from 2925; ~10 new SW-output assertions). The new `generateSW`-based test ran successfully in-process.
- Post-commit adversarial review: `REVIEW_CLEAN` / `REVIEW_VERDICT:MERGE`.

## Screenshots
N/A — test/config infrastructure change, no UI surface affected.

## Commits
- [`13fb204`](https://github.com/aschung212/Lift/commit/13fb204) test(LIFT-1049): verify generated SW behavior, not config source text

## Test Results
- Before: 2925 passing
- After: 2935 passing (10 delta)

---
_Automated by overnight pipeline — Thu Jul 30 00:37:24 PDT 2026_

## Preview
Test on your phone: https://lift-p0p29yg2l-aschung212-1101s-projects.vercel.app