### PR TITLE
feat(LIFT-1143): explain e1RM jargon with a tappable info popover

### DIFF
--- a/src/components/InfoPopover.vue
+++ b/src/components/InfoPopover.vue
@@ -1,0 +1,174 @@
+<template>
+  <!-- Subtle inline info affordance (LIFT-1143). Renders only a small circled-i
+       glyph; the sanctioned 44pt hit area is extended via a transparent
+       ::before overlay (same pattern as .logSetFieldClear) so the tiny visual
+       icon never inflates the line height of the caption it sits in. The
+       explanation bubble is Teleported to <body> so a modal's `overflow:hidden`
+       can never clip it, and anchored to the trigger via getBoundingClientRect. -->
+  <button
+    ref="triggerEl"
+    type="button"
+    class="infoPopover"
+    :aria-label="`What is ${label}? ${open ? 'Hide' : 'Show'} explanation`"
+    :aria-expanded="open"
+    aria-haspopup="dialog"
+    @click.stop="toggle"
+  >
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </svg>
+  </button>
+
+  <Teleport to="body">
+    <div v-if="open" class="infoPopoverBackdrop" @click="close">
+      <div
+        ref="bubbleEl"
+        class="infoPopoverBubble"
+        role="dialog"
+        :aria-label="title"
+        :style="bubbleStyle"
+        tabindex="-1"
+        @click.stop
+      >
+        <p class="infoPopoverTitle">{{ title }}</p>
+        <p class="infoPopoverBody"><slot></slot></p>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, nextTick, onBeforeUnmount } from 'vue'
+
+defineProps<{
+  /** The term being explained — used only for the trigger's aria-label. */
+  label: string
+  /** Heading shown at the top of the popover bubble. */
+  title: string
+}>()
+
+const open = ref(false)
+const triggerEl = ref<HTMLElement | null>(null)
+const bubbleEl = ref<HTMLElement | null>(null)
+const bubbleStyle = ref<Record<string, string>>({})
+
+const BUBBLE_WIDTH = 244
+const MARGIN = 12
+const GAP = 8
+
+/** Anchor the fixed-position bubble under the trigger, clamped to the viewport
+ *  so it can never overflow off-screen on a narrow phone. */
+function positionBubble(): void {
+  const el = triggerEl.value
+  if (!el) return
+  const r = el.getBoundingClientRect()
+  const vw = window.innerWidth
+  const centerX = r.left + r.width / 2
+  const left = Math.max(MARGIN, Math.min(centerX - BUBBLE_WIDTH / 2, vw - MARGIN - BUBBLE_WIDTH))
+  bubbleStyle.value = {
+    left: `${Math.round(left)}px`,
+    top: `${Math.round(r.bottom + GAP)}px`,
+    width: `${BUBBLE_WIDTH}px`,
+  }
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    e.stopPropagation()
+    close()
+  }
+}
+
+async function toggle(): Promise<void> {
+  if (open.value) {
+    close()
+    return
+  }
+  open.value = true
+  window.addEventListener('keydown', onKeydown, true)
+  // iOS-native popovers dismiss on scroll rather than drifting with the anchor.
+  window.addEventListener('scroll', close, true)
+  window.addEventListener('resize', close)
+  await nextTick()
+  positionBubble()
+  bubbleEl.value?.focus()
+}
+
+function close(): void {
+  if (!open.value) return
+  open.value = false
+  window.removeEventListener('keydown', onKeydown, true)
+  window.removeEventListener('scroll', close, true)
+  window.removeEventListener('resize', close)
+  // Return focus to the trigger so keyboard users aren't stranded.
+  triggerEl.value?.focus()
+}
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeydown, true)
+  window.removeEventListener('scroll', close, true)
+  window.removeEventListener('resize', close)
+})
+</script>
+
+<style scoped>
+.infoPopover {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 4px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  line-height: 0;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Extend the hit area to 44x44pt without inflating the caption's line height.
+   Safe here because the icon is a lone control ringed by inert text, not a
+   tiling control (see CLAUDE.md iOS Compliance note). */
+.infoPopover::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  transform: translate(-50%, -50%);
+}
+
+.infoPopoverBackdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+}
+
+.infoPopoverBubble {
+  position: fixed;
+  max-width: calc(100vw - 24px);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+  padding: 12px 16px;
+  outline: none;
+}
+
+.infoPopoverTitle {
+  margin: 0 0 4px;
+  font: 600 var(--font-footnote) / 1.3 var(--ff);
+  color: var(--text-primary);
+}
+
+.infoPopoverBody {
+  margin: 0;
+  font: 400 var(--font-footnote) / 1.4 var(--ff);
+  color: var(--text-secondary);
+}
+</style>

