### PR TITLE
feat(LIFT-1060): snooze the install prompt instead of suppressing it forever

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -297,6 +297,7 @@ import { useUndoToast } from './composables/useUndoToast'
 import { useFocusTrap } from './composables/useFocusTrap'
 import { useKeyboardShortcuts } from './composables/useKeyboardShortcuts'
 import { useInstallPrompt } from './composables/useInstallPrompt'
+import { usePRBurst } from './composables/usePRBurst'
 import { useServiceWorker } from './composables/useServiceWorker'
 import { useAppBadge } from './composables/useAppBadge'
 import { todayISO, toLocalDateKey } from './lib/dates'
@@ -323,7 +324,15 @@ const bodyweightStore = useBodyweightStore()
 
 // ── PWA install prompt ──────────────────────────────────────────
 const installWorkoutDays = computed(() => workoutStore.workoutDates.length)
-const { showBanner: installBannerVisible, isIOSPrompt, dismiss: dismissInstallBanner, install: triggerInstall } = useInstallPrompt(installWorkoutDays)
+const { showBanner: installBannerVisible, isIOSPrompt, dismiss: dismissInstallBanner, install: triggerInstall, surfaceAtPeakMoment: surfaceInstallAtPeak } = useInstallPrompt(installWorkoutDays)
+
+// Re-surface the install prompt at a peak moment: once a PR celebration is
+// dismissed, the user is at a high point of engagement — a far better time to
+// ask than the raw 3-workout-day gate (#1060). Respects install/snooze state.
+const { visible: prBurstVisible } = usePRBurst()
+watch(prBurstVisible, (visible, wasVisible) => {
+  if (wasVisible && !visible) surfaceInstallAtPeak()
+})
 
 // ── Unfinished-workout app-icon badge ───────────────────────────
 // When the user backgrounds the app with sets logged today, badge the

