### PR TITLE
style(LIFT-1097): make .previewBanner theme-mode aware, not OS-color-scheme aware

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -822,27 +822,23 @@ button, [role="tab"], [role="switch"], a {
   margin: 0 auto;
 }
 
+/* Follows the app's data-mode-driven tokens (see useTheme applyResolvedMode),
+   NOT the OS color scheme — a user who forces light on a dark-OS phone still
+   gets a light banner. Never reintroduce a prefers-color-scheme override here. */
 .previewBanner {
   width: 100%;
   padding: 8px 16px;
   font-size: var(--font-footnote);
   font-weight: 500;
-  color: #1a6dff;
-  background: #e8f0fe;
-  border-bottom: 1px solid #b4d0fe;
+  color: var(--accent);
+  background: var(--accent-subtle);
+  border-bottom: 1px solid var(--border);
   text-align: center;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
-}
-@media (prefers-color-scheme: dark) {
-  .previewBanner {
-    color: #8ab4ff;
-    background: #1a2744;
-    border-bottom-color: #2a3f66;
-  }
 }
 .previewToggle {
   font-size: var(--font-caption2);

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -105,6 +105,30 @@ describe('CSS regression tests', () => {
     })
   })
 
+  describe('.previewBanner is data-mode aware, not OS-color-scheme aware (LIFT-1097)', () => {
+    const lines = getRuleLines('.previewBanner')
+
+    // The app resolves light/dark explicitly via the data-mode attribute
+    // (useTheme applyResolvedMode), so a user who forces a mode opposite their
+    // OS still gets consistent styling. The banner must follow the same tokens
+    // instead of hardcoding hex and switching on prefers-color-scheme.
+    it('uses theme tokens for color/background/border, not hardcoded hex', () => {
+      expect(lines.some(l => l.startsWith('color:') && l.includes('var(--accent'))).toBe(true)
+      expect(lines.some(l => l.startsWith('background:') && l.includes('var(--accent-subtle'))).toBe(true)
+      expect(lines.some(l => l.startsWith('border-bottom:') && l.includes('var(--border'))).toBe(true)
+    })
+
+    it('does not hardcode hex colors', () => {
+      expect(lines.some(l => /#[0-9a-fA-F]{3,6}/.test(l))).toBe(false)
+    })
+
+    // Regression guard: prefers-color-scheme couples visuals to the OS scheme,
+    // breaking the data-mode invariant. index.css must contain zero such rules.
+    it('index.css has no prefers-color-scheme override', () => {
+      expect(css.includes('@media (prefers-color-scheme')).toBe(false)
+    })
+  })
+
   describe('.wtDetailTabs segmented control', () => {
     const lines = getRuleLines('.wtDetailTabs')
 


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1097](https://github.com/aschung212/Lift/issues/1097)

Implement LIFT-1097: `.previewBanner` (index.css) was the only rule in the codebase coupling visuals to the OS color scheme (hardcoded blue hex + `@media (prefers-color-scheme: dark)`) instead of the app's `data-mode` attribute set by `useTheme` `applyResolvedMode`. A user forcing light mode on a dark-OS phone got a mismatched banner. Route it onto the design tokens and guard against recurrence.

## Changes
- `src/index.css` — replaced hardcoded hex (`#1a6dff`/`#e8f0fe`/`#b4d0fe` + the dark-mode override block) with `--accent` / `--accent-subtle` / `--border` tokens, deleted the `@media (prefers-color-scheme: dark)` override, and added a comment documenting the data-mode invariant.
- `src/lib/__tests__/cssRegression.test.ts` — new `describe` block asserting `.previewBanner` uses tokens (not hex) and that index.css contains zero `@media (prefers-color-scheme)` rules.

## Verification
- `npm test` — 3019 passed, 1 skipped (164 files); the new guard test passes.
- `npm run build` — succeeds.
- `npm run lint` — clean.
- Post-commit adversarial review: `REVIEW_CLEAN` / `REVIEW_VERDICT:MERGE`.

## Screenshots
None (CSS token swap; verified via build + regression tests. On-device forced-light-on-dark-OS check is the remaining manual step noted in the issue).

## Commits
- [`06c61b7`](https://github.com/aschung212/Lift/commit/06c61b7) style(LIFT-1097): make .previewBanner theme-mode aware, not OS-color-scheme aware

## Test Results
- Before: 3016 passing
- After: 3019 passing (3 delta)

---
_Automated by overnight pipeline — Thu Aug  6 00:01:11 PDT 2026_

## Preview
Test on your phone: https://lift-at5v7aqwd-aschung212-1101s-projects.vercel.app