### PR TITLE
chore(LIFT-850): harden AI Coach egress boundary + document native reachability for launch

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,11 @@
+# Netlify config ships the static SPA only — it declares NO functions.
+# The AI Coach proxy (`/api/coach`, a Vercel serverless function) therefore does
+# NOT exist on any Netlify deploy and would 404 there. AI Coach is deliberately
+# scoped to the Vercel origin (https://spa-rho-sandy.vercel.app); the client
+# calls that absolute origin on native and same-origin on the Vercel web build,
+# so a Netlify deploy simply never reaches the coach endpoint. See LIFT-850 and
+# docs/ai-coach.md ("Known deploy gotcha"). If AI Coach must run on Netlify,
+# port api/coach.ts to a Netlify Function before enabling it.
 [build]
   command   = "npm run build"
   publish   = "dist"

--- a/src/lib/__tests__/coachEgressLeak.test.ts
+++ b/src/lib/__tests__/coachEgressLeak.test.ts
@@ -1,0 +1,77 @@
+/**
+ * AI Coach egress leak tripwire (LIFT-850).
+ *
+ * The Anthropic API key and provider origin are the entire trust boundary for
+ * the AI Coach feature. They live ONLY in the server-side function under `api/`
+ * (which is never bundled into the client), and the browser/native client only
+ * ever talks to our own same-origin proxy (`/api/coach`).
+ *
+ * This test fails loudly if any of the following leak into the CLIENT surface:
+ *   - the Anthropic origin (`api.anthropic.com`) or any LLM-provider origin,
+ *   - the provider key name (`ANTHROPIC_API_KEY`) or the `x-api-key` header,
+ * anywhere under `src/` (which compiles to `dist/`), or into the CSP
+ * `connect-src` in vercel.json.
+ *
+ * Why scan source, not `dist/`? `src/` is the sole input to the client bundle
+ * and doesn't require a build step, so this stays fast and CI-friendly while
+ * proving the same invariant: a provider secret/origin can only reach the
+ * shipped bundle by first appearing in `src/`. `api/coach.ts` is intentionally
+ * NOT scanned — that's the server function where these values belong.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const SRC_DIR = resolve(__dirname, '../..')
+
+/** Recursively collect every source file under `src/` (client bundle input). */
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full))
+    } else if (/\.(ts|tsx|vue|js|mjs|cjs)$/.test(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/**
+ * Patterns that must never appear in client source. This test file itself and
+ * its sibling regression tests reference these strings to assert their absence,
+ * so the scan excludes `__tests__` directories.
+ */
+const FORBIDDEN: Array<{ label: string; pattern: RegExp }> = [
+  { label: 'the Anthropic API origin', pattern: /api\.anthropic\.com/i },
+  { label: 'any anthropic.com origin', pattern: /https?:\/\/[^\s'"]*anthropic\.com/i },
+  { label: 'any openai.com origin', pattern: /https?:\/\/[^\s'"]*openai\.com/i },
+  { label: 'the Anthropic key env name', pattern: /ANTHROPIC_API_KEY/ },
+  { label: 'the provider key header', pattern: /['"]x-api-key['"]/i },
+]
+
+describe('AI Coach egress leak tripwire (LIFT-850)', () => {
+  const sourceFiles = collectSourceFiles(SRC_DIR).filter(
+    (f) => !f.includes('__tests__'),
+  )
+
+  it('scans a non-trivial number of client source files', () => {
+    // Guards against a broken glob silently passing the leak assertions.
+    expect(sourceFiles.length).toBeGreaterThan(50)
+  })
+
+  it.each(FORBIDDEN)('never exposes $label in client source', ({ pattern }) => {
+    const offenders: string[] = []
+    for (const file of sourceFiles) {
+      if (pattern.test(readFileSync(file, 'utf-8'))) {
+        offenders.push(file.slice(SRC_DIR.length + 1))
+      }
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/lib/__tests__/vercelHeadersRegression.test.ts
+++ b/src/lib/__tests__/vercelHeadersRegression.test.ts
@@ -132,6 +132,32 @@ describe('vercel.json security headers', () => {
       expect(csp).toContain('https://vitals.vercel-insights.com')
     })
 
+    /**
+     * AI Coach launch reachability (LIFT-850). The coach proxy lives at
+     * `/api/coach` on the deployment origin. On web/PWA that is same-origin
+     * (already covered by `'self'`), but the native Capacitor build is
+     * cross-origin and calls the absolute origin — pin it explicitly so the
+     * coach endpoint stays reachable and the intent is documented at the
+     * launch gate. This origin must match `COACH_PROD_ORIGIN` in coachClient.ts
+     * and the function CORS allowlist in api/coach.ts.
+     */
+    it('allows the AI Coach proxy origin on connect-src (LIFT-850)', () => {
+      expect(csp).toContain('https://spa-rho-sandy.vercel.app')
+    })
+
+    /**
+     * Egress tripwire (LIFT-850): the Anthropic key lives ONLY in the server
+     * function (api/coach.ts) and the browser must never talk to an LLM
+     * provider directly. If a provider origin ever appears on connect-src it
+     * means the proxy boundary was bypassed — fail loudly.
+     */
+    it('never allows an LLM-provider origin on connect-src (LIFT-850)', () => {
+      const connectSrc = /connect-src\s+([^;]*)/.exec(csp)?.[1] ?? ''
+      expect(connectSrc).not.toMatch(/anthropic\.com/i)
+      expect(connectSrc).not.toMatch(/openai\.com/i)
+      expect(connectSrc).not.toMatch(/api\.anthropic\.com/i)
+    })
+
     it('blocks framing (clickjacking defense)', () => {
       expect(csp).toMatch(/frame-ancestors\s+'none'/)
     })

--- a/vercel.json
+++ b/vercel.json
@@ -40,7 +40,7 @@
         { "key": "Cross-Origin-Resource-Policy", "value": "same-origin" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://vitals.vercel-insights.com; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://spa-rho-sandy.vercel.app https://*.supabase.co wss://*.supabase.co https://*.sentry.io https://*.ingest.sentry.io https://vitals.vercel-insights.com; font-src 'self' data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-850](https://github.com/aschung212/Lift/issues/850)

Implement the code-side, testable slice of **LIFT-850** (AI Coach launch readiness). The bulk of the issue is ops/infra (Vercel env vars, WAF/BotID rules, provider budget cap, Slack spend alert) that can't be done from the repo. The concrete code deliverables are: native reachability (CSP `connect-src` + CORS confirmation + headers test), a provider-egress leak tripwire test, and the Netlify reconciliation/documentation.

## Changes
- **`vercel.json`** — pinned the coach proxy origin `https://spa-rho-sandy.vercel.app` on CSP `connect-src` so `/api/coach` is explicitly reachable (same-origin on web, absolute origin on native). Matches `COACH_PROD_ORIGIN` (coachClient.ts) and `ALLOWED_ORIGINS` (api/coach.ts).
- **`src/lib/__tests__/vercelHeadersRegression.test.ts`** — in lockstep: assert the coach origin IS present, and assert no LLM-provider origin (anthropic/openai) ever appears on `connect-src`.
- **`src/lib/__tests__/coachEgressLeak.test.ts`** (new) — tripwire scanning all client source under `src/`: no file may reference `api.anthropic.com`, any anthropic/openai origin, `ANTHROPIC_API_KEY`, or the `x-api-key` header. The provider key/origin stay server-only in `api/`.
- **`netlify.toml`** — documented that `/api/coach` is Vercel-only and 404s on Netlify (scopes AI Coach to the Vercel origin — the "Known deploy gotcha").

## Verification
- Post-commit adversarial review (Sonnet): **REVIEW_CLEAN / MERGE**.
- lint-staged eslint (`--max-warnings 5`) passed on both changed `.ts` files.
- `vercel.json` re-read and confirmed valid JSON (only a string value changed).
- Leak-test correctness pre-verified via Grep: `src/` has zero matches for `api.anthropic.com`, `ANTHROPIC_API_KEY`, `x-api-key`, or any openai/anthropic origin; the new test file lives in `__tests__/` and is excluded from its own scan.
- Only my two touched test files reference `connect-src`; no other test pins the exact CSP string, so the vercel.json edit can't break an unrelated assertion.
- Note: I could not execute `npm test`/`vitest` in this sandbox (exec approval denied), so the full-suite green check falls to the pipeline's CI gate before the PR opens.

## Screenshots
None — no UI changes (config + tests + infra docs only).

## Commits
- [`5e49dbc`](https://github.com/aschung212/Lift/commit/5e49dbc) chore(LIFT-850): harden AI Coach egress boundary + document native reachability for launch

## Test Results
- Before: 2902 passing
- After: 2910 passing (8 delta)

---
_Automated by overnight pipeline — Sat Aug  1 00:28:58 PDT 2026_

## Preview
Test on your phone: https://lift-h0pe0bdjn-aschung212-1101s-projects.vercel.app