### PR TITLE
style(LIFT-1063): use the real --font-subhead token for banner titles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,22 @@
           Viewing sample data — Tap to clear and start fresh
         </button>
 
+        <!-- Storage-eviction warning (LIFT-1063): persistent storage was denied -->
+        <Transition name="storageWarn">
+          <div v-if="storageWarningVisible" class="storageWarnBanner" role="status">
+            <div class="storageWarnContent">
+              <svg class="storageWarnIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+              <div class="storageWarnText">
+                <strong class="storageWarnTitle">Keep your data safe</strong>
+                <span class="storageWarnDesc">This browser may clear saved workouts to free up space. Add Lift to your Home Screen so your data stays put.</span>
+              </div>
+              <button class="storageWarnDismiss" @click="dismissStorageWarning" aria-label="Dismiss storage warning">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </button>
+            </div>
+          </div>
+        </Transition>
+
         <!-- PWA install banner -->
         <Transition name="installBanner">
           <div v-if="installBannerVisible" class="installBanner" role="banner">
@@ -285,6 +301,7 @@ import { xpToast, unlockCelebration, dismissUnlockCelebration, showXPToast } fro
 import { useXPCeremony } from './composables/useXPCeremony'
 import { isMigrated, markMigrated, computeRetroactiveXP } from './lib/xpMigration'
 import { requestPersistentStorage, ensureLocalStorage } from './lib/durableStorage'
+import { shouldWarnStorageEviction, isPersistenceSupported, hasLocalUserData } from './lib/storagePersistence'
 import { useAuth } from './composables/useAuth'
 import { useAnalytics } from './composables/useAnalytics'
 import { captureAcquisitionSource } from './composables/useAcquisitionSource'
@@ -296,7 +313,7 @@ import { useBodyweightStore } from './stores/bodyweight'
 import { useUndoToast } from './composables/useUndoToast'
 import { useFocusTrap } from './composables/useFocusTrap'
 import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
-import { useInstallPrompt } from './composables/useInstallPrompt'
+import { useInstallPrompt, isStandalone } from './composables/useInstallPrompt'
 import { useServiceWorker } from './composables/useServiceWorker'
 import { useAppBadge } from './composables/useAppBadge'
 import { todayISO, toLocalDateKey } from './lib/dates'
@@ -324,6 +341,18 @@ const bodyweightStore = useBodyweightStore()
 // ── PWA install prompt ──────────────────────────────────────────
 const installWorkoutDays = computed(() => workoutStore.workoutDates.length)
 const { showBanner: installBannerVisible, isIOSPrompt, dismiss: dismissInstallBanner, install: triggerInstall } = useInstallPrompt(installWorkoutDays)
+
+// ── Storage-eviction warning (LIFT-1063) ────────────────────────
+// When the browser DENIES persistent storage, an un-installed PWA's local data
+// is evictable (iOS clears it after ~7 days idle). For a local-first app that
+// risks silently losing not-yet-synced workouts, so we nudge to install. The
+// dismissal is device-local (like the install prompt), never synced.
+const STORAGE_WARN_DISMISS_KEY = 'storage-eviction-warning-dismissed'
+const storageWarningVisible = ref(false)
+function dismissStorageWarning() {
+  storageWarningVisible.value = false
+  localStorage.setItem(STORAGE_WARN_DISMISS_KEY, 'true')
+}
 
 // ── Unfinished-workout app-icon badge ───────────────────────────
 // When the user backgrounds the app with sets logged today, badge the