--- a/src/composables/__tests__/useInstallPrompt.test.ts
+++ b/src/composables/__tests__/useInstallPrompt.test.ts
@@ -196,7 +196,9 @@ describe('useInstallPrompt', () => {
   })
 
   describe('dismiss', () => {
-    it('hides banner and persists dismissal', () => {
+    it('hides banner and persists a dismissal timestamp (snooze, not forever)', () => {
+      const now = 1_700_000_000_000
+      vi.spyOn(Date, 'now').mockReturnValue(now)
       const state = useInstallPrompt(() => 5)
       const mockEvent = { preventDefault: vi.fn() }
       fireWindowEvent('beforeinstallprompt', mockEvent)
@@ -205,7 +207,80 @@ describe('useInstallPrompt', () => {
 
       state.dismiss()
       expect(state.showBanner.value).toBe(false)
-      expect(localStorage.getItem('install-prompt-dismissed')).toBe('true')
+      // A timestamp is stored so the prompt can re-surface after the snooze window.
+      expect(localStorage.getItem('install-prompt-dismissed')).toBe(String(now))
+    })
+
+    it('keeps the prompt suppressed while the snooze window is active', () => {
+      const now = 1_700_000_000_000
+      vi.spyOn(Date, 'now').mockReturnValue(now)
+      // Dismissed 10 days ago — still inside the 30-day snooze.
+      localStorage.setItem('install-prompt-dismissed', String(now - 10 * 24 * 60 * 60 * 1000))
+
+      const state = useInstallPrompt(() => 10)
+      const mockEvent = { preventDefault: vi.fn() }
+      fireWindowEvent('beforeinstallprompt', mockEvent)
+
+      expect(state.showBanner.value).toBe(false)
+    })
+
+    it('re-surfaces the prompt once the snooze window has elapsed', () => {
+      const now = 1_700_000_000_000
+      vi.spyOn(Date, 'now').mockReturnValue(now)
+      // Dismissed 31 days ago — snooze has expired.
+      localStorage.setItem('install-prompt-dismissed', String(now - 31 * 24 * 60 * 60 * 1000))
+
+      const state = useInstallPrompt(() => 10)
+      const mockEvent = { preventDefault: vi.fn() }
+      fireWindowEvent('beforeinstallprompt', mockEvent)
+
+      expect(state.showBanner.value).toBe(true)
+    })
+
+    it('treats a legacy "true" dismissal flag as a permanent suppression', () => {
+      localStorage.setItem('install-prompt-dismissed', 'true')
+      const state = useInstallPrompt(() => 10)
+      const mockEvent = { preventDefault: vi.fn() }
+      fireWindowEvent('beforeinstallprompt', mockEvent)
+
+      expect(state.showBanner.value).toBe(false)
+    })
+  })
+
+  describe('surfaceAtPeakMoment', () => {
+    it('re-surfaces the banner (bypassing the engagement gate) when a deferred prompt exists', () => {
+      // Below MIN_WORKOUT_DAYS — the normal gate would keep the banner hidden.
+      const state = useInstallPrompt(() => 1)
+      const mockEvent = { preventDefault: vi.fn() }
+      fireWindowEvent('beforeinstallprompt', mockEvent)
+      expect(state.showBanner.value).toBe(false)
+
+      state.surfaceAtPeakMoment()
+      expect(state.showBanner.value).toBe(true)
+      expect(state.isIOSPrompt.value).toBe(false)
+    })
+
+    it('does not re-surface while an install has been recorded', () => {
+      localStorage.setItem('install-prompt-installed', '1')
+      const state = useInstallPrompt(() => 5)
+      const mockEvent = { preventDefault: vi.fn() }
+      fireWindowEvent('beforeinstallprompt', mockEvent)
+
+      state.surfaceAtPeakMoment()
+      expect(state.showBanner.value).toBe(false)
+    })
+
+    it('does not re-surface while a dismissal snooze is active', () => {
+      const now = 1_700_000_000_000
+      vi.spyOn(Date, 'now').mockReturnValue(now)
+      const state = useInstallPrompt(() => 5)
+      const mockEvent = { preventDefault: vi.fn() }
+      fireWindowEvent('beforeinstallprompt', mockEvent)
+      state.dismiss()
+      expect(state.showBanner.value).toBe(false)
+
+      state.surfaceAtPeakMoment()
+      expect(state.showBanner.value).toBe(false)
     })
   })
 
@@ -223,7 +298,9 @@ describe('useInstallPrompt', () => {
 
       expect(mockEvent.prompt).toHaveBeenCalled()
       expect(state.showBanner.value).toBe(false)
-      expect(localStorage.getItem('install-prompt-dismissed')).toBe('true')
+      // Install acceptance is a permanent suppression, tracked separately from
+      // the dismiss snooze.
+      expect(localStorage.getItem('install-prompt-installed')).toBe('1')
     })
 
     it('hides banner when user declines native install dialog', async () => {
@@ -261,7 +338,7 @@ describe('useInstallPrompt', () => {
 
       fireWindowEvent('appinstalled')
       expect(state.showBanner.value).toBe(false)
-      expect(localStorage.getItem('install-prompt-dismissed')).toBe('true')
+      expect(localStorage.getItem('install-prompt-installed')).toBe('1')
     })
   })
 
@@ -305,6 +382,30 @@ describe('useInstallPrompt', () => {
       const state = mod.useInstallPrompt(() => 5)
 
       expect(state.showBanner.value).toBe(false)
+    })
+
+    it('surfaceAtPeakMoment shows the iOS prompt below the engagement gate', async () => {
+      vi.resetModules()
+      vi.doMock('../../lib/platform', () => ({
+        isNative: false,
+        isIOS: true,
+        platform: 'web',
+      }))
+
+      windowListeners = {}
+      vi.spyOn(window, 'addEventListener').mockImplementation(
+        (event: string, handler: unknown) => addWindowListener(event, handler as (...args: unknown[]) => void)
+      )
+      mockMatchMedia(false)
+
+      const mod = await import('../useInstallPrompt')
+      // Below MIN_WORKOUT_DAYS — normal gate keeps it hidden.
+      const state = mod.useInstallPrompt(() => 0)
+      expect(state.showBanner.value).toBe(false)
+
+      state.surfaceAtPeakMoment()
+      expect(state.showBanner.value).toBe(true)
+      expect(state.isIOSPrompt.value).toBe(true)
     })
   })
 

--- a/src/composables/useInstallPrompt.ts
+++ b/src/composables/useInstallPrompt.ts
@@ -12,8 +12,17 @@ export interface BeforeInstallPromptEvent extends Event {
   prompt(): Promise<{ outcome: 'accepted' | 'dismissed' }>
 }
 
+// Stores the timestamp (ms) of the user's last banner dismissal. A dismissal
+// used to write the literal string 'true' and suppress the prompt forever;
+// it now snoozes for SNOOZE_MS so a user who dismisses before understanding
+// the value gets a second chance (installed users convert ~5x better).
 const DISMISS_KEY = 'install-prompt-dismissed'
+// Set once the app is actually installed (native prompt accepted / appinstalled
+// fired) — a permanent suppression, distinct from the temporary dismiss snooze.
+const INSTALLED_KEY = 'install-prompt-installed'
 const MIN_WORKOUT_DAYS = 3
+// Re-surface a dismissed prompt after ~30 days.
+const SNOOZE_MS = 30 * 24 * 60 * 60 * 1000
 
 /** Whether the app is running in standalone (installed) mode. */
 export function isStandalone(): boolean {
@@ -33,6 +42,13 @@ export interface InstallPromptState {
   dismiss: () => void
   /** Trigger the native install prompt (Chrome/Edge). No-op on iOS. */
   install: () => Promise<void>
+  /**
+   * Re-surface the banner at a high-engagement "peak moment" (a new PR, a
+   * streak milestone). Bypasses the MIN_WORKOUT_DAYS engagement gate — a peak
+   * moment is itself the engagement signal — but still respects an installed
+   * app and an active dismiss snooze. No-op if already visible/suppressed.
+   */
+  surfaceAtPeakMoment: () => void
   /** Remove event listeners. Call when the consumer unmounts. */
   destroy: () => void
 }
@@ -64,11 +80,40 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     return typeof workoutDayCount === 'function' ? workoutDayCount() : workoutDayCount.value
   }
 
+  /** True once the app has actually been installed — a permanent suppression. */
+  function isInstallRemembered(): boolean {
+    return localStorage.getItem(INSTALLED_KEY) === '1'
+  }
+
+  /**
+   * True while a dismissal is still within its snooze window. Legacy dismissals
+   * (and legacy installs) wrote the literal 'true' before snoozing existed; we
+   * can't tell the two apart, so treat 'true' as a permanent suppression to
+   * avoid re-prompting someone who may already have installed.
+   */
+  function isSnoozeActive(): boolean {
+    const raw = localStorage.getItem(DISMISS_KEY)
+    if (raw === null) return false
+    if (raw === 'true') return true
+    const ts = Number(raw)
+    if (!Number.isFinite(ts)) return false
+    return Date.now() - ts < SNOOZE_MS
+  }
+
+  /** Permanently installed, or temporarily snoozed after a dismissal. */
+  function isSuppressed(): boolean {
+    return isInstallRemembered() || isSnoozeActive()
+  }
+
+  function rememberInstalled() {
+    localStorage.setItem(INSTALLED_KEY, '1')
+  }
+
   function shouldShow(): boolean {
     // Never show in native or already-installed PWA
     if (isNative || isStandalone()) return false
-    // User already dismissed
-    if (localStorage.getItem(DISMISS_KEY)) return false
+    // User already installed, or dismissed within the snooze window
+    if (isSuppressed()) return false
     // Not enough engagement
     if (getDayCount() < MIN_WORKOUT_DAYS) return false
     return true
@@ -78,7 +123,23 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     showBanner.value = false
     deferredPrompt = null
     hasPendingPrompt = false
-    localStorage.setItem(DISMISS_KEY, 'true')
+    // Snooze (timestamp) rather than suppress forever — re-surfaces after SNOOZE_MS.
+    localStorage.setItem(DISMISS_KEY, String(Date.now()))
+  }
+
+  function surfaceAtPeakMoment() {
+    if (showBanner.value) return
+    if (isNative || isStandalone()) return
+    if (isSuppressed()) return
+    if (deferredPrompt) {
+      isIOSPrompt.value = false
+      showBanner.value = true
+      hasPendingPrompt = false
+    } else if (isIOS && !isNative && !isStandalone()) {
+      isIOSPrompt.value = true
+      showBanner.value = true
+      hasPendingPrompt = false
+    }
   }
 
   async function install() {
@@ -89,7 +150,7 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     // Hide regardless of outcome — the native prompt can only be triggered once
     showBanner.value = false
     if (outcome === 'accepted') {
-      localStorage.setItem(DISMISS_KEY, 'true')
+      rememberInstalled()
     }
   }
 
@@ -111,7 +172,7 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     showBanner.value = false
     deferredPrompt = null
     hasPendingPrompt = false
-    localStorage.setItem(DISMISS_KEY, 'true')
+    rememberInstalled()
   }
 
   // Register listeners — cleaned up via destroy() if the consumer unmounts.
@@ -130,7 +191,7 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     if (shouldShow()) {
       isIOSPrompt.value = true
       showBanner.value = true
-    } else if (!localStorage.getItem(DISMISS_KEY)) {
+    } else if (!isSuppressed()) {
       // Data may not be loaded yet — watch for threshold crossing
       hasPendingPrompt = true
     }
@@ -159,6 +220,7 @@ export function useInstallPrompt(workoutDayCount: WatchSource<number>): InstallP
     isIOSPrompt,
     dismiss,
     install,
+    surfaceAtPeakMoment,
     destroy,
   }
 }


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1060](https://github.com/aschung212/Lift/issues/1060)

LIFT-1060: The install banner wrote a permanent `install-prompt-dismissed='true'` flag on dismiss, so a user who dismissed once never saw it again. Replace the permanent flag with a 30-day snooze timestamp, track genuine installs under a separate permanent key, and re-surface the prompt at a peak engagement moment (after a PR celebration).

## Changes
- `src/composables/useInstallPrompt.ts` — `dismiss()` now stores `Date.now()` (30-day snooze) instead of `'true'`; new `install-prompt-installed` key records real installs (native accept / `appinstalled`) as a permanent suppression; added `isSnoozeActive`/`isInstallRemembered`/`isSuppressed` helpers; legacy `'true'` still treated as permanent. New `surfaceAtPeakMoment()` re-surfaces the banner bypassing the 3-workout-day gate but honoring install/snooze state.
- `src/App.vue` — watch `usePRBurst().visible`; when a PR celebration is dismissed, call `surfaceAtPeakMoment()`.
- `src/composables/__tests__/useInstallPrompt.test.ts` — updated install/appinstalled assertions to the new key; added snooze-active / snooze-expired / legacy-flag tests and peak-moment tests (Chromium + iOS + suppressed states). 26/26 pass.

## Verification
- `npx vitest run useInstallPrompt.test.ts` → 26 passed
- `npm run lint` → clean
- `npm run build` → type-check + build succeeded
- Post-commit adversarial review → REVIEW_CLEAN / MERGE

## Screenshots
None (logic + persistence change; no new UI surface).

## Commits
- [`ed0ceee`](https://github.com/aschung212/Lift/commit/ed0ceee) feat(LIFT-1060): snooze the install prompt instead of suppressing it forever

## Test Results
- Before: 2902 passing
- After: 2909 passing (7 delta)

---
_Automated by overnight pipeline — Mon Aug  3 23:27:18 PDT 2026_

## Preview
Test on your phone: https://lift-dmwogdfov-aschung212-1101s-projects.vercel.app