### PR TITLE
perf(LIFT-1112): compute exercise-row meta once per render instead of 5x

### DIFF
--- a/src/components/WorkoutTracker.vue
+++ b/src/components/WorkoutTracker.vue
@@ -154,7 +154,7 @@
             <div class="wtExerciseNameBlock">
               <div class="wtExerciseTopLine">
                 <span class="wtExerciseName">{{ exercise.name }}</span>
-                <span v-if="getRowMeta(exercise.id).isNewPRBadge" class="wtExerciseNewPR">
+                <span v-if="rowMetaByExercise[exercise.id]?.isNewPRBadge" class="wtExerciseNewPR">
                   <span class="wtExerciseNewPRIcon" aria-hidden="true">🏆</span>
                   <span>NEW PR</span>
                 </span>
@@ -165,10 +165,10 @@
                   :key="tag"
                   class="wtExerciseTag"
                 >{{ tag }}</span>
-                <span v-if="getRowMeta(exercise.id).lastSet" class="wtExerciseStat">
-                  · {{ displayWeight(getRowMeta(exercise.id).lastSet!.weight) }} {{ weightUnit }}
-                  × {{ getRowMeta(exercise.id).lastSet!.reps }}
-                  · {{ getRowMeta(exercise.id).timeAgo }}
+                <span v-if="rowMetaByExercise[exercise.id]?.lastSet" class="wtExerciseStat">
+                  · {{ displayWeight(rowMetaByExercise[exercise.id]!.lastSet!.weight) }} {{ weightUnit }}
+                  × {{ rowMetaByExercise[exercise.id]!.lastSet!.reps }}
+                  · {{ rowMetaByExercise[exercise.id]!.timeAgo }}
                 </span>
                 <span v-else class="wtExerciseStat wtExerciseStatEmpty">· No sets yet</span>
               </div>
@@ -1245,11 +1245,10 @@ interface ExerciseRowMeta {
   isNewPRBadge: boolean
 }
 
-function getRowMeta(exerciseId: string): ExerciseRowMeta {
-  const ex = store.exercises.find(e => e.id === exerciseId)
-  if (!ex || ex.sets.length === 0) return { lastSet: null, timeAgo: null, isNewPRBadge: false }
+function computeRowMeta(ex: Exercise): ExerciseRowMeta {
+  if (ex.sets.length === 0) return { lastSet: null, timeAgo: null, isNewPRBadge: false }
   const last = ex.sets[ex.sets.length - 1]
-  const prSet = store.getExercisePRSet(exerciseId, prBaselineDate.value)
+  const prSet = store.getExercisePRSet(ex.id, prBaselineDate.value)
   const isFreshPR = !!prSet && (Date.now() - new Date(prSet.date).getTime()) < 7 * 86400000
   return {
     lastSet: { weight: last.weight, reps: last.reps, date: last.date },
@@ -1257,6 +1256,22 @@ function getRowMeta(exerciseId: string): ExerciseRowMeta {
     isNewPRBadge: isFreshPR,
   }
 }
+
+/**
+ * Per-row meta for every visible exercise, computed once per render pass and
+ * keyed by id (#1112). The template reads each row's meta up to 5× (badge, last
+ * set weight/reps, time-ago); computing it here — instead of calling a helper
+ * per template binding — collapses the per-row `getExercisePRSet` + date math
+ * from 5 invocations down to 1. Recomputes only when the visible list, the PR
+ * baseline, or a set changes (all reactive deps below).
+ */
+const rowMetaByExercise = computed<Record<string, ExerciseRowMeta>>(() => {
+  const map: Record<string, ExerciseRowMeta> = {}
+  for (const ex of filteredExercises.value) {
+    map[ex.id] = computeRowMeta(ex)
+  }
+  return map
+})
 
 // Remove stale tags from active filters
 watch(() => store.allTags, (tags) => {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1112](https://github.com/aschung212/Lift/issues/1112)

Implement LIFT-1112: eliminate the redundant `getRowMeta()` invocations (5× per exercise row) in `WorkoutTracker.vue` by computing each row's meta once per render.

## Changes
- `src/components/WorkoutTracker.vue`:
  - Replaced the `getRowMeta(exerciseId)` helper (which did `store.exercises.find()` + `getExercisePRSet()` + date math on every template binding) with `computeRowMeta(ex: Exercise)` that works directly off the exercise object already in scope (drops the `find()`).
  - Added a `rowMetaByExercise` computed map keyed by exercise id, built once over `filteredExercises`. Recomputes only when the visible list, PR baseline, or a set changes.
  - Updated the 5 template bindings (NEW PR badge, last-set weight/reps, time-ago) to read from the map via `rowMetaByExercise[exercise.id]`, collapsing per-row PR lookup + date math from 5 invocations to 1.

## Verification
- `npm test -- WorkoutTracker.test.ts` — 190/190 pass
- `npm run typecheck` — clean
- `npm run build` — succeeds
- `npm run lint` — clean
- Post-commit adversarial review: REVIEW_CLEAN / MERGE

## Screenshots
None — no visual change (identical rendered output, pure render-cost reduction).

## Commits
- [`1497fb2`](https://github.com/aschung212/Lift/commit/1497fb2) perf(LIFT-1112): compute exercise-row meta once per render instead of 5x

## Test Results
- Before: 3122 passing
- After: 3123 passing (1 delta)

---
_Automated by overnight pipeline — Mon Aug 10 23:12:56 PDT 2026_

## Preview
Test on your phone: https://lift-8rcsfvszl-aschung212-1101s-projects.vercel.app