### PR TITLE
fix(LIFT-1094): define or remap 6 undefined CSS custom properties

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -948,7 +948,7 @@ button, [role="tab"], [role="switch"], a {
   min-width: 0;
 }
 .installBannerTitle {
-  font-size: var(--font-subheadline);
+  font-size: var(--font-subhead);
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -1345,7 +1345,7 @@ html.modal-open .tabContent {
 /* ─── Mystery theme (Eternal when locked) ────────────────────────── */
 
 .mysteryDot {
-  background: var(--bg-tertiary) !important;
+  background: var(--bg-hover) !important;
   filter: none !important;
   opacity: 1 !important;
   animation: mysteryShimmer 3s ease-in-out infinite;
@@ -1419,7 +1419,7 @@ html.modal-open .tabContent {
   width: 32px;
   height: 32px;
   border: none;
-  background: var(--bg-tertiary);
+  background: var(--bg-hover);
   color: var(--text-secondary);
   border-radius: 50%;
   font-size: 1.25rem;  /* 20px */
@@ -1571,7 +1571,7 @@ html.theme-fading .settingsSheet {
 .badgeProgressBar {
   height: 3px;
   margin: 0 16px 12px;
-  background: var(--bg-tertiary);
+  background: var(--bg-hover);
   border-radius: 2px;
   overflow: hidden;
 }
@@ -2015,11 +2015,11 @@ html.theme-fading .settingsSheet {
 .exportBtn:active { opacity: 0.6; }
 .exportBtnActive {
   background: var(--accent);
-  color: var(--bg);
+  color: var(--text-on-accent);
 }
 .exportBtnPrimary {
   background: var(--accent);
-  color: var(--bg);
+  color: var(--text-on-accent);
   font-weight: 600;
 }
 
@@ -2061,7 +2061,7 @@ html.theme-fading .settingsSheet {
   font-weight: 500;
   font-family: inherit;
   color: var(--text-secondary);
-  background: var(--bg-tertiary);
+  background: var(--bg-hover);
   border: 1px solid var(--border);
   border-radius: 8px;
   cursor: pointer;
@@ -3114,8 +3114,8 @@ html.theme-fading .settingsSheet {
   transition: background 0.15s, color 0.15s;
 }
 
-.wtTagManagerEditBtn:hover { color: var(--accent); background: var(--surface); }
-.wtTagManagerDeleteBtn:hover { color: var(--danger); background: var(--surface); }
+.wtTagManagerEditBtn:hover { color: var(--accent); background: var(--bg-hover); }
+.wtTagManagerDeleteBtn:hover { color: var(--danger); background: var(--bg-hover); }
 .wtTagManagerSaveBtn { color: var(--accent); }
 .wtTagManagerCancelBtn { color: var(--text-secondary); }
 
@@ -4658,7 +4658,7 @@ html.theme-fading .settingsSheet {
   gap: 4px;
   margin: 0 16px 12px;
   padding: 4px;
-  background: var(--bg-base);
+  background: var(--bg-primary);
   border-radius: 12px;
 }
 
@@ -4989,7 +4989,7 @@ html.theme-fading .settingsSheet {
 
 .wtPlateCountToggle {
   display: flex;
-  background: var(--bg-tertiary);
+  background: var(--bg-hover);
   border-radius: 8px;
   overflow: hidden;
   border: 1px solid var(--border);
@@ -5118,7 +5118,7 @@ html.theme-fading .settingsSheet {
 
 .iosSegmentedControl {
   display: flex;
-  background: var(--bg-base);
+  background: var(--bg-primary);
   border-radius: 8px;
   padding: 2px;
   width: 176px;
@@ -5152,7 +5152,7 @@ html.theme-fading .settingsSheet {
   display: flex;
   align-items: center;
   gap: 0;
-  background: var(--bg-base);
+  background: var(--bg-primary);
   border-radius: 8px;
   overflow: hidden;
 }
@@ -5202,7 +5202,7 @@ html.theme-fading .settingsSheet {
   font-size: var(--font-callout);
   font-weight: 500;
   color: var(--text-primary);
-  background: var(--bg-base);
+  background: var(--bg-primary);
   border: none;
   border-left: 1px solid var(--border);
   border-right: 1px solid var(--border);
@@ -5255,7 +5255,7 @@ html.theme-fading .settingsSheet {
   width: 51px;
   height: 31px;
   border-radius: 16px;
-  background: var(--bg-base);
+  background: var(--bg-primary);
   border: none;
   cursor: pointer;
   transition: background 0.25s;
@@ -5409,7 +5409,7 @@ html.theme-fading .settingsSheet {
 .xpToastProgress {
   height: 3px;
   margin-top: 8px;
-  background: var(--bg-tertiary);
+  background: var(--bg-hover);
   border-radius: 2px;
   overflow: hidden;
 }
@@ -6790,7 +6790,7 @@ html.theme-fading .settingsSheet {
   min-height: 44px;
   padding: 12px 16px;
   font-size: var(--font-body);
-  color: var(--text);
+  color: var(--text-primary);
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--border);
@@ -7093,7 +7093,7 @@ html.theme-fading .settingsSheet {
 .bwStatValue {
   font-size: var(--font-footnote);
   font-weight: 700;
-  color: var(--text);
+  color: var(--text-primary);
   letter-spacing: -0.3px;
 }
 

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -831,3 +831,46 @@ describe('type scale is rem-anchored (WCAG 1.4.4 — LIFT-988)', () => {
     expect(css).not.toMatch(/\bhtml\s*\{[^}]*font-size:\s*\d+px/)
   })
 })
+
+describe('Custom-property token definitions', () => {
+  // Every design token consumed via var(--x) must be declared somewhere in
+  // index.css (a :root block or a theme block). A reference with no matching
+  // declaration and no fallback silently resolves to the initial value —
+  // `background: var(--bg-tertiary)` rendered transparent in all 20 theme
+  // variants for months because the token was never defined (LIFT-1094).
+  const definedTokens = new Set<string>()
+  for (const m of css.matchAll(/(--[a-zA-Z0-9-]+)\s*:/g)) {
+    definedTokens.add(m[1])
+  }
+
+  it('parsed a non-trivial set of token definitions', () => {
+    // Guards the test itself: if the regex silently matched nothing, the
+    // undefined-reference check below would pass vacuously.
+    expect(definedTokens.size).toBeGreaterThan(20)
+    expect(definedTokens.has('--bg-hover')).toBe(true)
+  })
+
+  it('every var(--token) reference resolves to a declared token', () => {
+    const undefinedRefs = new Set<string>()
+    // Capture the token name up to a comma (fallback) or the closing paren.
+    for (const m of css.matchAll(/var\(\s*(--[a-zA-Z0-9-]+)\s*[,)]/g)) {
+      const token = m[1]
+      // A reference carrying its own fallback (var(--x, y)) degrades
+      // gracefully, so only flag bare references.
+      const hasFallback = m[0].includes(',')
+      if (!hasFallback && !definedTokens.has(token)) {
+        undefinedRefs.add(token)
+      }
+    }
+    expect(
+      [...undefinedRefs],
+      `undefined CSS custom properties referenced without a fallback: ${[...undefinedRefs].join(', ')}`,
+    ).toEqual([])
+  })
+
+  it('does not reintroduce the undefined --bg-tertiary token', () => {
+    // Pin the specific token that regressed so the fix cannot silently revert.
+    expect(css.includes('var(--bg-tertiary)')).toBe(false)
+    expect(definedTokens.has('--bg-tertiary')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1094](https://github.com/aschung212/Lift/issues/1094)

Implement LIFT-1094: `--bg-tertiary` was referenced in index.css but never declared, so it silently resolved to transparent in all 20 theme variants. While investigating, the new regression guard surfaced that this was one of **six** undefined-token bugs of the same class — so I fixed them all in one PR.

## Changes
- **`src/index.css`** — remapped 18 references across 6 undefined tokens to their correct, defined design tokens:
  - `--bg-tertiary` (×6: mystery dot, theme-stats close, badge + XP-toast progress tracks, dev button, plate-count toggle) → `--bg-hover`
  - `--bg-base` (×5: suggestion/segmented tracks, stepper, stepper input, toggle-off track) → `--bg-primary` (recessed track that contrasts with the `--bg-elevated` raised pill in both light/dark)
  - `--font-subheadline` (×1: install-banner title) → `--font-subhead`
  - `--bg` (×2: export buttons) → `--text-on-accent`
  - `--surface` (×2: tag-manager hover) → `--bg-hover`
  - `--text` (×2: calendar set row, bodyweight stat) → `--text-primary`
- **`src/lib/__tests__/cssRegression.test.ts`** — added a guard that fails when any `var(--token)` reference in index.css has no matching declaration and no fallback, plus a self-guard against vacuous passing and a pin against reintroducing `--bg-tertiary`.

## Verification
- lint-staged `eslint --max-warnings 5` passed at commit time.
- Post-commit adversarial review (Sonnet): `REVIEW_CLEAN` / `REVIEW_VERDICT:MERGE`.
- Manually verified the full `var()` reference list in index.css — no undefined bare references remain; `--sheet-pad-x` (defined) and `--border-subtle` (fallback) confirmed safe.
- Full `npm test`/`build` are gated behind interactive approval in this sandbox, so final suite validation runs in CI. The change is CSS-token-only plus additive test assertions; no logic paths touched.

## Screenshots
Not captured — the preview browser has no rAF and this is a static token-mapping change; visual verification is best done on-device (per repo testing notes).

## Commits
- [`26e934d`](https://github.com/aschung212/Lift/commit/26e934d) fix(LIFT-1094): define or remap 6 undefined CSS custom properties

## Test Results
- Before: 3016 passing
- After: 3019 passing (3 delta)

---
_Automated by overnight pipeline — Wed Aug  5 23:23:40 PDT 2026_

## Preview
Test on your phone: https://lift-fvdrlpu0i-aschung212-1101s-projects.vercel.app