--- a/src/components/WorkoutCompleteView.vue
+++ b/src/components/WorkoutCompleteView.vue
@@ -44,7 +44,10 @@
           </div>
           <div class="wcBestSetName">{{ summary.bestSet.name }}</div>
           <div class="wcBestSetWeight">{{ summary.bestSet.weight }} × {{ summary.bestSet.reps }}</div>
-          <div class="wcBestSetE1RM">~{{ summary.bestSet.e1RM }} {{ summary.unitLabel }} e1RM</div>
+          <div class="wcBestSetE1RM">~{{ summary.bestSet.e1RM }} {{ summary.unitLabel }} e1RM<InfoPopover
+            label="e1RM"
+            title="Estimated 1-rep max"
+          >Your predicted max for a single all-out rep, calculated from the weight and reps you lifted.</InfoPopover></div>
         </section>
       </template>
 
@@ -73,6 +76,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, defineAsyncComponent } from 'vue'
 import { useModal } from '../composables/useModal'
+import InfoPopover from './InfoPopover.vue'
 import type { SessionSummary } from '../lib/sessionSummary'
 
 const SharePickerSheet = defineAsyncComponent(() => import('./share/SharePickerSheet.vue'))

--- a/src/components/__tests__/InfoPopover.test.ts
+++ b/src/components/__tests__/InfoPopover.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, enableAutoUnmount, VueWrapper } from '@vue/test-utils'
+import InfoPopover from '../InfoPopover.vue'
+
+enableAutoUnmount(afterEach)
+
+function mountPopover(): VueWrapper {
+  return mount(InfoPopover, {
+    props: { label: 'e1RM', title: 'Estimated 1-rep max' },
+    slots: { default: 'Your predicted max for a single all-out rep.' },
+    attachTo: document.body,
+  })
+}
+
+describe('InfoPopover (LIFT-1143)', () => {
+  it('renders a labelled, collapsed trigger by default', () => {
+    const wrapper = mountPopover()
+    const trigger = wrapper.get('button.infoPopover')
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+    expect(trigger.attributes('aria-haspopup')).toBe('dialog')
+    expect(trigger.attributes('aria-label')).toContain('What is e1RM?')
+    // No bubble until tapped — progressive disclosure.
+    expect(document.querySelector('.infoPopoverBubble')).toBeNull()
+  })
+
+  it('reveals the explanation bubble on tap with the title and body', async () => {
+    const wrapper = mountPopover()
+    await wrapper.get('button.infoPopover').trigger('click')
+
+    const bubble = document.querySelector('.infoPopoverBubble')
+    expect(bubble).not.toBeNull()
+    expect(bubble?.getAttribute('role')).toBe('dialog')
+    expect(bubble?.getAttribute('aria-label')).toBe('Estimated 1-rep max')
+    expect(bubble?.textContent).toContain('Estimated 1-rep max')
+    expect(bubble?.textContent).toContain('predicted max for a single all-out rep')
+    expect(wrapper.get('button.infoPopover').attributes('aria-expanded')).toBe('true')
+  })
+
+  it('toggles closed on a second tap', async () => {
+    const wrapper = mountPopover()
+    const trigger = wrapper.get('button.infoPopover')
+    await trigger.trigger('click')
+    expect(document.querySelector('.infoPopoverBubble')).not.toBeNull()
+    await trigger.trigger('click')
+    expect(document.querySelector('.infoPopoverBubble')).toBeNull()
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('closes when the backdrop is tapped', async () => {
+    const wrapper = mountPopover()
+    await wrapper.get('button.infoPopover').trigger('click')
+    const backdrop = document.querySelector('.infoPopoverBackdrop') as HTMLElement
+    expect(backdrop).not.toBeNull()
+    backdrop.click()
+    await wrapper.vm.$nextTick()
+    expect(document.querySelector('.infoPopoverBubble')).toBeNull()
+  })
+
+  it('closes on Escape', async () => {
+    const wrapper = mountPopover()
+    await wrapper.get('button.infoPopover').trigger('click')
+    expect(document.querySelector('.infoPopoverBubble')).not.toBeNull()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    await wrapper.vm.$nextTick()
+    expect(document.querySelector('.infoPopoverBubble')).toBeNull()
+  })
+
+  it('removes its global listeners on unmount so it cannot fire on a dead component', async () => {
+    const wrapper = mountPopover()
+    await wrapper.get('button.infoPopover').trigger('click')
+    wrapper.unmount()
+    // A stray scroll after unmount must not throw or resurrect the bubble.
+    window.dispatchEvent(new Event('scroll'))
+    expect(document.querySelector('.infoPopoverBubble')).toBeNull()
+  })
+})

--- a/src/views/ExerciseDetailModal.vue
+++ b/src/views/ExerciseDetailModal.vue
@@ -98,7 +98,11 @@
                   <div class="wtPRCardBottom">
                     <span>{{ formatShortDate(setDayKey(pr.date) + 'T12:00:00') }}</span>
                     <span class="wtPRCardSep">·</span>
-                    <span>e1RM ~{{ displayWeight(pr.estimated1RM) }} {{ weightUnit }}</span>
+                    <span>e1RM<InfoPopover
+                      v-if="i === 0"
+                      label="e1RM"
+                      title="Estimated 1-rep max"
+                    >Your predicted max for a single all-out rep, calculated from the weight and reps you lifted.</InfoPopover> ~{{ displayWeight(pr.estimated1RM) }} {{ weightUnit }}</span>
                   </div>
                 </div>
                 <div v-if="pr.e1rmDelta != null" class="wtPRConnector">
@@ -133,6 +137,7 @@ import { usePreferencesStore } from '../stores/preferences'
 import { setDayKey, formatShortDate } from '../lib/dates'
 import { buildWarmupSetIds } from '../lib/classifyWarmupSets'
 import ExerciseGraph from '../components/ExerciseGraph.vue'
+import InfoPopover from '../components/InfoPopover.vue'
 import type { Exercise, WorkoutSet } from '../stores/workout'
 
 interface PREntry extends WorkoutSet {


### PR DESCRIPTION
## Summary
**Issue:** [LIFT-1143](https://github.com/aschung212/Lift/issues/1143)

Implement LIFT-1143: add a tappable info popover explaining the "e1RM" jargon for beginners, on the two surfaces named in the issue (workout-complete summary + exercise detail PR history).

## Changes
- **`src/components/InfoPopover.vue`** (new) — reusable, prop-driven presentational component. Renders a subtle circled-i glyph with a sanctioned **44pt `::before` hit area** (matches `.logSetFieldClear`, no line-height inflation). On tap it reveals a body-`Teleport`ed explanation bubble anchored to the trigger via `getBoundingClientRect`, viewport-clamped so it can't overflow a narrow phone, and dismissed on outside tap / Escape / scroll with focus returned to the trigger. Uses theme tokens throughout; scoped styles so it drops into both a scoped-style and a global-CSS host.
- **`src/components/WorkoutCompleteView.vue`** — added the popover to the best-set `e1RM` line.
- **`src/views/ExerciseDetailModal.vue`** — added the popover to the **current** PR card's `e1RM` only (`v-if="i === 0"`) to avoid repeating identical info icons down the history list (progressive disclosure).
- **`src/components/__tests__/InfoPopover.test.ts`** (new) — 6 tests: collapsed-by-default aria state, reveal-on-tap content/roles, toggle, backdrop-dismiss, Escape-dismiss, and listener cleanup on unmount.

## Verification
- `npx vitest run` — 3166 passed, 1 skipped (170 files)
- `npm run typecheck` (vue-tsc) — clean
- `npm run lint` — clean
- `npm run build` — built successfully (PWA precache regenerated)
- Post-commit adversarial review — `REVIEW_CLEAN` / `MERGE`

## Screenshots
None (no simulator/browser session in this iteration; behavior covered by component tests).

## Commits
- [`c0a5e35`](https://github.com/aschung212/Lift/commit/c0a5e35) feat(LIFT-1143): explain e1RM jargon with a tappable info popover

## Test Results
- Before: 3160 passing
- After: 3166 passing (6 delta)

---
_Automated by overnight pipeline — Thu Aug 13 23:11:17 PDT 2026_

## Preview
Test on your phone: https://lift-5bnbopm78-aschung212-1101s-projects.vercel.app