### PR TITLE
fix: stop the settings sheet stranding itself open (closes #1079)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -435,7 +435,16 @@ const {
 } = useOnboarding({ workoutStore, bodyweightStore })
 
 function closeSettings() {
-  settingsSheetRef.value?.closeSettings()
+  const sheet = settingsSheetRef.value
+  // The sheet runs its own exit animation before emitting the close — but it can
+  // only do that if it actually mounted. SettingsSheet is an async component, so
+  // the ref is still null while its chunk is in flight and stays null forever if
+  // that chunk fails to resolve (offline, or a stale hash after a deploy). The
+  // bare `?.` here meant `settingsOpen` stayed true with nothing rendered, and
+  // since the gear reads `settingsOpen ? closeSettings() : (settingsOpen = true)`
+  // it could never reach the open branch again — settings was dead until reload.
+  if (sheet) sheet.closeSettings()
+  else settingsOpen.value = false
 }
 
 // ── Sign out handler (from SettingsSheet) ────────────────────────

--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -728,7 +728,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick, type ComponentPublicInstance } from 'vue'
+import { ref, computed, watch, nextTick, onUnmounted, type ComponentPublicInstance } from 'vue'
 import { useTheme } from '../composables/useTheme'
 import { useWeightUnit } from '../composables/useWeightUnit'
 import { useRestTimer } from '../composables/useRestTimer'
@@ -924,8 +924,49 @@ function onSettingsSheetMounted(el: Element | ComponentPublicInstance | null) {
   }
 }
 