@@ -593,8 +622,18 @@ onMounted(async () => {
     .then(() => initAuth())
     .catch(() => initAuth())
 
-  // Request persistent storage to prevent browser eviction
-  requestPersistentStorage()
+  // Request persistent storage to prevent browser eviction. If the browser
+  // DENIES it (iOS Safari commonly does for un-installed PWAs), surface a
+  // dismissible nudge to install so local-first data isn't silently evicted.
+  requestPersistentStorage().then((persisted) => {
+    storageWarningVisible.value = shouldWarnStorageEviction({
+      supported: isPersistenceSupported(),
+      persisted,
+      standalone: isStandalone(),
+      hasLocalData: hasLocalUserData(),
+      dismissed: localStorage.getItem(STORAGE_WARN_DISMISS_KEY) === 'true',
+    })
+  })
 
   // Restore from IndexedDB if localStorage was cleared
   const restored = await Promise.all([

--- a/src/index.css
+++ b/src/index.css
@@ -964,6 +964,73 @@ button, [role="tab"], [role="switch"], a {
   padding-bottom: 0;
 }
 
+/* Storage-eviction warning banner (LIFT-1063) */
+.storageWarnBanner {
+  width: 100%;
+  padding: 12px 16px;
+  background: var(--accent-subtle);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.storageWarnContent {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.storageWarnIcon {
+  width: 24px;
+  height: 24px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+.storageWarnText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+.storageWarnTitle {
+  font-size: var(--font-subheadline);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.storageWarnDesc {
+  font-size: var(--font-caption1);
+  color: var(--text-secondary);
+}
+.storageWarnDismiss {
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.storageWarnDismiss svg {
+  width: 20px;
+  height: 20px;
+}
+.storageWarn-enter-active,
+.storageWarn-leave-active {
+  transition: opacity 0.2s ease, max-height 0.2s ease;
+  max-height: 120px;
+  overflow: hidden;
+}
+.storageWarn-enter-from,
+.storageWarn-leave-to {
+  opacity: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .appTopBar {
   display: flex;
   justify-content: space-between;

--- a/src/index.css
+++ b/src/index.css
@@ -894,7 +894,7 @@ button, [role="tab"], [role="switch"], a {
   min-width: 0;
 }
 .installBannerTitle {
-  font-size: var(--font-subheadline);
+  font-size: var(--font-subhead);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -991,7 +991,7 @@ button, [role="tab"], [role="switch"], a {
   flex: 1;
 }
 .storageWarnTitle {
-  font-size: var(--font-subheadline);
+  font-size: var(--font-subhead);
   font-weight: 600;
   color: var(--text-primary);
 }

--- a/src/lib/__tests__/storagePersistence.test.ts
+++ b/src/lib/__tests__/storagePersistence.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for storagePersistence.ts (LIFT-1063).
+ *
+ * The module turns the boolean `navigator.storage.persist()` returns — which
+ * App.vue previously discarded — into a single decision about whether to warn a
+ * user that their local-first workout data is evictable. The gate is pure so all
+ * branches are covered here without a DOM.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  shouldWarnStorageEviction,
+  isPersistenceSupported,
+  hasLocalUserData,
+  type StorageEvictionInput,
+} from '../storagePersistence'
+
+const base: StorageEvictionInput = {
+  supported: true,
+  persisted: false,
+  standalone: false,
+  hasLocalData: true,
+  dismissed: false,
+}
+
+describe('shouldWarnStorageEviction', () => {
+  it('warns when persistence is denied, data exists, not installed, not dismissed', () => {
+    expect(shouldWarnStorageEviction(base)).toBe(true)
+  })
+
+  it('never warns when the persistence API is unsupported (a false result is meaningless)', () => {
+    expect(shouldWarnStorageEviction({ ...base, supported: false })).toBe(false)
+  })
+
+  it('does not warn when persistence was granted', () => {
+    expect(shouldWarnStorageEviction({ ...base, persisted: true })).toBe(false)
+  })
+
+  it('does not warn in an installed (standalone) PWA — the install nudge is moot', () => {
+    expect(shouldWarnStorageEviction({ ...base, standalone: true })).toBe(false)
+  })
+
+  it('does not warn when there is no local data worth protecting', () => {
+    expect(shouldWarnStorageEviction({ ...base, hasLocalData: false })).toBe(false)
+  })
+
+  it('stays hidden once the user has dismissed it', () => {
+    expect(shouldWarnStorageEviction({ ...base, dismissed: true })).toBe(false)
+  })
+})
+
+describe('isPersistenceSupported', () => {
+  const originalNavigator = globalThis.navigator
+
+  afterEach(() => {
+    vi.stubGlobal('navigator', originalNavigator)
+  })
+
+  it('is true when navigator.storage.persist is a function', () => {
+    vi.stubGlobal('navigator', { storage: { persist: () => Promise.resolve(true) } })
+    expect(isPersistenceSupported()).toBe(true)
+  })
+
+  it('is false when the Storage API is absent', () => {
+    vi.stubGlobal('navigator', {})
+    expect(isPersistenceSupported()).toBe(false)
+  })
+
+  it('is false when persist is not a function', () => {
+    vi.stubGlobal('navigator', { storage: {} })
+    expect(isPersistenceSupported()).toBe(false)
+  })
+})
+
+describe('hasLocalUserData', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('is false when no workout or bodyweight data is stored', () => {
+    expect(hasLocalUserData()).toBe(false)
+  })
+
+  it('is false when the stored arrays are empty', () => {
+    localStorage.setItem('workout-exercises', '[]')
+    localStorage.setItem('bodyweight-entries', '[]')
+    expect(hasLocalUserData()).toBe(false)
+  })
+
+  it('is true when workout data exists', () => {
+    localStorage.setItem('workout-exercises', JSON.stringify([{ id: '1', name: 'Bench', sets: [] }]))
+    expect(hasLocalUserData()).toBe(true)
+  })
+
+  it('is true when bodyweight data exists', () => {
+    localStorage.setItem('bodyweight-entries', JSON.stringify([{ date: '2026-07-30', weight: 180 }]))
+    expect(hasLocalUserData()).toBe(true)
+  })
+
+  it('is false (not thrown) when the stored value is corrupt JSON', () => {
+    localStorage.setItem('workout-exercises', '{not json')
+    expect(hasLocalUserData()).toBe(false)
+  })
+
+  it('is false when the stored value is not an array', () => {
+    localStorage.setItem('workout-exercises', JSON.stringify({ nope: true }))
+    expect(hasLocalUserData()).toBe(false)
+  })
+})

--- a/src/lib/storagePersistence.ts
+++ b/src/lib/storagePersistence.ts
@@ -1,0 +1,83 @@
+/**
+ * Storage-eviction warning decision (LIFT-1063).
+ *
+ * `navigator.storage.persist()` reports whether the browser granted persistent
+ * storage. When it is DENIED, the browser may evict IndexedDB + localStorage
+ * under storage pressure — and iOS Safari evicts the storage of an un-installed
+ * PWA after ~7 days of inactivity. For a local-first app that means silent
+ * workout-data loss for a user whose writes haven't reached Supabase yet (logged
+ * offline, or before a sync completed).
+ *
+ * When persistence is denied we nudge the user to add Lift to their Home Screen:
+ * installed PWAs are granted persistent storage and are not subject to the 7-day
+ * eviction, so their local data is durably retained alongside cloud sync.
+ *
+ * `App.vue` currently discards the boolean `requestPersistentStorage()` returns;
+ * this module turns that discarded signal into a single, cheap decision.
+ */
+
+const WORKOUT_STORAGE_KEY = 'workout-exercises'
+const BODYWEIGHT_STORAGE_KEY = 'bodyweight-entries'
+
+export interface StorageEvictionInput {
+  /**
+   * Whether `navigator.storage.persist` exists. A `false` `persisted` result on
+   * an *unsupported* browser is meaningless (nothing was actually denied), so we
+   * only warn when the API is present and returned `false`.
+   */
+  supported: boolean
+  /** The boolean returned by `navigator.storage.persist()`. */
+  persisted: boolean
+  /**
+   * Running as an installed PWA. Installed apps already receive persistent
+   * storage and escape the 7-day eviction, so the "add to Home Screen" nudge is
+   * moot — never warn there.
+   */
+  standalone: boolean
+  /** The user has local workout/bodyweight data worth protecting. */
+  hasLocalData: boolean
+  /** The user previously dismissed this warning. */
+  dismissed: boolean
+}
+
+/**
+ * Decide whether to surface the storage-eviction warning banner. Pure so the
+ * gating logic is unit-testable without a DOM.
+ */
+export function shouldWarnStorageEviction(input: StorageEvictionInput): boolean {
+  const { supported, persisted, standalone, hasLocalData, dismissed } = input
+  if (!supported) return false
+  if (persisted) return false
+  if (standalone) return false
+  if (!hasLocalData) return false
+  if (dismissed) return false
+  return true
+}
+
+/**
+ * True when the Storage persistence API is available. Distinguishes a genuine
+ * DENIAL (`persist()` → false) from an unsupported browser (no API at all).
+ */
+export function isPersistenceSupported(): boolean {
+  return typeof navigator !== 'undefined' && typeof navigator.storage?.persist === 'function'
+}
+
+/**
+ * Whether localStorage holds any real user workout/bodyweight data. Read straight
+ * from localStorage (the local-first source of truth) so the check is synchronous
+ * and race-free against async store hydration.
+ */
+export function hasLocalUserData(): boolean {
+  return isNonEmptyArrayKey(WORKOUT_STORAGE_KEY) || isNonEmptyArrayKey(BODYWEIGHT_STORAGE_KEY)
+}
+
+function isNonEmptyArrayKey(key: string): boolean {
+  try {
+    const raw = localStorage.getItem(key)
+    if (!raw) return false
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) && parsed.length > 0
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1063](https://github.com/aschung212/Lift/issues/1063)

Implement **LIFT-1063**: `App.vue` called `requestPersistentStorage()` and discarded its boolean. When the browser *denies* persistence (iOS Safari commonly does for un-installed PWAs, which then evicts local data after ~7 days idle), a local-first user can silently lose not-yet-synced workouts. Turn that discarded signal into a dismissible install nudge.

## Changes
- **`src/lib/storagePersistence.ts`** (new) — pure decision layer: `shouldWarnStorageEviction()` (warns only when persistence is supported + denied, real local data exists, not already installed, not dismissed), `isPersistenceSupported()` (distinguishes genuine denial from an unsupported API), `hasLocalUserData()` (reads localStorage directly, race-free vs async store hydration).
- **`src/App.vue`** — consume `requestPersistentStorage()`'s result, gate a new dismissible `.storageWarnBanner` (`role="status"`, 44pt dismiss, theme vars, safe-area-agnostic top banner) nudging "Add Lift to your Home Screen". Dismissal is device-local (`storage-eviction-warning-dismissed`), never synced.
- **`src/index.css`** — `.storageWarnBanner` styles + dedicated transition; also fixed a pre-existing undefined-token bug (`--font-subheadline` → `--font-subhead`) flagged by review, in both the new banner and `.installBannerTitle` (fix-all-instances).
- **`src/lib/__tests__/storagePersistence.test.ts`** (new) — 15 tests covering every gate branch, API-support detection, and corrupt/empty/non-array localStorage.

## Verification
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — success
- New module tests: 15/15 pass; full lib suite 1315/1315; cssRegression 121/121; App suite 88/88
- Adversarial review: final verdict `MERGE` (REVIEW_CLEAN) after the font-token fix

## Screenshots
None (banner only renders when the browser denies persistence at runtime; behavior verified via unit tests over the pure gate).

## Commits
- [`afc9e40`](https://github.com/aschung212/Lift/commit/afc9e40) style(LIFT-1063): use the real --font-subhead token for banner titles
- [`d98b86d`](https://github.com/aschung212/Lift/commit/d98b86d) feat(LIFT-1063): warn about local-data eviction when persistent storage is denied

## Test Results
- Before: 2902 passing
- After: 2917 passing (15 delta)

---
_Automated by overnight pipeline — Thu Jul 30 23:43:51 PDT 2026_

## Preview
Test on your phone: https://lift-l2trnxlkn-aschung212-1101s-projects.vercel.app