### PR TITLE
chore(LIFT-1124): harden Supabase auth password policy to 8-char + mixed complexity

### DIFF
--- a/src/lib/__tests__/supabaseAuthConfigRegression.test.ts
+++ b/src/lib/__tests__/supabaseAuthConfigRegression.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const authConfig = readFileSync(
+  resolve(__dirname, '../../../supabase/config.toml'),
+  'utf-8',
+)
+
+// supabase/config.toml is committed and pushed to production via `supabase config
+// push`, so it IS the intended production auth posture — not just local-dev
+// scaffolding. These assertions pin the hardened password policy from LIFT-1124
+// so a future config edit can't silently regress it back below Supabase's own
+// recommended floor (and below iOS App Store account-security expectations).
+describe('supabase/config.toml auth password policy regression', () => {
+  const uncommented = (key: string): string | undefined => {
+    // Match the first non-commented `key = value` line for the given key.
+    const match = authConfig.match(
+      new RegExp(`^\\s*${key}\\s*=\\s*(.+)$`, 'm'),
+    )
+    return match?.[1]?.trim()
+  }
+
+  it('requires at least 8-character passwords (Supabase-recommended floor)', () => {
+    const value = uncommented('minimum_password_length')
+    expect(value).toBeDefined()
+    const length = Number(value)
+    expect(Number.isInteger(length)).toBe(true)
+    expect(length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('enforces mixed-case-and-digit password complexity', () => {
+    expect(uncommented('password_requirements')).toBe(
+      '"lower_upper_letters_digits"',
+    )
+  })
+
+  it('never regresses password_requirements back to the empty (no-op) policy', () => {
+    expect(uncommented('password_requirements')).not.toBe('""')
+  })
+})

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -171,10 +171,10 @@ enable_anonymous_sign_ins = false
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
-minimum_password_length = 6
+minimum_password_length = 8
 # Passwords that do not meet the following requirements will be rejected as weak. Supported values
 # are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
-password_requirements = ""
+password_requirements = "lower_upper_letters_digits"
 
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1124](https://github.com/aschung212/Lift/issues/1124)

Implement **LIFT-1124** — harden the committed Supabase auth password policy in `supabase/config.toml`, which is pushed to production via `supabase config push` and therefore *is* the intended prod auth posture.

## Changes
- `supabase/config.toml`: `minimum_password_length` 6 → **8** (Supabase's own recommended floor); `password_requirements` `""` → **`"lower_upper_letters_digits"`** (must mix case + digits) — supabase/config.toml:174,177
- `src/lib/__tests__/supabaseAuthConfigRegression.test.ts`: new regression test pinning length ≥ 8, the complexity string, and guarding against reverting to the empty no-op policy (mirrors `capacitorConfigRegression.test.ts`).

**Deliberate scope call:** the issue also asked to enable HaveIBeenPwned leaked-password protection. That is a hosted-dashboard-only Auth setting with **no `config.toml` key** — per the SEV1 no-fabricate-identifiers rule I did not invent one. It cannot be expressed in the committed file, so it's out of scope for a config-file change and would need a dashboard toggle.

## Verification
- New test: 3 passed
- Full suite: 167 files passed | 1 skipped, 3110 passed | 1 skipped
- `npm run lint`: clean
- `npm run build`: success
- Post-commit adversarial review: REVIEW_CLEAN / MERGE

## Screenshots
None — config + test only, no UI change.

## Commits
- [`11121ec`](https://github.com/aschung212/Lift/commit/11121ec) chore(LIFT-1124): harden Supabase auth password policy to 8-char + mixed complexity

## Test Results
- Before: 3107 passing
- After: 3110 passing (3 delta)

---
_Automated by overnight pipeline — Tue Aug 11 23:34:08 PDT 2026_

## Preview
Test on your phone: https://lift-j2ewr1vhp-aschung212-1101s-projects.vercel.app