+/**
+ * Duration of `sheetSlideDown` in index.css. The fallback below waits a little
+ * longer than the animation so the event wins the race under normal conditions.
+ */
+const CLOSE_ANIM_MS = 150
+
+let closing = false
+let closeFallbackTimer: ReturnType<typeof setTimeout> | null = null
+
+/** Commit the close exactly once, whatever settled it. */
+function settleClose() {
+  if (closeFallbackTimer) { clearTimeout(closeFallbackTimer); closeFallbackTimer = null }
+  closing = false
+  emit('update:modelValue', false)
+}
+
+/**
+ * Close the sheet. The slide-down animation is decoration — it must never be
+ * the thing that owns `modelValue`.
+ *
+ * This previously emitted the close from a bare one-shot `animationend`
+ * listener, so the app's `settingsOpen` flag only cleared if that event
+ * actually arrived. When it didn't — background the PWA mid-close and iOS
+ * freezes animations on a hidden page, so `sheetSlideDown` never completes —
+ * the emit never fired and `settingsOpen` stayed `true` forever with the sheet
+ * parked off-screen by `animation-fill-mode: forwards`. Nothing could recover
+ * it: the gear button reads `settingsOpen ? closeSettings() : (settingsOpen =
+ * true)`, so it could only ever re-enter this function, and `classList.add` of
+ * an already-present class does NOT restart a CSS animation — no further
+ * `animationend` was ever coming. Settings then refused to open until a full
+ * app reload, which is exactly how the bug was reported.
+ *
+ * Three guarantees now:
+ *  1. `closing` makes the close idempotent — one animation, one settle.
+ *  2. `animationend` bubbles, so the handler matches on this element and this
+ *     animation; a descendant's animation ending can no longer close the sheet
+ *     out from under the user.
+ *  3. A fallback timer settles the close even if the event never lands. CSS
+ *     still drives the motion — the timer only guarantees the state change,
+ *     the same safety net Vue's own <Transition> keeps.
+ */
 function closeSettings() {
-  if (!props.modelValue) return
+  if (!props.modelValue || closing) return
   // Revert any active theme preview
   if (previewTimer) { clearTimeout(previewTimer); previewTimer = null }
   if (previewingThemeId.value) {
@@ -933,12 +974,24 @@ function closeSettings() {
     revertPreview()
   }
   const el = settingsEl.value
-  if (!el) { emit('update:modelValue', false); return }
+  if (!el) { settleClose(); return }
+  closing = true
   el.classList.add('settingsSheetClosing')
-  el.addEventListener('animationend', () => {
-    emit('update:modelValue', false)
-  }, { once: true })
+  const onAnimationEnd = (e: AnimationEvent) => {
+    if (e.target !== el || e.animationName !== 'sheetSlideDown') return
+    el.removeEventListener('animationend', onAnimationEnd)
+    settleClose()
+  }
+  el.addEventListener('animationend', onAnimationEnd)
+  closeFallbackTimer = setTimeout(() => {
+    el.removeEventListener('animationend', onAnimationEnd)
+    settleClose()
+  }, CLOSE_ANIM_MS + 100)
 }
+
+onUnmounted(() => {
+  if (closeFallbackTimer) { clearTimeout(closeFallbackTimer); closeFallbackTimer = null }
+})
 
 defineExpose({ closeSettings })
 

--- a/src/components/__tests__/SettingsSheet.test.ts
+++ b/src/components/__tests__/SettingsSheet.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { ref, reactive } from 'vue'
 import { mount, VueWrapper } from '@vue/test-utils'
 
@@ -438,6 +438,109 @@ describe('SettingsSheet', () => {
       await wrapper.find('.settingsDeleteAccount').trigger('click')
       expect(wrapper.find('.deleteConfirmSheet').exists()).toBe(true)
       expect(mockLogEvent).toHaveBeenCalledWith('delete_account_opened')
+    })
+  })
+
+  // ── Close path ───────────────────────────────────────────────────
+  // Regression: closeSettings() used to emit the close from a bare one-shot
+  // `animationend` listener, so `modelValue` only cleared if that event
+  // arrived. Background the PWA mid-close (iOS freezes animations on a hidden
+  // page) and it never did — App's `settingsOpen` stayed true with the sheet
+  // parked off-screen by `animation-fill-mode: forwards`, and the gear button
+  // (`settingsOpen ? closeSettings() : (settingsOpen = true)`) could only ever
+  // re-enter closeSettings(). Re-adding an already-present class does not
+  // restart a CSS animation, so no further event was coming: settings refused
+  // to open until a full reload.
+  //
+  // These were never caught because the only close assertion in this suite went
+  // through the sign-out path, which emits synchronously — and jsdom never
+  // dispatches `animationend` on its own, so an animation-gated state change is
+  // invisible to the suite by construction. Each test below drives that event
+  // explicitly (or withholds it) to pin the contract.
+  describe('closing', () => {
+    /** jsdom's AnimationEvent support is patchy — build the event by hand. */
+    function animationEnd(animationName: string): Event {
+      const e = new Event('animationend', { bubbles: true })
+      Object.defineProperty(e, 'animationName', { value: animationName })
+      return e
+    }
+    const close = (wrapper: VueWrapper) =>
+      (wrapper.vm as unknown as { closeSettings: () => void }).closeSettings()
+    const closeEmits = (wrapper: VueWrapper) =>
+      (wrapper.emitted('update:modelValue') ?? []).filter(e => e[0] === false)
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('still closes when animationend never fires', () => {
+      vi.useFakeTimers()
+      const wrapper = mountSheet()
+      close(wrapper)
+      // The animation is never allowed to complete — the sheet must not be
+      // able to strand the app in a permanently-open state.
+      expect(closeEmits(wrapper)).toHaveLength(0)
+      vi.advanceTimersByTime(250)
+      expect(closeEmits(wrapper)).toHaveLength(1)
+    })
+
+    it('closes as soon as the slide-down animation ends, and only once', () => {
+      vi.useFakeTimers()
+      const wrapper = mountSheet()
+      const sheet = wrapper.find('.settingsSheet').element
+      close(wrapper)
+      expect(sheet.classList.contains('settingsSheetClosing')).toBe(true)
+
+      sheet.dispatchEvent(animationEnd('sheetSlideDown'))
+      expect(closeEmits(wrapper)).toHaveLength(1)
+
+      // The fallback timer must not fire a second close behind the event.
+      vi.advanceTimersByTime(500)
+      expect(closeEmits(wrapper)).toHaveLength(1)
+    })
+
+    it('ignores animationend bubbling up from a descendant', () => {
+      vi.useFakeTimers()
+      const wrapper = mountSheet()
+      const sheet = wrapper.find('.settingsSheet').element
+      close(wrapper)
+
+      // `animationend` bubbles: any animated descendant inside the sheet would
+      // otherwise satisfy the one-shot listener and close it out from under the
+      // user, mid slide-down.
+      const descendant = sheet.querySelector('.settingsScrollBody')!
+      descendant.dispatchEvent(animationEnd('sheetSlideDown'))
+      expect(closeEmits(wrapper)).toHaveLength(0)
+
+      // A different animation on the sheet itself is likewise not our cue.
+      sheet.dispatchEvent(animationEnd('sheetSlideUp'))
+      expect(closeEmits(wrapper)).toHaveLength(0)
+
+      sheet.dispatchEvent(animationEnd('sheetSlideDown'))
+      expect(closeEmits(wrapper)).toHaveLength(1)
+    })
+
+    it('is idempotent while a close is already in flight', () => {
+      vi.useFakeTimers()
+      const wrapper = mountSheet()
+      const sheet = wrapper.find('.settingsSheet').element
+      // Tapping the gear repeatedly during the 150ms animation must not queue
+      // extra closes — `classList.add` of a present class does not restart the
+      // animation, so re-registering listeners would strand them.
+      close(wrapper)
+      close(wrapper)
+      close(wrapper)
+      sheet.dispatchEvent(animationEnd('sheetSlideDown'))
+      vi.advanceTimersByTime(500)
+      expect(closeEmits(wrapper)).toHaveLength(1)
+    })
+
+    it('closes immediately when the sheet element was never captured', () => {
+      const wrapper = mountSheet(false)
+      // modelValue false → no sheet element, so there is nothing to animate.
+      // (Guarded early-return; the close is a no-op rather than a strand.)
+      close(wrapper)
+      expect(closeEmits(wrapper)).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
Fixes #1079 — "sometimes the settings page won't open until I fully close and reload the app."

## Root cause

`SettingsSheet.closeSettings()` emitted the close from a bare one-shot `animationend` listener, so App's `settingsOpen` flag only cleared if that CSS animation event actually arrived:

```js
el.classList.add('settingsSheetClosing')
el.addEventListener('animationend', () => {
  emit('update:modelValue', false)
}, { once: true })
```

When it doesn't arrive — backgrounding the PWA mid-close freezes animations on a hidden page, so `sheetSlideDown` never completes — the emit never fires. `settingsOpen` stays `true` with the sheet parked off-screen by `animation-fill-mode: forwards`, so nothing is visible.

There was then **no recovery path**:

- The gear reads `settingsOpen ? closeSettings() : (settingsOpen = true)`, so it could only ever re-enter `closeSettings()` — never the open branch.
- `classList.add` of an already-present class does **not** restart a CSS animation, so no further `animationend` was ever coming.
- Every tab tap hit the same dead end (`onBeforeSwitch: closeSettings`).

Only a full reload cleared it. `animationend` appeared exactly once in the codebase — this was the only modal gating a state change on an animation event; every other sheet closes synchronously.

## Changes

**`SettingsSheet.vue`** — the animation is now decoration, never the owner of `modelValue`:
- a `closing` guard makes the close idempotent (one animation, one settle);
- the `animationend` handler matches on this element *and* this animation name. This fixes a **second bug**: `animationend` bubbles, and the listener sat on the wrapper for the entire settings UI, so any descendant's animation ending could close the sheet early, mid slide-down;
- a duration-derived fallback timer settles the close if the event never lands. CSS still drives the motion — the timer only guarantees the state change, the same safety net Vue's own `<Transition>` keeps.

**`App.vue`** — fixes a second, independent stranding path. `closeSettings()` was `settingsSheetRef.value?.closeSettings()`, and `SettingsSheet` is an async component whose ref stays null forever if its chunk fails to resolve (offline, or a stale hash after a deploy). That bare `?.` silently no-opped and left `settingsOpen` true with nothing rendered — same dead gear, same reload-only recovery. It now falls back to clearing the flag directly.

## Why tests missed it

`SettingsSheet.test.ts` had **no coverage of `closeSettings()` at all** — the only close assertion went through the sign-out path, which emits synchronously. And jsdom never dispatches `animationend` on its own, so an animation-gated state change was invisible to the suite by construction.

The new `closing` describe block drives that event explicitly (or withholds it). **Three of its five cases fail against the unfixed source:**

```
× still closes when animationend never fires
× ignores animationend bubbling up from a descendant
× is idempotent while a close is already in flight
```

## Verification

Gates: `npm run lint` clean · `npm test` 2986 passed · `npm run build` OK.

Verified end-to-end in a browser where `requestAnimationFrame` never fires, so **zero** animation events are dispatched — i.e. the exact failure condition. Before the fix the sheet stuck on the first close (`overlay` stayed in the DOM with `settingsSheetClosing` applied and the gear went dead). After:

| step | overlay present |
|---|---|
| open | ✅ |
| close | ❌ |
| **reopen** (previously dead) | ✅ |
| close | ❌ |
| reopen | ✅ |

All three close paths re-verified: gear button, tab switch (`onBeforeSwitch`), and backdrop click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)