### PR TITLE
feat(LIFT-906): fire the supporter impression on visibility, not on settings-open

### DIFF
--- a/_genwide.test.mjs
+++ b/_genwide.test.mjs
@@ -1,0 +1,3 @@
+// Scratch file (untracked, not part of the PR). Intentionally a no-op.
+import { it, expect } from 'vitest'
+it('noop', () => { expect(true).toBe(true) })

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -19,6 +19,34 @@ const localStorageMock = (() => {
 
 vi.stubGlobal('localStorage', localStorageMock)
 
+// ── IntersectionObserver mock ─────────────────────────────────────
+// happy-dom ships no IntersectionObserver. Components use it to detect when an
+// element actually scrolls into view (e.g. SettingsSheet's supporter-funnel
+// impression, LIFT-906). This controllable stub records every live observer in
+// `mockIntersectionObservers` so a test can fire an intersection deliberately
+// via `instance.trigger(isIntersecting)` rather than guessing at real layout.
+class MockIntersectionObserver {
+  callback: IntersectionObserverCallback
+  elements = new Set<Element>()
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb
+    mockIntersectionObservers.push(this)
+  }
+  observe(el: Element): void { this.elements.add(el) }
+  unobserve(el: Element): void { this.elements.delete(el) }
+  disconnect(): void { this.elements.clear() }
+  takeRecords(): IntersectionObserverEntry[] { return [] }
+  /** Test helper — fire the callback for every currently-observed target. */
+  trigger(isIntersecting = true): void {
+    const entries = [...this.elements].map(
+      (target) => ({ isIntersecting, target } as IntersectionObserverEntry),
+    )
+    if (entries.length) this.callback(entries, this as unknown as IntersectionObserver)
+  }
+}
+export const mockIntersectionObservers: MockIntersectionObserver[] = []
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+
 // ── Supabase mock ────────────────────────────────────────────────
 // Most tests need supabase stubbed to null (local-first architecture).
 vi.mock('../lib/supabase', () => ({ supabase: null }))
@@ -35,5 +63,6 @@ vi.mock('../lib/supabase', () => ({ supabase: null }))
 // files reset their own store in beforeEach, so nothing leaks.
 afterEach(() => {
   localStorage.clear?.()
+  mockIntersectionObservers.length = 0
   vi.clearAllMocks()
 })

--- a/src/components/SettingsSheet.vue
+++ b/src/components/SettingsSheet.vue
@@ -545,7 +545,7 @@
         </div>
 
 
-        <div class="settingsGroup">
+        <div ref="supportGroupEl" class="settingsGroup">
           <div class="settingsHeader">Support</div>
           <button class="settingsRow settingsRowBtn" :disabled="appShareInFlight" @click="shareLift">
             <span class="settingsLabel">
@@ -837,11 +837,47 @@ async function shareLift() {
 
 // ── Supporter conversion funnel (LIFT-906) ─────────────────────
 // Instrument the Support-group CTAs so tip-jar vs. subscription can be a
-// data-driven decision before any IAP is wired. Impression fires once per
-// settings-open (proxy for "the Support group was reachable"); taps fire on
-// each external CTA. The default navigation is left untouched.
+// data-driven decision before any IAP is wired. Taps fire on each external
+// CTA; the default navigation is left untouched.
 function onSupportTap(cta: 'github_sponsors' | 'buymeacoffee') {
   supportFunnel('tap', { cta })
+}
+
+// The impression is the TOP of the funnel, so it must mean "the user actually
+// saw the Support CTAs" — not merely "opened Settings". The Support group is
+// the 12th of 14 groups, near the bottom of a long scroll, so firing on open
+// counted a mostly-unseen CTA and made tap/impression conversion meaningless.
+// Fire it once per settings-open, only when the group scrolls into view.
+const supportGroupEl = ref<HTMLElement | null>(null)
+let supportObserver: IntersectionObserver | null = null
+let impressionLogged = false
+
+function armSupportImpression() {
+  if (impressionLogged) return
+  const el = supportGroupEl.value
+  if (!el) return
+  // Platforms without IntersectionObserver (should not happen on iOS 12.2+ /
+  // modern Chromium) fall back to the old open-time proxy so the funnel top is
+  // never silently empty.
+  if (typeof IntersectionObserver === 'undefined') {
+    impressionLogged = true
+    supportFunnel('impression')
+    return
+  }
+  supportObserver = new IntersectionObserver((entries) => {
+    if (impressionLogged) return
+    if (entries.some((e) => e.isIntersecting)) {
+      impressionLogged = true
+      supportFunnel('impression')
+      disarmSupportImpression()
+    }
+  })
+  supportObserver.observe(el)
+}
+
+function disarmSupportImpression() {
+  supportObserver?.disconnect()
+  supportObserver = null
 }
 
 // ── App icon picker (native iOS only) ──────────────────────────
@@ -925,12 +961,15 @@ const confirmFocus = useFocusTrap()
 watch(() => props.modelValue, (open) => {
   if (open) {
     settingsModal.open()
-    // Top of the supporter funnel (LIFT-906): the Support group renders with
-    // the sheet, so an open is one impression opportunity for its CTAs.
-    supportFunnel('impression')
+    // Top of the supporter funnel (LIFT-906): arm a visibility observer so the
+    // impression fires only once the Support group actually scrolls into view,
+    // not merely because Settings opened. nextTick so the ref is populated.
+    nextTick(armSupportImpression)
   } else {
     settingsModal.close()
     settingsSwipe.detach()
+    disarmSupportImpression()
+    impressionLogged = false
   }
 }, { immediate: true })
 
@@ -1012,6 +1051,7 @@ function closeSettings() {
 
 onUnmounted(() => {
   if (closeFallbackTimer) { clearTimeout(closeFallbackTimer); closeFallbackTimer = null }
+  disarmSupportImpression()
 })
 
 defineExpose({ closeSettings })

--- a/src/components/__tests__/SettingsSheet.test.ts
+++ b/src/components/__tests__/SettingsSheet.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { ref, reactive, defineComponent } from 'vue'
+import { ref, reactive, defineComponent, nextTick } from 'vue'
 import { mount, VueWrapper, enableAutoUnmount } from '@vue/test-utils'
 import { useModal } from '../../composables/useModal'
+import { mockIntersectionObservers } from '../../__tests__/setup'
+
+// The Support-group visibility observer (LIFT-906) is the most-recently armed
+// IntersectionObserver; grab it to fire an intersection deliberately.
+function lastIntersectionObserver() {
+  const observer = mockIntersectionObservers.at(-1)
+  if (!observer) throw new Error('no IntersectionObserver was armed')
+  return observer
+}
 
 // Unmount every wrapper after each test. The sheet now holds a background-
 // scroll lock while open, and useModal's reference count is module state
@@ -23,10 +32,10 @@ const mockSupportFunnel = vi.fn()
 vi.mock('../../composables/useAnalytics', () => ({
   useAnalytics: () => ({
     logEvent: mockLogEvent,
-    // The supporter-funnel impression (LIFT-906) fires on open. It was absent
-    // from this mock and nothing noticed, because the open branch was gated on
-    // a false→true prop transition that never happens — App.vue mounts the
-    // sheet with `v-if="settingsOpen"` (#955), so it arrives already-open.
+    // The supporter-funnel impression (LIFT-906) fires when the Support group
+    // actually scrolls into view (via IntersectionObserver), not on open — so
+    // tap/impression stays a meaningful conversion rate rather than counting
+    // every Settings open, where the Support group (12th of 14) is unseen.
     supportFunnel: mockSupportFunnel,
     tabSwitch: vi.fn(),
     flushEngagement: vi.fn(),
@@ -562,19 +571,40 @@ describe('SettingsSheet', () => {
   })
 
   describe('supporter funnel (LIFT-906)', () => {
-    it('logs one impression when the sheet is mounted open', () => {
-      // App.vue mounts the sheet with `v-if="settingsOpen"` (#955), so it is
-      // already open on mount. The impression used to hang off a non-immediate
-      // false→true prop watch, which that mounting pattern never triggers — so
-      // no impression was ever recorded on the only path that opens the sheet.
+    it('does not log an impression until the Support group scrolls into view', async () => {
+      // App.vue mounts the sheet already-open (#955), but the Support group is
+      // 12th of 14 groups — firing on open counted a mostly-unseen CTA. The
+      // impression must wait for the group to actually enter the viewport.
       mountSheet(true)
+      await nextTick()
+      expect(mockSupportFunnel).not.toHaveBeenCalled()
+
+      // The visibility observer for the Support group is the latest one armed.
+      lastIntersectionObserver().trigger(true)
       expect(mockSupportFunnel).toHaveBeenCalledWith('impression')
       expect(mockSupportFunnel).toHaveBeenCalledTimes(1)
     })
 
-    it('logs no impression when mounted closed', () => {
+    it('logs the impression only once even if the group re-enters view', async () => {
+      mountSheet(true)
+      await nextTick()
+      const observer = lastIntersectionObserver()
+      observer.trigger(true)
+      observer.trigger(true) // scrolled away and back within the same open
+      expect(mockSupportFunnel).toHaveBeenCalledTimes(1)
+    })
+
+    it('logs no impression when mounted closed', async () => {
       mountSheet(false)
+      await nextTick()
+      expect(mockIntersectionObservers).toHaveLength(0)
       expect(mockSupportFunnel).not.toHaveBeenCalled()
+    })
+
+    it('taps still report the CTA regardless of the impression gate', () => {
+      const wrapper = mountSheet(true)
+      wrapper.find('a[href="https://github.com/sponsors/aschung212"]').trigger('click')
+      expect(mockSupportFunnel).toHaveBeenCalledWith('tap', { cta: 'github_sponsors' })
     })
   })
 

--- a/src/composables/useAnalytics.ts
+++ b/src/composables/useAnalytics.ts
@@ -10,7 +10,9 @@ let _tabStart = Date.now()
  * Supporter conversion funnel (LIFT-906). One event name (`support_funnel`)
  * with a `stage` discriminator so impression → tap → purchase → restore can be
  * grouped as a single funnel in the analytics dashboard, mirroring the existing
- * share funnel. `purchase`/`restore` are reserved for the native IAP wiring
+ * share funnel. `impression` means the Support CTAs actually scrolled into view
+ * (not merely that Settings opened), so tap/impression is a meaningful
+ * conversion rate. `purchase`/`restore` are reserved for the native IAP wiring
  * (LIFT-598 / LIFT-910); only `impression` and `tap` fire today.
  */
 export type SupportFunnelStage = 'impression' | 'tap' | 'purchase' | 'restore'


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-906](https://github.com/aschung212/Lift/issues/906)



## Changes




## Commits
- [`af8d7da`](https://github.com/aschung212/Lift/commit/af8d7da) feat(LIFT-906): fire the supporter impression on visibility, not on settings-open

## Test Results
- Before: 3001 passing
- After: 3003 passing (2 delta)

---
_Automated by overnight pipeline — Tue Aug  4 23:51:35 PDT 2026_

## Preview
Test on your phone: https://lift-iugc4tivl-aschung212-1101s-projects.vercel.app