### PR TITLE
feat(LIFT-1083): add local-only "Continue without an account" guest mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,14 @@
           Viewing sample data — Tap to clear and start fresh
         </button>
 
+        <div v-if="showGuestBackupPrompt" class="guestBackupBanner" role="status">
+          <span class="guestBackupText">Your workouts are saved on this device only.</span>
+          <button class="guestBackupCta" @click="createAccountFromGuest">Create account</button>
+          <button class="guestBackupDismiss" @click="dismissGuestBackupPrompt" aria-label="Dismiss">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
+        </div>
+
         <!-- PWA install banner -->
         <Transition name="installBanner">
           <div v-if="installBannerVisible" class="installBanner" role="banner">
@@ -304,6 +312,7 @@ import { todayISO, toLocalDateKey } from './lib/dates'
 import { useOnboarding } from './composables/useOnboarding'
 import { useTabRouting } from './composables/useTabRouting'
 import { onCrossTabMessage, type StoreKey } from './lib/crossTabSync'
+import { GUEST_BACKUP_PROMPT_DISMISSED_KEY } from './composables/useAuth'
 
 const { currentTheme, THEME_PREVIEWS, resolvedMode, isThemeUnlocked } = useTheme()
 
@@ -311,7 +320,7 @@ const progressionStore = useProgressionStore()
 connectProgressionStore(() => progressionStore)
 const { celebrateUnlocks } = useXPCeremony()
 
-const { user, loading, init: initAuth, signOut } = useAuth()
+const { user, loading, isGuest, init: initAuth, signOut, exitGuestMode } = useAuth()
 const { logEvent, tabSwitch, flushEngagement } = useAnalytics()
 const prefs = usePreferencesStore()
 const { toast: undoToast, performUndo } = useUndoToast()
@@ -449,8 +458,35 @@ function closeSettings() {
 
 // ── Sign out handler (from SettingsSheet) ────────────────────────
 function handleSignOut() {
+  // A guest has no server account — "signing out" just returns them to the
+  // auth screen so they can create one. Preserve local data (no resetStores)
+  // so signing up migrates their existing workouts (LIFT-1083).
+  if (isGuest.value) {
+    exitGuestMode()
+    return
+  }
   resetOnboarding()
   signOut()
+}
+
+// ── Guest "create an account to back up" nudge (LIFT-1083) ───────
+// Surfaced only once a guest has real (non-sample) workout data — the point at
+// which they have something worth losing. Dismissal persists so it doesn't nag.
+const guestPromptDismissed = ref(localStorage.getItem(GUEST_BACKUP_PROMPT_DISMISSED_KEY) === 'true')
+const showGuestBackupPrompt = computed(() =>
+  isGuest.value &&
+  !hasSampleData.value &&
+  !guestPromptDismissed.value &&
+  workoutStore.workoutDates.length > 0,
+)
+function createAccountFromGuest() {
+  logEvent('guest_create_account_tap')
+  exitGuestMode()
+}
+function dismissGuestBackupPrompt() {
+  guestPromptDismissed.value = true
+  localStorage.setItem(GUEST_BACKUP_PROMPT_DISMISSED_KEY, 'true')
+  logEvent('guest_backup_prompt_dismissed')
 }
 
 // ── Acquisition attribution ─────────────────────────────────────

--- a/src/components/__tests__/AuthScreen.test.ts
+++ b/src/components/__tests__/AuthScreen.test.ts
@@ -6,12 +6,16 @@ import AuthScreen from '../../views/AuthScreen.vue'
 const mockSignInWithProvider = vi.fn().mockResolvedValue({ error: null })
 const mockSignInWithEmail = vi.fn().mockResolvedValue({ error: null })
 const mockSignUp = vi.fn().mockResolvedValue({ error: null, needsConfirmation: false })
+const mockContinueAsGuest = vi.fn()
+const mockDevSignIn = vi.fn()
 
 vi.mock('../../composables/useAuth', () => ({
   useAuth: () => ({
     signInWithProvider: mockSignInWithProvider,
     signInWithEmail: mockSignInWithEmail,
     signUp: mockSignUp,
+    continueAsGuest: mockContinueAsGuest,
+    devSignIn: mockDevSignIn,
   })
 }))
 
@@ -233,6 +237,25 @@ describe('AuthScreen', () => {
       await wrapper.find('form').trigger('submit')
       await flushPromises()
       expect(wrapper.findAll('.authInput')[0].attributes('aria-invalid')).toBeUndefined()
+    })
+  })
+
+  describe('continue without an account (LIFT-1083)', () => {
+    it('renders a guest entry that defers sign-up', () => {
+      const btn = wrapper.find('.authGuestBtn')
+      expect(btn.exists()).toBe(true)
+      expect(btn.text()).toBe('Continue without an account')
+    })
+
+    it('explains that local-only data can be backed up later', () => {
+      const hint = wrapper.find('.authGuestHint')
+      expect(hint.exists()).toBe(true)
+      expect(hint.text()).toContain('this device')
+    })
+
+    it('enters guest mode when clicked', async () => {
+      await wrapper.find('.authGuestBtn').trigger('click')
+      expect(mockContinueAsGuest).toHaveBeenCalledOnce()
     })
   })
 

