### PR TITLE
fix(LIFT-1123): keep the dev sign-in bypass out of production bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,13 @@ jobs:
 
       - run: npm run build
 
+      # Fail the production build if the dev sign-in bypass ("Continue as Dev")
+      # tree-shakes back in — e.g. VITE_E2E leaked into a prod build or the
+      # AuthScreen flag gate was removed (LIFT-1123). This job builds WITHOUT
+      # VITE_E2E, so the dev-signin chunk must be absent from dist/.
+      - name: Guard against dev sign-in in production bundle
+        run: npm run guard:dev-signin
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "generate-launch-screens": "node scripts/generate-launch-screens.js",
     "generate-wide-screenshot": "node scripts/generate-wide-screenshot.js",
     "test": "vitest run",
+    "guard:dev-signin": "node scripts/check-no-dev-signin.js",
     "test:integration": "vitest run --config vitest.integration.config.js",
     "test:e2e": "playwright test",
     "lint": "eslint src/",

--- a/scripts/check-no-dev-signin.js
+++ b/scripts/check-no-dev-signin.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+/**
+ * Production-bundle guard: fails if the dev sign-in bypass shipped (LIFT-1123).
+ *
+ * AuthScreen renders a "Continue as Dev" button that calls devSignIn(), which
+ * fabricates a `{ id: 'local-dev' }` session and skips the entire auth gate.
+ * It is meant to exist ONLY in local dev and the CI e2e build (which sets
+ * VITE_E2E=true). The button lives in DevSignInButton.vue, lazily imported by
+ * AuthScreen behind a build-time `import.meta.env.VITE_E2E` flag, so a normal
+ * production build tree-shakes the component and its chunk out entirely.
+ *
+ * The only thing that could reintroduce it in production is a misconfigured
+ * Vercel env var setting VITE_E2E — a silent auth-UI bypass with no other gate.
+ * This script greps the built `dist/` (which CI produces WITHOUT VITE_E2E) for
+ * the button's UI markers and fails the build if any are present.
+ *
+ * Run against a production build only (e.g. the build-and-test CI job). Running
+ * it after `VITE_E2E=true npm run build` is expected to fail.
+ *
+ * Usage:
+ *   node scripts/check-no-dev-signin.js
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const distDir = resolve(root, 'dist');
+
+// UI markers unique to the dev sign-in button. We deliberately do NOT grep for
+// 'local-dev' / 'dev@localhost': those live in useAuth's devSignIn helper, which
+// is part of the composable's returned API and therefore always present in the
+// bundle regardless of the flag. The button's class + label are what actually
+// render the bypass, and they are the strings that get tree-shaken out.
+const FORBIDDEN_MARKERS = ['authDevBtn', 'Continue as Dev'];
+
+if (!existsSync(distDir)) {
+  console.error(
+    `Error: ${distDir} not found. Run \`npm run build\` before this guard so ` +
+      `there is a production bundle to inspect.`,
+  );
+  process.exit(1);
+}
+
+/** Recursively collect every emitted JS file under dist/ (chunks may be lazy). */
+function collectJsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectJsFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const jsFiles = collectJsFiles(distDir);
+
+if (jsFiles.length === 0) {
+  console.error(`Error: no .js files found under ${distDir} — is the build complete?`);
+  process.exit(1);
+}
+
+const offenders = [];
+for (const file of jsFiles) {
+  const contents = readFileSync(file, 'utf-8');
+  const hits = FORBIDDEN_MARKERS.filter((marker) => contents.includes(marker));
+  if (hits.length > 0) {
+    offenders.push({ file: file.replace(`${root}/`, ''), hits });
+  }
+}
+
+if (offenders.length > 0) {
+  console.error('❌ Dev sign-in bypass leaked into the production bundle:');
+  for (const { file, hits } of offenders) {
+    console.error(`   ${file} contains: ${hits.join(', ')}`);
+  }
+  console.error(
+    '\nThe "Continue as Dev" button must never ship to production. This usually ' +
+      'means VITE_E2E was set for a production build, or the flag gate in ' +
+      'AuthScreen.vue was removed. See LIFT-1123.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✅ No dev sign-in bypass in the production bundle (scanned ${jsFiles.length} JS files).`,
+);

--- a/src/lib/__tests__/prodBundleGuard.test.ts
+++ b/src/lib/__tests__/prodBundleGuard.test.ts
@@ -1,0 +1,105 @@
+/// <reference types="node" />
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, existsSync } from 'fs'
+import { resolve, join } from 'path'
+
+/**
+ * Guard: the dev sign-in bypass must never ship to production (LIFT-1123).
+ *
+ * AuthScreen exposes a "Continue as Dev" button that calls devSignIn(), which
+ * fabricates a `{ id: 'local-dev' }` session and skips the entire auth gate. It
+ * exists only for local dev and the CI e2e build (which sets VITE_E2E=true).
+ *
+ * The button lives in DevSignInButton.vue, lazily imported by AuthScreen behind
+ * a build-time `import.meta.env.VITE_E2E` flag, so a normal production build
+ * folds the flag to false, tree-shakes the component, and never emits its chunk.
+ * The only thing that could reintroduce it is a misconfigured Vercel env var
+ * setting VITE_E2E — a silent auth-UI bypass with no other gate.
+ *
+ * These are structural pins (mirroring metaRegression.test.ts). The definitive
+ * build-output check — grep the real production dist/ — runs in CI via
+ * `npm run guard:dev-signin` (scripts/check-no-dev-signin.js), and is mirrored
+ * below whenever a build exists locally.
+ */
+
+const root = resolve(__dirname, '../../..')
+const srcDir = resolve(root, 'src')
+
+// UI markers unique to the dev sign-in button. We deliberately do NOT pin
+// 'local-dev' / 'dev@localhost': those live in useAuth's devSignIn helper, part
+// of the composable's always-bundled API. The button's class + label are the
+// strings that actually render the bypass and that get tree-shaken out.
+const DEV_SIGNIN_MARKERS = ['authDevBtn', 'Continue as Dev']
+const DEV_SIGNIN_COMPONENT = 'DevSignInButton.vue'
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walk(full))
+    } else if (entry.isFile()) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/** Committed source files that render UI (excludes tests). */
+function sourceFiles(): string[] {
+  return walk(srcDir).filter(
+    (file) => /\.(vue|ts)$/.test(file) && !/\.test\.ts$/.test(file),
+  )
+}
+
+describe('production bundle guard: dev sign-in bypass (LIFT-1123)', () => {
+  describe('source structure keeps the bypass tree-shakeable', () => {
+    const authScreen = readFileSync(resolve(srcDir, 'views/AuthScreen.vue'), 'utf-8')
+
+    it('AuthScreen no longer renders the dev button inline', () => {
+      // Inlined, it compiles to an always-present runtime v-if that ships in
+      // every bundle. It must live in a separately-chunked component instead.
+      for (const marker of DEV_SIGNIN_MARKERS) {
+        expect(authScreen).not.toContain(marker)
+      }
+    })
+
+    it('AuthScreen gates the dev button behind the VITE_E2E build flag', () => {
+      expect(authScreen).toContain('import.meta.env.VITE_E2E')
+      expect(authScreen).toContain('defineAsyncComponent')
+      expect(authScreen).toContain(DEV_SIGNIN_COMPONENT)
+    })
+
+    it('the dev button component still carries the markers (guard is non-vacuous)', () => {
+      const component = readFileSync(resolve(srcDir, 'views', DEV_SIGNIN_COMPONENT), 'utf-8')
+      for (const marker of DEV_SIGNIN_MARKERS) {
+        expect(component).toContain(marker)
+      }
+    })
+
+    it('DevSignInButton.vue is the ONLY source file that renders the bypass', () => {
+      const offenders = sourceFiles().filter((file) => {
+        if (file.endsWith(DEV_SIGNIN_COMPONENT)) return false
+        const contents = readFileSync(file, 'utf-8')
+        return DEV_SIGNIN_MARKERS.some((marker) => contents.includes(marker))
+      })
+      expect(offenders).toEqual([])
+    })
+  })
+
+  // Mirrors scripts/check-no-dev-signin.js. Only runs when a build exists (it
+  // does after `npm run build`; CI enforces the real check in build-and-test).
+  describe('built production bundle omits the bypass', () => {
+    const distDir = resolve(root, 'dist')
+    const hasBuild = existsSync(distDir)
+
+    it.runIf(hasBuild)('no emitted JS chunk contains the dev sign-in markers', () => {
+      const jsFiles = walk(distDir).filter((f) => f.endsWith('.js'))
+      const offenders = jsFiles.filter((file) => {
+        const contents = readFileSync(file, 'utf-8')
+        return DEV_SIGNIN_MARKERS.some((marker) => contents.includes(marker))
+      })
+      expect(offenders).toEqual([])
+    })
+  })
+})

