### PR TITLE
feat(LIFT-1084): add one-time log-set coach-mark on the starter path

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -130,6 +130,18 @@
       {{ effectiveGymFilter ? 'No exercises match your filters.' : 'No exercises match your search.' }}
     </p>
 
+    <!-- One-time coach-mark: guide the "Popular exercises" starter path to
+         the first log action (LIFT-1084). Points at the circular + button on
+         the first exercise row. -->
+    <div v-if="showStarterLogHint" class="wtLogHint" role="note">
+      <div class="wtLogHintBubble">
+        <svg class="wtLogHintIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16" aria-hidden="true"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+        <span class="wtLogHintText">Tap the <span class="wtLogHintPlus" aria-hidden="true">+</span> on any exercise to log your first set</span>
+        <button class="wtLogHintDismiss" @click="dismissStarterLogHint" aria-label="Dismiss tip">×</button>
+      </div>
+      <span class="wtLogHintArrow" aria-hidden="true"></span>
+    </div>
+
     <ul v-if="filteredExercises.length > 0" class="wtExerciseList">
       <li
         v-for="exercise in filteredExercises"
@@ -1742,6 +1754,28 @@ function openSettingsFromHint() {
   if (ex) openEditExerciseModal(ex)
 }
 
+// ── One-time starter coach-mark (LIFT-1084) ──────────────────────
+// The "Popular exercises" onboarding path pre-loads exercises with zero sets
+// and lands the user on the exercise list, which offers no cue toward the core
+// log action (the fresh-start CTA only renders when there are no exercises).
+// OnboardingScreen arms this flag; we point at the first row's + button until
+// the first set is logged (or the tip is dismissed), then clear it for good.
+const STARTER_LOG_HINT_KEY = 'starter-log-set-hint'
+const starterLogHintPending = ref(localStorage.getItem(STARTER_LOG_HINT_KEY) === 'pending')
+
+const showStarterLogHint = computed(() =>
+  starterLogHintPending.value &&
+  listView.value === 'exercises' &&
+  !isFilteringActive.value &&
+  filteredExercises.value.length > 0 &&
+  store.exercises.every(e => e.sets.length === 0)
+)
+
+function dismissStarterLogHint() {
+  starterLogHintPending.value = false
+  localStorage.removeItem(STARTER_LOG_HINT_KEY)
+}
+
 function adjustReps(delta: number) {
   const current = reps.value ?? 0
   const next = Math.max(0, Math.min(MAX_REPS, current + delta))
@@ -2474,6 +2508,7 @@ function saveSet() {
         localStorage.getItem(FIRST_SET_FLAG) !== 'true' &&
         store.exercises.every(e => e.sets.length === 0)
       store.logSet(exerciseId, effWeightLbs, effReps, date.value)
+      if (starterLogHintPending.value) dismissStarterLogHint()
       recordNudgeAcceptIfAny(exerciseId, effWeightLbs)
       logEvent('set_log', { exercise: selectedExerciseName.value, isPR: wasPR })
       // XP: get the just-logged set (last in array) and compute XP

--- a/src/components/__tests__/OnboardingScreen.test.ts
+++ b/src/components/__tests__/OnboardingScreen.test.ts
@@ -136,6 +136,14 @@ describe('OnboardingScreen', () => {
       )
       expect(sampleDataCalls.length).toBe(0)
     })
+
+    it('does not arm the starter coach-mark flag (scoped to the Popular path)', async () => {
+      await chooseEmptyAndSkip()
+      const hintCalls = localStorageMock.setItem.mock.calls.filter(
+        ([key]: [string]) => key === 'starter-log-set-hint'
+      )
+      expect(hintCalls.length).toBe(0)
+    })
   })
 
   describe('Popular exercises', () => {
@@ -160,6 +168,11 @@ describe('OnboardingScreen', () => {
     it('does not log any sets', async () => {
       await wrapper.findAll('.obOption')[0].trigger('click')
       expect(mockLogSet).not.toHaveBeenCalled()
+    })
+
+    it('arms the one-time log-set coach-mark flag (LIFT-1084)', async () => {
+      await wrapper.findAll('.obOption')[0].trigger('click')
+      expect(localStorageMock.setItem).toHaveBeenCalledWith('starter-log-set-hint', 'pending')
     })
 
     it('sets plate calculator mode on barbell exercises via store method', async () => {

--- a/src/components/__tests__/WorkoutTracker.test.ts
+++ b/src/components/__tests__/WorkoutTracker.test.ts
@@ -1123,6 +1123,71 @@ describe('WorkoutTracker', () => {
     })
   })
 
+  describe('starter log-set coach-mark (LIFT-1084)', () => {
+    /** Starter-path fixture: exercises pre-loaded with zero sets, mirroring the
+     *  6-exercise "Popular exercises" onboarding pre-load (≥5 so the search bar
+     *  renders, matching the real path). */
+    function createStarterExercises(): Exercise[] {
+      return [
+        { id: 'ex-1', name: 'Bench Press', tags: ['Chest'], sets: [] },
+        { id: 'ex-2', name: 'Squat', tags: ['Legs'], sets: [] },
+        { id: 'ex-3', name: 'Deadlift', tags: ['Back'], sets: [] },
+        { id: 'ex-4', name: 'Overhead Press', tags: ['Shoulders'], sets: [] },
+        { id: 'ex-5', name: 'Row', tags: ['Back'], sets: [] },
+        { id: 'ex-6', name: 'Pull-ups', tags: ['Back'], sets: [] },
+      ]
+    }
+
+    it('shows the coach-mark on the starter path (flag pending, no sets yet)', () => {
+      localStorageMock.setItem('starter-log-set-hint', 'pending')
+      mockState.exercises = createStarterExercises()
+      const wrapper = mountTracker()
+
+      expect(wrapper.find('.wtLogHint').exists()).toBe(true)
+      expect(wrapper.find('.wtLogHintText').text()).toContain('log your first set')
+    })
+
+    it('does not show the coach-mark when the flag was never armed', () => {
+      mockState.exercises = createStarterExercises()
+      const wrapper = mountTracker()
+
+      expect(wrapper.find('.wtLogHint').exists()).toBe(false)
+    })
+
+    it('does not show once any exercise already has a logged set', () => {
+      localStorageMock.setItem('starter-log-set-hint', 'pending')
+      // createExercises() ships exercises that already carry sets.
+      mockState.exercises = createExercises()
+      const wrapper = mountTracker()
+
+      expect(wrapper.find('.wtLogHint').exists()).toBe(false)
+    })
+
+    it('hides while a search filter is active (the pointer targets the first row)', async () => {
+      localStorageMock.setItem('starter-log-set-hint', 'pending')
+      mockState.exercises = createStarterExercises()
+      const wrapper = mountTracker()
+      expect(wrapper.find('.wtLogHint').exists()).toBe(true)
+
+      await wrapper.find('input[type="search"]').setValue('Bench')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.wtLogHint').exists()).toBe(false)
+    })
+
+    it('dismiss button clears the flag and hides the coach-mark', async () => {
+      localStorageMock.setItem('starter-log-set-hint', 'pending')
+      mockState.exercises = createStarterExercises()
+      const wrapper = mountTracker()
+
+      await wrapper.find('.wtLogHintDismiss').trigger('click')
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.find('.wtLogHint').exists()).toBe(false)
+      expect(localStorageMock.getItem('starter-log-set-hint')).toBeNull()
+    })
+  })
+
   describe('usual ladder & ghost logging (#741)', () => {
     /** Local calendar date, matching the component's todayISO(). */
     function localDay(daysAgo = 0): string {

--- a/src/index.css
+++ b/src/index.css
@@ -4756,6 +4756,77 @@ html.theme-fading .settingsSheet {
   border-radius: 8px;
 }
 
+/* One-time starter coach-mark (LIFT-1084) — points at the first exercise
+   row's circular + log button. Reuses the WCAG-validated plate-hint palette
+   (elevated bg + accent border + secondary text) so contrast holds in all
+   10 themes; the accent border/badge give it a touch more prominence as the
+   primary activation nudge. */
+.wtLogHint {
+  position: relative;
+  width: 100%;
+  margin: 8px 0 0;
+}
+
+.wtLogHintBubble {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--accent);
+  border-radius: 12px;
+  font-size: 0.8125rem;  /* 13px */
+  color: var(--text-secondary);
+  text-align: left;
+  box-shadow: var(--shadow-sm);
+}
+
+.wtLogHintIcon {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.wtLogHintText {
+  flex: 1;
+  min-width: 0;
+  line-height: 1.3;
+}
+
+.wtLogHintPlus {
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.wtLogHintDismiss {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.125rem;  /* 18px */
+  cursor: pointer;
+  margin: -12px -8px -12px 0;
+  border-radius: 8px;
+}
+
+/* Caret pointing down-right toward the first row's + button. Borders match
+   the bubble so the visible corner reads as one shape. */
+.wtLogHintArrow {
+  position: absolute;
+  right: 20px;
+  bottom: -6px;
+  width: 11px;
+  height: 11px;
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--accent);
+  border-bottom: 1px solid var(--accent);
+  transform: rotate(45deg);
+}
+
 .wtPlateCalc {
   padding: 0;
 }

--- a/src/views/OnboardingScreen.vue
+++ b/src/views/OnboardingScreen.vue
@@ -481,6 +481,10 @@ function chooseStarter() {
       workoutStore.setExerciseInputMode(id, ex.inputMode)
     }
   }
+  // Arm the one-time "log your first set" coach-mark (LIFT-1084): this path
+  // pre-loads exercises but zero sets, so the exercise list otherwise offers
+  // no cue toward the core log action. WorkoutTracker consumes + clears this.
+  localStorage.setItem('starter-log-set-hint', 'pending')
   goToStarter(false)
 }
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1084](https://github.com/aschung212/Lift/issues/1084)

Implement LIFT-1084: add a one-time, dismissible "log your first set" coach-mark on the "Popular exercises" onboarding starter path, which pre-loads 6 exercises with zero sets and otherwise offers no guidance toward the core log action.

## Changes
- **`src/views/OnboardingScreen.vue`** — `chooseStarter()` arms a one-time `starter-log-set-hint` localStorage flag (scoped to the Popular path only; empty/explore paths don't set it).
- **`src/components/WorkoutTracker.vue`** — added `showStarterLogHint` computed (flag pending + exercises view + unfiltered + no set logged anywhere) and a dismissible coach-mark above the exercise list pointing at the first row's circular `+` log button. Self-clears on the first logged set (in `saveSet`) or on dismiss, mirroring the existing plate-calc hint pattern.
- **`src/index.css`** — `.wtLogHint` styles reusing the WCAG-validated plate-hint palette (elevated bg + accent border + secondary text) with a caret; 44pt dismiss target.
- **Tests** — 5 WorkoutTracker cases (shows/hides on flag, existing-sets, filter-active, dismiss-clears-flag) + 2 OnboardingScreen cases (arms flag on Popular path, not on empty path).

## Verification
- `npm test` — 3008 passed | 1 skipped (7 new tests)
- `npm run lint` — clean
- `npm run build` — succeeds
- Post-commit adversarial review — `REVIEW_CLEAN` / `MERGE`

## Screenshots
None (no simulator/browser session in this iteration; behavior covered by component tests).

## Commits
- [`f667c71`](https://github.com/aschung212/Lift/commit/f667c71) feat(LIFT-1084): add one-time log-set coach-mark on the starter path

## Test Results
- Before: 3001 passing
- After: 3008 passing (7 delta)

---
_Automated by overnight pipeline — Tue Aug  4 23:20:57 PDT 2026_

## Preview
Test on your phone: https://lift-9ir062k2y-aschung212-1101s-projects.vercel.app