--- a/src/composables/__tests__/useAuth.test.ts
+++ b/src/composables/__tests__/useAuth.test.ts
@@ -217,6 +217,44 @@ describe('useAuth', () => {
     })
   })
 
+  describe('guest mode (LIFT-1083)', () => {
+    it('continueAsGuest sets a local user without initializing stores/Supabase', async () => {
+      const { continueAsGuest, user, isGuest, loading } = useAuth()
+      continueAsGuest()
+      expect(user.value).toEqual({ id: 'guest-local', email: '' })
+      expect(isGuest.value).toBe(true)
+      expect(loading.value).toBe(false)
+      // A guest must never hit Supabase — no migration is kicked off.
+      const { migrateLocalStorageToSupabase } = await import('../../lib/migrate')
+      expect(migrateLocalStorageToSupabase).not.toHaveBeenCalled()
+    })
+
+    it('persists the guest flag so a reload restores the session', () => {
+      const { continueAsGuest } = useAuth()
+      continueAsGuest()
+      expect(localStorageMock.getItem('guest-mode')).toBe('true')
+    })
+
+    it('exitGuestMode returns to the auth screen without wiping local data', async () => {
+      const { continueAsGuest, exitGuestMode, user, isGuest } = useAuth()
+      continueAsGuest()
+      mockWorkoutReset.mockClear()
+
+      exitGuestMode()
+
+      expect(user.value).toBeNull()
+      expect(isGuest.value).toBe(false)
+      expect(localStorageMock.getItem('guest-mode')).toBeNull()
+      // Local data must be preserved so a later sign-up can migrate it.
+      expect(mockWorkoutReset).not.toHaveBeenCalled()
+    })
+
+    it('exposes isGuest as a reactive ref defaulting to false', () => {
+      const { isGuest } = useAuth()
+      expect(isGuest.value).toBe(false)
+    })
+  })
+
   describe('destroy', () => {
     it('calls unsubscribe on the auth state change subscription', () => {
       const mockUnsubscribe = vi.fn()

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -21,18 +21,35 @@ interface AuthError {
 export interface UseAuthReturn {
   user: Ref<User | { id: string; email: string } | null>
   loading: Ref<boolean>
+  isGuest: Ref<boolean>
   init: () => void
   signInWithProvider: (provider: Provider) => Promise<{ error: AuthError | null }>
   signInWithEmail: (email: string, password: string) => Promise<{ error: AuthError | null }>
   signUp: (email: string, password: string) => Promise<{ error: AuthError | null; needsConfirmation?: boolean }>
   signOut: () => Promise<void>
   devSignIn: () => Promise<void>
+  continueAsGuest: () => void
+  exitGuestMode: () => void
   deleteAccount: () => Promise<void>
   destroy: () => void
 }
 
+// Local-only "guest" mode (LIFT-1083): the app is local-first (Pinia +
+// localStorage is the source of truth), so it fully works with no account.
+// A guest sets a local user identity WITHOUT calling initStores — so the
+// stores' `_userId` stays null and nothing is ever enqueued to Supabase. The
+// flag is persisted so the guest is restored on reload instead of being bounced
+// back to the auth gate. When a guest later creates a real account, the normal
+// SIGNED_IN path runs initStores → migrateLocalStorageToSupabase, so their
+// device-local data is backed up on conversion.
+const GUEST_MODE_KEY = 'guest-mode'
+const GUEST_USER_ID = 'guest-local'
+/** Persisted dismissal of the "create an account to back up" nudge (App.vue). */
+export const GUEST_BACKUP_PROMPT_DISMISSED_KEY = 'guest-backup-prompt-dismissed'
+
 const user: Ref<User | { id: string; email: string } | null> = ref(null)
 const loading: Ref<boolean> = ref(true)
+const isGuest: Ref<boolean> = ref(false)
 
 let _initialized = false
 let _authUnsubscribe: (() => void) | null = null
@@ -123,41 +140,103 @@ async function initStores(userId: string): Promise<void> {
   syncSettingsWithComposables()
 }
 
+/** Clear guest mode (a real session supersedes it). */
+function clearGuestFlag(): void {
+  isGuest.value = false
+  localStorage.removeItem(GUEST_MODE_KEY)
+}
+
+/**
+ * Restore a persisted guest session so a reload keeps the user in the app
+ * instead of bouncing them back to the auth gate. Returns true if a guest was
+ * restored.
+ */
+function restoreGuestIfFlagged(): boolean {
+  if (localStorage.getItem(GUEST_MODE_KEY) === 'true') {
+    isGuest.value = true
+    user.value = { id: GUEST_USER_ID, email: '' }
+    return true
+  }
+  return false
+}
+
 function init(): void {
   if (_initialized) return
   _initialized = true
 
   // Dev mode or Supabase unavailable: fall back to local-only mode
   if (import.meta.env.DEV || !supabase) {
+    restoreGuestIfFlagged()
     loading.value = false
     return
   }
 
   supabase.auth.getSession().then(({ data: { session } }) => {
-    user.value = session?.user ?? null
     if (session?.user) {
+      user.value = session.user
+      // A real session supersedes any prior guest mode.
+      clearGuestFlag()
       initStores(session.user.id).then(() => { loading.value = false })
     } else {
+      user.value = null
+      restoreGuestIfFlagged()
       loading.value = false
     }
   }).catch((err) => {
     logError(err, { source: 'useAuth', action: 'getSession' })
+    restoreGuestIfFlagged()
     loading.value = false
   })
 
   const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
     const prev = user.value
-    user.value = session?.user ?? null
+    // A guest converting to a real account has a truthy `prev` (the guest
+    // identity), so `!prev` alone would skip initStores — and with it the
+    // local→Supabase migration. Init when the previous state had no real
+    // account: either signed out (`!prev`) or a guest (LIFT-1083).
+    const wasUnauthenticated = !prev || isGuest.value
     // A successful (re)auth means the token is healthy again — clear any
     // pending "re-sign-in needed" prompt (LIFT-784).
     if (event === 'TOKEN_REFRESHED' || event === 'SIGNED_IN') clearReauthFlag()
-    if (session?.user && !prev) {
-      initStores(session.user.id)
+    if (session?.user) {
+      user.value = session.user
+      if (wasUnauthenticated) {
+        clearGuestFlag()
+        initStores(session.user.id)
+      }
+    } else if (event === 'SIGNED_OUT') {
+      // Only an explicit sign-out clears the user. A null-session
+      // INITIAL_SESSION event must NOT clobber a guest that getSession()
+      // restored, or the guest would be bounced back to the auth gate.
+      user.value = null
     }
   })
   _authUnsubscribe = () => subscription.unsubscribe()
 
   setupSessionRefreshLifecycle()
+}
+
+/**
+ * Enter local-only guest mode (LIFT-1083). Deliberately does NOT init stores:
+ * the stores already hydrated from localStorage at instantiation, and leaving
+ * `_userId` null keeps every write local (nothing is enqueued to Supabase). The
+ * user is prompted to create an account later to back up / sync.
+ */
+function continueAsGuest(): void {
+  localStorage.setItem(GUEST_MODE_KEY, 'true')
+  isGuest.value = true
+  user.value = { id: GUEST_USER_ID, email: '' }
+  loading.value = false
+}
+
+/**
+ * Leave guest mode to return to the auth screen (e.g. to create an account).
+ * Preserves all local data — does NOT resetStores — so signing up migrates the
+ * guest's existing workouts to their new account.
+ */
+function exitGuestMode(): void {
+  clearGuestFlag()
+  user.value = null
 }
 
 async function signInWithProvider(provider: Provider): Promise<{ error: AuthError | null }> {
@@ -249,7 +328,7 @@ async function deleteAccount(): Promise<void> {
     'onboarding-complete', 'sample-data', 'active-tab', 'wt-list-view',
     'rest-duration', 'rest-warning-options', 'rest-warnings', 'rest-presets-disabled', 'rest-presets',
     'app-theme', 'app-mode', 'app-glass', 'rest-timer', 'rest-timer-autostart', 'weight-unit',
-    'coach-insights-history',
+    'coach-insights-history', GUEST_MODE_KEY, GUEST_BACKUP_PROMPT_DISMISSED_KEY,
   ]
   for (const key of localStorageKeys) {
     localStorage.removeItem(key)
@@ -284,5 +363,5 @@ function destroy(): void {
 }
 
 export function useAuth(): UseAuthReturn {
-  return { user, loading, init, signInWithProvider, signInWithEmail, signUp, signOut, devSignIn, deleteAccount, destroy }
+  return { user, loading, isGuest, init, signInWithProvider, signInWithEmail, signUp, signOut, devSignIn, continueAsGuest, exitGuestMode, deleteAccount, destroy }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -873,6 +873,60 @@ button, [role="tab"], [role="switch"], a {
   flex-shrink: 0;
 }
 
+/* Guest "create an account to back up" nudge (LIFT-1083) */
+.guestBackupBanner {
+  width: 100%;
+  padding: 8px 12px;
+  min-height: 44px;
+  background: var(--accent-subtle);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.guestBackupText {
+  flex: 1;
+  font-size: var(--font-footnote);
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-align: left;
+}
+
+.guestBackupCta {
+  flex-shrink: 0;
+  min-height: 44px;
+  padding: 4px 12px;
+  font-size: var(--font-caption1);
+  font-weight: 700;
+  font-family: inherit;
+  color: var(--text-on-accent);
+  background: var(--accent);
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+}
+
+.guestBackupDismiss {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.guestBackupDismiss svg {
+  width: 18px;
+  height: 18px;
+}
+
 /* PWA install banner */
 .installBanner {
   width: 100%;

--- a/src/views/AuthScreen.vue
+++ b/src/views/AuthScreen.vue
@@ -57,6 +57,9 @@
         </button>
       </div>
 
+      <button class="authGuestBtn" @click="handleGuest">Continue without an account</button>
+      <p class="authGuestHint">Your workouts stay on this device. Create an account any time to back up &amp; sync.</p>
+
       <button v-if="isDev" class="authDevBtn" @click="devSignIn">Continue as Dev</button>
 
       <p v-if="message" :class="['authMessage', { authError: isError, authSuccess: !isError }]" :id="isError ? 'auth-error' : undefined" role="status" aria-live="polite">{{ message }}</p>
@@ -70,7 +73,7 @@ import type { Provider } from '@supabase/supabase-js'
 import { useAuth } from '../composables/useAuth'
 import { useAnalytics } from '../composables/useAnalytics'
 
-const { signInWithProvider, signInWithEmail, signUp, devSignIn } = useAuth()
+const { signInWithProvider, signInWithEmail, signUp, devSignIn, continueAsGuest } = useAuth()
 const { logEvent } = useAnalytics()
 // Show the dev sign-in button in local dev mode OR in CI e2e builds where
 // no Supabase backend is configured. import.meta.env values are inlined at
@@ -120,6 +123,11 @@ async function handleEmailSubmit() {
   }
 
   submitting.value = false
+}
+
+function handleGuest() {
+  logEvent('auth_continue_as_guest')
+  continueAsGuest()
 }
 
 async function handleOAuth(provider: Provider) {
@@ -303,6 +311,38 @@ async function handleOAuth(provider: Provider) {
 
 .authProviderIcon {
   flex-shrink: 0;
+}
+
+.authGuestBtn {
+  width: 100%;
+  padding: 12px 16px;
+  min-height: 44px;
+  margin-top: 12px;
+  font-size: var(--font-subhead);
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.authGuestBtn:hover {
+  background: var(--bg-elevated);
+  border-color: var(--accent);
+}
+
+.authGuestBtn:active {
+  opacity: 0.85;
+}
+
+.authGuestHint {
+  margin-top: 8px;
+  font-size: var(--font-caption1);
+  color: var(--text-muted);
+  line-height: 1.4;
 }
 
 .authDevBtn {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1083](https://github.com/aschung212/Lift/issues/1083)

Implement LIFT-1083: add a local-only "Continue without an account" entry on AuthScreen so users can defer sign-up until after they've experienced first value, leveraging the app's existing local-first architecture (Pinia + localStorage is the source of truth; Supabase only syncs in the background).

## Changes
- **`src/composables/useAuth.ts`** — Added guest mode: `isGuest` ref, `continueAsGuest()` (sets a local user identity without calling `initStores`, so stores' `_userId` stays null and nothing is enqueued to Supabase), `exitGuestMode()` (returns to auth screen preserving local data), and a persisted `guest-mode` flag with `restoreGuestIfFlagged()`/`clearGuestFlag()`. Reworked `init()` to restore a persisted guest on reload and reworked `onAuthStateChange` so a guest→real-account conversion still runs `initStores` → `migrateLocalStorageToSupabase` (guest's `prev` is truthy, so the old `!prev` guard would have skipped migration), while a null-session `INITIAL_SESSION` event no longer clobbers a restored guest. Added guest keys to the `deleteAccount` cleanup list.
- **`src/views/AuthScreen.vue`** — Added the "Continue without an account" button + a hint line explaining data stays on-device and can be backed up later; theme-token styling, 44pt targets.
- **`src/App.vue`** — Guest-aware `handleSignOut` (exits guest mode without wiping data), plus a dismissible "saved on this device only / Create account" nudge that surfaces only once a guest has real (non-sample) workout data (persisted dismissal).
- **`src/index.css`** — `.guestBackupBanner` styling (theme vars, 44pt controls).
- **Tests** — Guest-mode unit tests in `useAuth.test.ts` (local-only entry, no Supabase migration, persisted flag, non-destructive exit) and AuthScreen rendering/click tests.

## Verification
- `npm run lint` — clean
- `npm run build` — typecheck + build pass
- `npx vitest run` — 3008 passed | 1 skipped (was 3001; +7 new)
- Post-commit adversarial review (Sonnet): `REVIEW_CLEAN` / `MERGE`
- Pushed `enhance/run3-2026-08-04`; open PR: https://github.com/aschung212/Lift/pull/new/enhance/run3-2026-08-04

## Screenshots
None (headless enhancer run; the preview browser lacks rAF and I avoided unreliable visual repro). New UI is covered by component tests and follows the existing banner/button patterns and theme tokens.

## Commits
- [`bce0bfd`](https://github.com/aschung212/Lift/commit/bce0bfd) feat(LIFT-1083): add local-only "Continue without an account" guest mode

## Test Results
- Before: 3001 passing
- After: 3008 passing (7 delta)

---
_Automated by overnight pipeline — Tue Aug  4 23:36:18 PDT 2026_

## Preview
Test on your phone: https://lift-ga066zcrt-aschung212-1101s-projects.vercel.app