--- a/src/views/AuthScreen.vue
+++ b/src/views/AuthScreen.vue
@@ -60,7 +60,7 @@
       <button class="authGuestBtn" @click="handleGuest">Continue without an account</button>
       <p class="authGuestHint">Your workouts stay on this device. Create an account any time to back up &amp; sync.</p>
 
-      <button v-if="isDev" class="authDevBtn" @click="devSignIn">Continue as Dev</button>
+      <component :is="DevSignInButton" v-if="DevSignInButton" />
 
       <p class="authTrust">Free forever — no paywall. Your data syncs privately across your devices.</p>
 
@@ -70,18 +70,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { defineAsyncComponent, ref } from 'vue'
 import type { Provider } from '@supabase/supabase-js'
 import { useAuth } from '../composables/useAuth'
 import { useAnalytics } from '../composables/useAnalytics'
 
-const { signInWithProvider, signInWithEmail, signUp, devSignIn, continueAsGuest } = useAuth()
+const { signInWithProvider, signInWithEmail, signUp, continueAsGuest } = useAuth()
 const { logEvent } = useAnalytics()
-// Show the dev sign-in button in local dev mode OR in CI e2e builds where
-// no Supabase backend is configured. import.meta.env values are inlined at
-// build time, so VITE_E2E is only true for the bundle produced by the
-// e2e CI job — real Vercel deploys do not set it.
-const isDev = import.meta.env.DEV || import.meta.env.VITE_E2E === 'true'
+// The dev sign-in bypass is loaded ONLY in local dev mode OR CI e2e builds.
+// import.meta.env values are inlined + folded at build time, so this ternary
+// resolves to `null` in a normal production build — the dev-signin component
+// (and its chunk) is then fully tree-shaken out, never shipping to real users.
+// A misconfigured Vercel env var that set VITE_E2E is the only way it could
+// reach production, which prodBundleGuard.test.ts pins against (LIFT-1123).
+const DevSignInButton =
+  import.meta.env.DEV || import.meta.env.VITE_E2E === 'true'
+    ? defineAsyncComponent(() => import('./DevSignInButton.vue'))
+    : null
 
 const email = ref('')
 const password = ref('')
