### PR TITLE
test(LIFT-1099): also reject lvh in the viewport-unit guard

### DIFF
--- a/COMMIT_MSG_TMP
+++ b/COMMIT_MSG_TMP
@@ -1,0 +1,17 @@
+test(LIFT-1095): parse the contrast audit's theme palettes from index.css
+
+The WCAG contrast audit re-declared all 20 theme palettes as inline hex
+literals, so it validated a stale copy of the design tokens rather than the
+source of truth. The two had already diverged — air-dark was still the old
+blue palette while index.css ships a gold one, and eternal-dark
+text-on-accent read 0c0c0c vs the real 0a0a0a — meaning the shipped colors
+could regress below AA while the suite stayed green.
+
+Route the audit off the duplicate: a small parser reads index.css at test
+time, extracts each [data-theme][data-mode] block's tokens, and drives the
+assertions from the real values. The parse fails loudly if a block is missing
+a required token or if a token becomes non-hex, and a guard asserts all 20
+variants were found so a parser regression can't leave the audit green on an
+empty set. Also corrected the stale "9 themes (18 variants)" header.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

--- a/src/index.css
+++ b/src/index.css
@@ -794,6 +794,17 @@ button, [role="tab"], [role="switch"], a {
 
 /* ─── App shell ─────────────────────────────────────────────────────────── */
 
+/*
+  Viewport-height convention (LIFT-1099): all full-height and max-height
+  surfaces are sized in `svh` (the SMALLEST viewport height). svh resolves to
+  the viewport with the mobile browser chrome EXPANDED, so an svh-sized element
+  always fits regardless of whether the URL bar is showing — it can never
+  overflow or jump as the chrome collapses. The outer shell (#app) is 100svh
+  with `overflow: hidden`, so any nested surface sized in a larger unit (`dvh`,
+  or bare `vh` which equals `lvh`) could exceed the shell and be clipped. Use
+  `dvh`/`lvh` ONLY where an element is intended to grow with the chrome — no
+  surface in Lift currently needs that. cssRegression.test.ts enforces this.
+*/
 #app {
   height: 100svh;
   display: flex;
@@ -1391,7 +1402,7 @@ html.modal-open .tabContent {
   border-top-left-radius: 24px;
   border-top-right-radius: 24px;
   padding: 24px 24px calc(24px + env(safe-area-inset-bottom, 0px));
-  max-height: 70vh;
+  max-height: 70svh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   animation: statsSlideUp 0.3s ease;
@@ -3923,7 +3934,7 @@ html.theme-fading .settingsSheet {
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
-  max-height: calc(100dvh - env(safe-area-inset-top, 0px) - 96px);
+  max-height: calc(100svh - env(safe-area-inset-top, 0px) - 96px);
   touch-action: auto;
   background: var(--glass-fill, var(--bg-elevated));
   backdrop-filter: blur(32px) saturate(180%);
@@ -3957,8 +3968,8 @@ html.theme-fading .settingsSheet {
   --sheet-pad-x: 20px; /* shared with the sticky action bar's full-bleed margins */
   max-width: 100%;
   width: 100%;
-  height: 88dvh;
-  max-height: 88dvh;
+  height: 88svh;
+  max-height: 88svh;
   padding: 16px var(--sheet-pad-x) calc(24px + env(safe-area-inset-bottom, 0px));
   border-radius: 24px 24px 0 0;
   border-bottom: none;
@@ -5936,7 +5947,7 @@ html.theme-fading .settingsSheet {
 }
 
 .wtTimerEditListScroll {
-  max-height: 35vh;
+  max-height: 35svh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
@@ -7155,7 +7166,7 @@ html.theme-fading .settingsSheet {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100dvh;
+  min-height: 100svh;
   padding: 32px;
   text-align: center;
   background: var(--bg-primary);
@@ -7414,7 +7425,7 @@ html.theme-fading .settingsSheet {
   padding: 24px 32px;
   width: 100%;
   max-width: 480px;
-  max-height: 80vh;
+  max-height: 80svh;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -44,8 +44,9 @@ describe('CSS regression tests', () => {
     // exact overflow risk this convention forbids. Any `<number>vh` token in a
     // property value must be prefixed with `s` (i.e. `svh`).
     it('uses only svh for every viewport-height value', () => {
-      // Match a numeric length followed by an optional s/d prefix and `vh`.
-      const matches = css.match(/\d+(?:\.\d+)?(?:s|d)?vh\b/g) ?? []
+      // Match a numeric length followed by an optional s/d/l prefix and `vh`
+      // (svh, dvh, lvh, or bare vh — all forbidden except svh).
+      const matches = css.match(/\d+(?:\.\d+)?(?:s|d|l)?vh\b/g) ?? []
       expect(matches.length, 'expected viewport-height units to exist').toBeGreaterThan(0)
       const offenders = matches.filter(m => !/svh\b/.test(m))
       expect(

--- a/src/lib/__tests__/cssRegression.test.ts
+++ b/src/lib/__tests__/cssRegression.test.ts
@@ -36,6 +36,30 @@ function getVueStyleBlock(componentPath: string): string {
 }
 
 describe('CSS regression tests', () => {
+  describe('viewport-height unit convention (LIFT-1099)', () => {
+    // Full-height/max-height surfaces must all use `svh` (smallest viewport
+    // height). svh always fits regardless of browser-chrome state, so a nested
+    // surface can never exceed the 100svh #app shell and get clipped, nor jump
+    // when the URL bar collapses. `dvh`/`lvh`/bare `vh` are larger and are the
+    // exact overflow risk this convention forbids. Any `<number>vh` token in a
+    // property value must be prefixed with `s` (i.e. `svh`).
+    it('uses only svh for every viewport-height value', () => {
+      // Match a numeric length followed by an optional s/d prefix and `vh`.
+      const matches = css.match(/\d+(?:\.\d+)?(?:s|d)?vh\b/g) ?? []
+      expect(matches.length, 'expected viewport-height units to exist').toBeGreaterThan(0)
+      const offenders = matches.filter(m => !/svh\b/.test(m))
+      expect(
+        offenders,
+        `non-svh viewport-height units found (use svh — see LIFT-1099): ${offenders.join(', ')}`
+      ).toEqual([])
+    })
+
+    it('sizes the #app shell in svh', () => {
+      const lines = getRuleLines('#app')
+      expect(lines.some(l => l.startsWith('height: 100svh'))).toBe(true)
+    })
+  })
+
   describe('.tabContent base rule', () => {
     const lines = getRuleLines('.tabContent')
 
@@ -689,7 +713,7 @@ describe('CSS regression tests', () => {
 
   describe('log-set sheet sticky save bar', () => {
     // Regression: the log form (usual ladder + PR card + plate calc) grew
-    // taller than the 88dvh sheet, pushing Save/Done below the fold — users
+    // taller than the 88svh sheet, pushing Save/Done below the fold — users
     // had to scroll to find Save and could close the sheet thinking the set
     // was logged. The action bar must stay pinned/visible at the sheet
     // bottom while the form scrolls behind it.


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1099](https://github.com/aschung212/Lift/issues/1099)

Implement LIFT-1099: full-height/max-height surfaces in `src/index.css` mixed viewport units — the `#app` shell used `100svh` (smallest) while nested surfaces used `100dvh`, `88dvh`, and bare `vh` (largest). Since `svh`/`dvh`/`lvh` resolve to different heights as mobile browser chrome expands/collapses, a larger-unit surface nested inside the `100svh` `overflow:hidden` shell could exceed it and be clipped, or jump when the URL bar hides. Standardize on `svh` (always fits regardless of chrome state), document the convention, and guard it with a test.

## Changes
- `src/index.css`:
  - Added a documented convention comment above `#app` explaining why `svh` is the standard.
  - Converted every non-`svh` full-height/max-height value to `svh`: `.themeStatsSheet` (70vh), `.repMaxModal` (100dvh), `.repMaxModal.logSetSheet` height + max-height (88dvh), `.wtTimerEditListScroll` (35vh), `.errorBoundary` (100dvh), `.legalSheet` (80vh). `#app`, `.settingsSheet`, `.wtDetailModal`, `.wtDetailBody` were already `svh`.
- `src/lib/__tests__/cssRegression.test.ts`:
  - New `viewport-height unit convention (LIFT-1099)` describe block: fails any `<number>vh` token that isn't `svh` (regex covers `svh`/`dvh`/`lvh`/bare `vh`), plus asserts `#app` is `100svh`.
  - Updated a stale `88dvh` comment to `88svh`.

## Verification
- `npx vitest run src/lib/__tests__/cssRegression.test.ts` → 123 passed
- `npm run lint` → clean
- `npm run build` → success (5.03s)
- Post-commit adversarial review: first pass flagged a P2 (regex missed `lvh`) — fixed in a follow-up commit; second pass `REVIEW_CLEAN / MERGE`.

## Screenshots
None — CSS unit swap with no visual change on Aaron's PWA standalone target (where `svh`==`dvh`==`lvh`); issue notes on-device verification is the final polish step.

## Commits
- [`9c900d4`](https://github.com/aschung212/Lift/commit/9c900d4) test(LIFT-1099): also reject lvh in the viewport-unit guard
- [`e519add`](https://github.com/aschung212/Lift/commit/e519add) style(LIFT-1099): standardize full-height surfaces on the svh viewport unit

## Test Results
- Before: 3016 passing
- After: 3018 passing (2 delta)

---
_Automated by overnight pipeline — Thu Aug  6 00:13:52 PDT 2026_

## Preview
Test on your phone: https://lift-6mzhdtoem-aschung212-1101s-projects.vercel.app