@@ -345,26 +350,6 @@ async function handleOAuth(provider: Provider) {
   font-size: var(--font-caption1);
   color: var(--text-muted);
   line-height: 1.4;
-}
-
-.authDevBtn {
-  width: 100%;
-  padding: 12px 16px;
-  min-height: 44px;
-  margin-top: 12px;
-  font-size: var(--font-subhead);
-  font-weight: 600;
-  font-family: inherit;
-  color: var(--accent);
-  background: transparent;
-  border: 1px dashed var(--accent);
-  border-radius: 10px;
-  cursor: pointer;
-  transition: opacity 0.15s;
-}
-
-.authDevBtn:active {
-  opacity: 0.7;
 }
 
 .authTrust {

--- a/src/views/DevSignInButton.vue
+++ b/src/views/DevSignInButton.vue
@@ -1,0 +1,36 @@
+<template>
+  <button class="authDevBtn" @click="devSignIn">Continue as Dev</button>
+</template>
+
+<script setup lang="ts">
+// Dev/e2e-only sign-in shortcut. This component is lazily imported by
+// AuthScreen ONLY when the build sets VITE_E2E, so the entire "Continue as Dev"
+// UI — and its chunk — is physically absent from a normal production bundle
+// (LIFT-1123). A misconfigured Vercel env var that set VITE_E2E would surface
+// it, which prodBundleGuard.test.ts pins against.
+import { useAuth } from '../composables/useAuth'
+
+const { devSignIn } = useAuth()
+</script>
+
+<style scoped>
+.authDevBtn {
+  width: 100%;
+  padding: 12px 16px;
+  min-height: 44px;
+  margin-top: 12px;
+  font-size: var(--font-subhead);
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--accent);
+  background: transparent;
+  border: 1px dashed var(--accent);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.authDevBtn:active {
+  opacity: 0.7;
+}
+</style>


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1123](https://github.com/aschung212/Lift/issues/1123)

Implement **LIFT-1123** — guard the production bundle against the `VITE_E2E` dev sign-in bypass. On investigation I found the situation was worse than the issue described: the "Continue as Dev" button was compiled into **every** bundle (inlined `v-if` → Vue emits a runtime `unref()` check esbuild can't fold), so the bypass markup already shipped to production, hidden only by a runtime flag. The fix had to both make the code genuinely tree-shakeable and add the guard.

## Changes
- **`src/views/DevSignInButton.vue`** (new): the dev-only button, extracted so it lives in its own chunk. Calls `useAuth().devSignIn` itself; keeps the `.authDevBtn` class + "Continue as Dev" label so e2e selectors are unchanged.
- **`src/views/AuthScreen.vue`**: replaced the inline button with a `<component :is>` that lazily imports `DevSignInButton` behind `import.meta.env.DEV || import.meta.env.VITE_E2E === 'true'`. In a normal prod build the ternary folds to `null`, so the component and its chunk are fully tree-shaken out (verified absent from `dist/`). Removed the now-unused CSS and `devSignIn` destructure.
- **`scripts/check-no-dev-signin.js`** (new) + **`package.json`** `guard:dev-signin` script: greps the built `dist/` for the button markers and fails if present.
- **`.github/workflows/ci.yml`**: added a "Guard against dev sign-in in production bundle" step in `build-and-test` (which builds without `VITE_E2E`) that runs the script.
- **`src/lib/__tests__/prodBundleGuard.test.ts`** (new, 5 tests): structural source pins (bypass lives only in the flag-gated component; AuthScreen no longer inlines it) plus a mirrored `dist/` grep when a build exists.

## Verification
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 167 files, 3112 passed / 1 skipped (was 166 / 3107; +5 guard tests)
- `npm run build` — succeeds; `grep` of `dist/` for `Continue as Dev`/`authDevBtn` → no matches
- Post-commit adversarial review: `REVIEW_CLEAN` / `MERGE`

## Screenshots
None — no user-visible UI change (the dev button only ever appears in dev/e2e builds, with identical class/label/behavior).

## Discovery
None new this iteration beyond the root cause noted above (the bypass shipping in prod), which is exactly what LIFT-1123 now fixes.

## Commits
- [`6d98c5e`](https://github.com/aschung212/Lift/commit/6d98c5e) fix(LIFT-1123): keep the dev sign-in bypass out of production bundles

## Test Results
- Before: 3107 passing
- After: 3112 passing (5 delta)

---
_Automated by overnight pipeline — Tue Aug 11 23:14:23 PDT 2026_

## Preview
Test on your phone: https://lift-9i5y162jf-aschung212-1101s-projects.vercel.app